### PR TITLE
Fix CI: pin bun version to 1.1.38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.1.38
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary
- Pin bun version in CI to `1.1.38` to match the `packageManager` field in `package.json`
- CI was using `bun-version: latest` (1.3.12) which caused `Failed to install 1 package` on every run

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)