### PR TITLE
feat(mobile): show favorite indicator on inbox session items

### DIFF
--- a/packages/mobile/components/SessionItem.tsx
+++ b/packages/mobile/components/SessionItem.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, TouchableOpacity, View as RNView, Text as RNText, Animated as RNAnimated } from 'react-native';
 import { useRef, useCallback, useEffect } from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
+import Feather from '@expo/vector-icons/Feather';
 import { Theme, Spacing } from '@/constants/Theme';
 
 export type SessionData = {
@@ -26,6 +27,7 @@ export type SessionData = {
   session_error?: string;
   author_name?: string | null;
   is_own?: boolean;
+  is_favorite?: boolean;
 };
 
 export function formatRelativeTime(timestamp: number): string {
@@ -145,6 +147,9 @@ export function SessionItem({ session, onPress, onPin }: { session: SessionData;
       <RNView style={styles.conversationHeader}>
         <RNView style={styles.titleRow}>
           <StatusDot session={session} />
+          {session.is_favorite && (
+            <Feather name="star" size={11} color={Theme.accent} style={{ marginRight: 3 }} />
+          )}
           {session.is_pinned && (
             <FontAwesome name="thumb-tack" size={10} color={Theme.magenta} style={{ marginRight: 4 }} />
           )}


### PR DESCRIPTION
## Summary
- Display a star icon next to favorited sessions in the inbox list
- Adds `is_favorite` field to `SessionData` type
- Matches the favorite state already visible in the session detail toolbar

## Test plan
- [ ] Favorite a session from the session detail screen
- [ ] Return to inbox — favorited session should show a star icon before the title
- [ ] Unfavorite — star should disappear on next render

🤖 Generated with [Claude Code](https://claude.com/claude-code)