### PR TITLE
fix(auth): patch @convex-dev/auth for GitHub RFC 9207 iss parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "convex:dev": "cd packages/convex && convex dev",
-    "convex:deploy": "cd packages/convex && convex deploy"
+    "convex:deploy": "cd packages/convex && convex deploy",
+    "postinstall": "bash patches/convex-auth-iss-fix.sh"
   },
   "devDependencies": {
     "turbo": "^2.3.0",

--- a/patches/convex-auth-iss-fix.sh
+++ b/patches/convex-auth-iss-fix.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Workaround for @convex-dev/auth OAuth callback failing with:
+#   "unexpected iss (issuer) response parameter value"
+#
+# Root cause: GitHub rolled out RFC 9207 (Authorization Server Issuer
+# Identification) on ~2026-04-08, adding an `iss` parameter to OAuth
+# authorization responses. The value is "https://github.com/login/oauth".
+#
+# @convex-dev/auth sets a dummy issuer ("theremustbeastringhere.dev") for
+# non-OIDC providers, so oauth4webapi v3's validateAuthResponse() always
+# rejects the iss mismatch. The error is silently caught in the callback
+# handler, which redirects without a code — breaking sign-in.
+#
+# Fix: Strip the `iss` param from callback query params before validation.
+# This is safe because iss validation only matters for multi-AS deployments
+# (RFC 9207 mix-up attack mitigation), which doesn't apply here.
+#
+# Tracking:
+#   - https://github.com/langfuse/langfuse/issues/13091 (same bug in Langfuse)
+#   - https://datatracker.ietf.org/doc/html/rfc9207
+#
+# Remove this script once @convex-dev/auth ships a proper fix.
+
+set -euo pipefail
+
+apply_patch() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  grep -q 'delete("iss")' "$file" 2>/dev/null && return 0
+
+  # The sed pattern matches both the .ts (multi-line) and .js (single-line) forms
+  if [[ "$file" == *.ts ]]; then
+    # TypeScript src: replace multi-line validateAuthResponse call
+    sed -i.bak '/new URLSearchParams(params),/{
+      s/new URLSearchParams(params),/(() => { const p = new URLSearchParams(params); p.delete("iss"); return p; })(),/
+    }' "$file"
+  else
+    # JavaScript dist: same replacement on single line
+    sed -i.bak 's/new URLSearchParams(params),/(() => { const p = new URLSearchParams(params); p.delete("iss"); return p; })(),/' "$file"
+  fi
+  rm -f "$file.bak"
+  echo "[convex-auth-iss-fix] Patched $file"
+}
+
+# Patch the direct node_modules copy
+apply_patch "node_modules/@convex-dev/auth/src/server/oauth/callback.ts"
+apply_patch "node_modules/@convex-dev/auth/dist/server/oauth/callback.js"
+
+# Patch bun-cached copies (bun symlinks node_modules/@convex-dev/auth -> .bun/...)
+for f in node_modules/.bun/@convex-dev+auth@*/node_modules/@convex-dev/auth/src/server/oauth/callback.ts \
+         node_modules/.bun/@convex-dev+auth@*/node_modules/@convex-dev/auth/dist/server/oauth/callback.js; do
+  apply_patch "$f"
+done


### PR DESCRIPTION
## Summary

GitHub silently rolled out [RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207) (OAuth 2.0 Authorization Server Issuer Identification) around **2026-04-08**, adding an `iss` query parameter to all OAuth authorization callback responses. The value GitHub sends is `https://github.com/login/oauth`.

This broke **all GitHub sign-ins** across mobile and web. The failure was silent — the OAuth webview would open, authenticate with GitHub, then close without actually signing the user in.

### Root cause

`@convex-dev/auth` (v0.0.79) uses a dummy issuer `"theremustbeastringhere.dev"` for non-OIDC providers like GitHub ([source](https://github.com/get-convex/convex-auth/blob/main/src/server/oauth/convexAuth.ts)). When the callback fires, `oauth4webapi` v3's `validateAuthResponse()` compares the `iss` param (`https://github.com/login/oauth`) against this dummy value and throws `"unexpected iss (issuer) response parameter value"`. The error is caught silently in the callback handler, which then redirects back to the app **without a `code` parameter** — so sign-in fails without any visible error.

### Fix

A postinstall patch (`patches/convex-auth-iss-fix.sh`) that strips the `iss` parameter from callback query params before `validateAuthResponse()` runs. This is safe because:

- RFC 9207 `iss` validation protects against [mix-up attacks](https://datatracker.ietf.org/doc/html/rfc9207#section-2) in multi-authorization-server deployments — not applicable here
- The `iss` param is purely additive per RFC 6749 — clients that don't understand it should ignore it
- The same approach is being used by other affected projects

### Other affected projects

This is **not** a CodeCast-specific issue. The same bug is hitting any project using `@auth/core` + `oauth4webapi` v3 with GitHub OAuth:

- [langfuse/langfuse#13091](https://github.com/langfuse/langfuse/issues/13091) — identical error, filed 2026-04-09
- [doorkeeper-gem/doorkeeper#1720](https://github.com/doorkeeper-gem/doorkeeper/issues/1720) — RFC 9207 support request

### Cleanup

Remove `patches/convex-auth-iss-fix.sh` and the `postinstall` hook in `package.json` once `@convex-dev/auth` ships a proper fix upstream.

## Changes

- `patches/convex-auth-iss-fix.sh` — idempotent patch script, auto-applied via postinstall
- `package.json` — added `postinstall` hook

## Test plan

- [x] Verified GitHub OAuth sign-in works on iOS simulator after deploying the fix
- [x] Confirmed Convex logs show successful `userOAuth` → `verifyCodeAndSignIn` → `refreshSession` flow
- [x] Verified patch script is idempotent (safe to run multiple times)
- [ ] Verify web GitHub sign-in still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)