### PR TITLE
feat(web): "Allow all" button on permission card to enable bypass mode

### DIFF
--- a/packages/web/components/ConversationView.tsx
+++ b/packages/web/components/ConversationView.tsx
@@ -7401,6 +7401,21 @@ export const ConversationView = forwardRef<ConversationViewHandle, ConversationV
     clearTimeout(optimisticTimerRef.current);
     optimisticTimerRef.current = setTimeout(() => setOptimisticMode(null), 8000);
   }, [conversation, effectiveIsOwner, sendKeys, optimisticMode, managedSession?.permission_mode, effectiveConversationId]);
+
+  const handleEnableBypass = useCallback(() => {
+    if (!conversation || !effectiveIsOwner || conversation.status !== "active") return;
+    const currentMode = optimisticMode || managedSession?.permission_mode || "default";
+    const currentIdx = CC_MODE_ORDER.indexOf(currentMode);
+    const targetIdx = CC_MODE_ORDER.indexOf("bypassPermissions");
+    if (currentIdx === -1 || targetIdx === -1 || currentIdx === targetIdx) return;
+    const steps = (targetIdx - currentIdx + CC_MODE_ORDER.length) % CC_MODE_ORDER.length;
+    if (steps === 0) return;
+    const keys = Array(steps).fill("BTab").join(" ");
+    sendKeys({ conversation_id: (effectiveConversationId || conversation._id) as Id<"conversations">, keys });
+    setOptimisticMode("bypassPermissions");
+    clearTimeout(optimisticTimerRef.current);
+    optimisticTimerRef.current = setTimeout(() => setOptimisticMode(null), 8000);
+  }, [conversation, effectiveIsOwner, sendKeys, optimisticMode, managedSession?.permission_mode, effectiveConversationId]);
   useWatchEffect(() => {
     if (optimisticMode && managedSession?.permission_mode === optimisticMode) {
       setOptimisticMode(null);
@@ -10299,7 +10314,17 @@ export const ConversationView = forwardRef<ConversationViewHandle, ConversationV
       {pendingPermissions && pendingPermissions.length > 0 && (
         <div className={`border-t border-sol-border/40 shrink-0 ${embedded ? "-mx-[9999px] px-[9999px]" : ""}`}>
           <div className="max-w-7xl mx-auto px-2 sm:px-3 md:px-4 py-1.5">
-            <PermissionStack permissions={pendingPermissions as any} />
+            <PermissionStack
+              permissions={pendingPermissions as any}
+              onAllowAll={
+                (conversation?.agent_type ?? "claude_code") === "claude_code" &&
+                effectiveIsOwner &&
+                conversation?.status === "active" &&
+                effectiveMode !== "bypassPermissions"
+                  ? handleEnableBypass
+                  : undefined
+              }
+            />
           </div>
         </div>
       )}

--- a/packages/web/components/PermissionCard.tsx
+++ b/packages/web/components/PermissionCard.tsx
@@ -70,7 +70,13 @@ function PermissionRow({
   );
 }
 
-export function PermissionStack({ permissions }: { permissions: Permission[] }) {
+export function PermissionStack({
+  permissions,
+  onAllowAll,
+}: {
+  permissions: Permission[];
+  onAllowAll?: () => void;
+}) {
   const updatePermissionStatus = useMutation(api.permissions.updatePermissionStatus);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState(false);
@@ -107,6 +113,16 @@ export function PermissionStack({ permissions }: { permissions: Permission[] }) 
       )
     );
   }, [pending, updatePermissionStatus]);
+
+  const handleAllowAll = useCallback(async () => {
+    if (!onAllowAll) return;
+    await Promise.all(
+      pending.map((p) =>
+        updatePermissionStatus({ permission_id: p._id, status: "approved" }).catch(() => {})
+      )
+    );
+    onAllowAll();
+  }, [pending, updatePermissionStatus, onAllowAll]);
 
   useEventListener("keydown", useCallback((e: KeyboardEvent) => {
     const tag = (e.target as HTMLElement)?.tagName;
@@ -171,6 +187,15 @@ export function PermissionStack({ permissions }: { permissions: Permission[] }) 
             >
               {inflight.has(p._id) ? "..." : "Approve"}
             </button>
+            {onAllowAll && (
+              <button
+                onClick={handleAllowAll}
+                title="Approve this and bypass all future permission prompts in this session"
+                className="px-2.5 py-0.5 text-[11px] font-medium rounded border border-orange-500/40 text-orange-500 hover:bg-orange-500 hover:text-sol-bg transition-colors"
+              >
+                Allow all
+              </button>
+            )}
             <button
               onClick={() => handleDeny(p._id)}
               disabled={inflight.has(p._id)}
@@ -215,6 +240,15 @@ export function PermissionStack({ permissions }: { permissions: Permission[] }) 
           >
             Approve all
           </button>
+          {onAllowAll && (
+            <button
+              onClick={handleAllowAll}
+              title="Approve all and bypass future permission prompts in this session"
+              className="px-2 py-0.5 text-[10px] font-medium rounded border border-orange-500/40 text-orange-500 hover:bg-orange-500 hover:text-sol-bg transition-colors"
+            >
+              Allow all tool calls
+            </button>
+          )}
           <button
             onClick={handleDenyAll}
             className="px-2 py-0.5 text-[10px] font-medium rounded border border-sol-border/40 text-sol-text-dim hover:bg-sol-red hover:text-sol-bg transition-colors"


### PR DESCRIPTION
## Summary
- Adds an orange **Allow all** button alongside Approve/Deny on the session permission card
- Clicking it approves pending permission requests and cycles the Claude Code session into `bypassPermissions` mode — reuses the same Shift+Tab (`BTab`) keystroke mechanism, sending the right number of presses in one `sendKeys` call
- Only shown for owner-driven active `claude_code` sessions that aren't already in bypass

## Test plan
- [ ] Start a Claude Code session, trigger a tool that prompts for permission, click **Allow all**, and confirm the mode indicator switches to `bypass` and subsequent tool calls auto-approve
- [ ] Verify the button is hidden when the session is already in bypass mode
- [ ] Verify it is hidden for non-owner viewers and non-`claude_code` agents
- [ ] Confirm single-permission and multi-permission layouts both render the new button correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)