### PR TITLE
fix(mobile): prevent silent message truncation for table-heavy content

### DIFF
--- a/packages/mobile/app/session/[id].tsx
+++ b/packages/mobile/app/session/[id].tsx
@@ -2529,8 +2529,8 @@ function MessageBubble({ message, agentType, model, showHeader = true, forkChild
           style={[
             styles.bubbleContent,
             isLongContent && !contentExpanded && styles.bubbleContentCollapsed,
-            !isUser && !contentExpanded && !isLongContent && { maxHeight: ASSISTANT_CONTENT_MAX_HEIGHT, overflow: 'hidden' as const },
-            isUser && !userContentExpanded && !isLongContent && { maxHeight: ASSISTANT_CONTENT_MAX_HEIGHT, overflow: 'hidden' as const },
+            !isUser && !contentExpanded && !isLongContent && estimatedOverflow && { maxHeight: ASSISTANT_CONTENT_MAX_HEIGHT, overflow: 'hidden' as const },
+            isUser && !userContentExpanded && !isLongContent && estimatedOverflow && { maxHeight: ASSISTANT_CONTENT_MAX_HEIGHT, overflow: 'hidden' as const },
           ]}
         >
           {(() => {


### PR DESCRIPTION
## Summary
- Messages with markdown tables (compact in raw text but tall when rendered) were getting silently clipped at 400px with no Expand button
- The `maxHeight` constraint was applied to all "non-long" content, but the Expand button only showed when `estimatedOverflow` was true — tables fell in the gap between these two checks
- Now `maxHeight` is only applied when `estimatedOverflow` is true, ensuring clipped content always has an Expand button

## Test plan
- [ ] Open a session containing a markdown table (e.g. job application profile) — full table should now be visible
- [ ] Verify long messages (>1500 chars or >30 lines) still show Expand/Collapse correctly
- [ ] Verify very long messages (>3000 chars) still truncate and show Expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)