### PR TITLE
feat(mobile): trigger absorption + TRIGGERS dock in the inbox

### DIFF
--- a/packages/mobile/app/(tabs)/inbox.tsx
+++ b/packages/mobile/app/(tabs)/inbox.tsx
@@ -16,8 +16,10 @@ import {
   sessionsWakeSig, pendingSendWakeSig,
 } from '@codecast/web/store/inboxStore';
 import { useCoarseNow } from '@codecast/web/hooks/useCoarseNow';
+import { partitionTriggerInbox, type TaskRow } from '@codecast/web/components/triggerTasks';
 import { labelHexColor } from '@/lib/labelColors';
 import { SessionListSkeleton } from '@/components/SkeletonLoader';
+import { TriggerDock } from '@/components/TriggerDock';
 import { useQuery } from 'convex/react';
 
 // Stashed/Killed bucket row — the web SessionCard's hidden variants. Tap opens
@@ -649,6 +651,34 @@ export default function InboxScreen() {
   const filteredStashed = useMemo(() => chipFilter(stashedSessions), [chipFilter, stashedSessions]);
   const filteredKilled = useMemo(() => chipFilter(dismissedOnly), [chipFilter, dismissedOnly]);
 
+  // Schedules in the inbox (mirrors GlobalSessionPanel). The same per-user
+  // webList the badges/dock subscribe to (Convex dedupes), partitioned into one
+  // row per armed schedule plus the set of sessions absorbed behind those rows
+  // (resting loop homes + uneventful runs). All membership rules live in
+  // partitionTriggerInbox. schedules_seen_at is read as a scalar off clientState
+  // (never the whole singleton), same as showSubagents.
+  const scheduleTasks = useQuery(api.agentTasks.webList, {}) as TaskRow[] | undefined;
+  const schedulesSeenAt = useInboxStore((s) => s.clientState?.ui?.schedules_seen_at ?? 0);
+  const schedulePartition = useMemo(
+    () => partitionTriggerInbox(scheduleTasks, visibleSessions, {
+      sessionsWithQueuedMessages,
+      seenAt: schedulesSeenAt,
+      focusedId: currentSessionId,
+    }),
+    [scheduleTasks, visibleSessions, sessionsWithQueuedMessages, schedulesSeenAt, currentSessionId],
+  );
+  // Absorbed-filtered lists: the TRIGGERS dock renders the sessions resting
+  // behind a schedule row, so they must not double-render in the triage buckets.
+  // Flat views ("recent"/"time") stay unabsorbed, mirroring web's visualOrder.
+  const statusNeedsInput = useMemo(
+    () => filteredNeedsInput.filter((s) => !schedulePartition.absorbedIds.has(s._id)),
+    [filteredNeedsInput, schedulePartition.absorbedIds],
+  );
+  const statusWorking = useMemo(
+    () => filteredWorking.filter((s) => !schedulePartition.absorbedIds.has(s._id)),
+    [filteredWorking, schedulePartition.absorbedIds],
+  );
+
   const listData = useMemo(() => {
     const sections: React.ReactNode[] = [];
     if (Object.keys(sessions).length === 0) {
@@ -693,7 +723,7 @@ export default function InboxScreen() {
     // not theme); the active set regroups by label or plan, with unfiled
     // sessions falling to auto-derived project groups — exactly web's layout.
     if (viewMode === "bucket" || viewMode === "plan") {
-      const active = [...filteredNew, ...filteredNeedsInput, ...filteredWorking];
+      const active = [...filteredNew, ...statusNeedsInput, ...statusWorking];
       sections.push(renderSection("Pinned", filteredPinned, Theme.magenta));
       if (viewMode === "bucket") {
         const { labelGroups, projectGroups } = groupSessionsForLabelView(active, buckets, bucketByConv);
@@ -712,16 +742,21 @@ export default function InboxScreen() {
     }
     sections.push(renderSection("Pinned", filteredPinned, Theme.magenta));
     sections.push(renderSection("New", filteredNew, Theme.blue));
-    sections.push(renderSection("Needs Input", filteredNeedsInput, Theme.accent));
-    sections.push(renderSection("Working", filteredWorking, Theme.greenBright));
+    sections.push(renderSection("Needs Input", statusNeedsInput, Theme.accent));
+    sections.push(renderSection("Working", statusWorking, Theme.greenBright));
     return sections.filter(Boolean);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sessionsSig gates the sessions map; manualOrderKey gates the getState() manual-order read
-  }, [activeSessions, sessionsSig, sessionsFirstLoad, filteredPinned, filteredWorking, filteredNeedsInput, filteredNew, renderSection, viewMode, sortedAll, subsByParent, showSubagents, manualOrderKey, currentSessionId, chipMatches, buckets, bucketByConv]);
+  }, [activeSessions, sessionsSig, sessionsFirstLoad, filteredPinned, statusWorking, statusNeedsInput, filteredNew, renderSection, viewMode, sortedAll, subsByParent, showSubagents, manualOrderKey, currentSessionId, chipMatches, buckets, bucketByConv]);
 
   // Stashed (agent alive, kill-all) and Killed buckets — the web panel's two
   // hidden sections, collapsed by default behind count toggles.
   const ListFooter = useMemo(() => (
     <RNView>
+      <TriggerDock
+        rows={schedulePartition.rows}
+        unreadCount={schedulePartition.unreadCount}
+        nextRunAt={schedulePartition.nextRunAt}
+      />
       <RNView style={styles.hiddenToggleRow}>
         <TouchableOpacity
           style={styles.hiddenToggle}
@@ -790,7 +825,7 @@ export default function InboxScreen() {
       )}
       <RNView style={{ height: 80 }} />
     </RNView>
-  ), [showStashed, showKilled, filteredStashed, filteredKilled, router, handleRestore, confirmKill, confirmKillAllStashed]);
+  ), [schedulePartition, showStashed, showKilled, filteredStashed, filteredKilled, router, handleRestore, confirmKill, confirmKillAllStashed]);
 
   // View switcher — same options, names, and availability rules as web's
   // GlobalSessionPanel dropdown: label view appears once a label exists, plan

--- a/packages/mobile/components/TriggerDock.tsx
+++ b/packages/mobile/components/TriggerDock.tsx
@@ -1,0 +1,210 @@
+import { StyleSheet, TouchableOpacity, View as RNView, Text as RNText } from 'react-native';
+import { useState, useCallback } from 'react';
+import { useRouter } from 'expo-router';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { Theme, Spacing } from '@/constants/Theme';
+import { useInboxStore } from '@codecast/web/store/inboxStore';
+import { useCoarseNow } from '@codecast/web/hooks/useCoarseNow';
+import { taskDisplayTitle, isTriggerFailing, type TriggerRow, type TaskRow } from '@codecast/web/components/triggerTasks';
+import { describeTaskCadence, fmtClock, fmtDuration, taskStateLabel } from '@codecast/web/components/triggerCadence';
+
+// The mobile TRIGGERS dock — the phone twin of GlobalSessionPanel's TriggerDock.
+// Every armed schedule lives in this one collapsible line docked at the top of
+// the inbox footer; the sessions those schedules quietly drive are absorbed
+// behind it (see partitionTriggerInbox). Collapsed, the line is the briefing:
+// how many are armed, when the next fires, how many outcomes landed unread, and
+// a red tint when one failed. Expanded, one row per schedule opens the
+// conversation behind it. CLOSING stamps the read watermark (schedules_seen_at)
+// — while open the per-row "new" pills stay visible, matching desktop.
+
+// Cadence chip text: recurring/event read off the task fields ("every 7d",
+// "on PR comment"); a one-time schedule shows WHEN it fires instead of the
+// generic "one-time".
+function cadenceLabel(task: TaskRow): string {
+  if (task.schedule_type === 'once') return task.run_at ? fmtClock(task.run_at) : 'one-time';
+  return describeTaskCadence(task);
+}
+
+export function TriggerDock({ rows, unreadCount, nextRunAt }: {
+  rows: TriggerRow[];
+  unreadCount: number;
+  nextRunAt?: number;
+}) {
+  const router = useRouter();
+  const [expanded, setExpanded] = useState(false);
+  const now = useCoarseNow(30_000);
+
+  // Stamp the briefing read on COLLAPSE, not open: the per-row "new" pills are
+  // derived from schedules_seen_at, so stamping on open would erase them the
+  // moment the roster appeared. Opening leaves the watermark alone.
+  const toggle = useCallback(() => {
+    setExpanded((prev) => {
+      if (prev) useInboxStore.getState().updateClientUI({ schedules_seen_at: Date.now() });
+      return !prev;
+    });
+  }, []);
+
+  if (rows.length === 0) return null;
+
+  const failing = rows.some((r) => isTriggerFailing(r.task));
+  const titleColor = failing ? Theme.red : Theme.orange;
+  const nextIn = nextRunAt !== undefined ? Math.max(0, nextRunAt - now) : undefined;
+
+  return (
+    <RNView style={styles.dock}>
+      <TouchableOpacity style={styles.header} onPress={toggle} activeOpacity={0.7}>
+        <FontAwesome name={expanded ? 'chevron-up' : 'chevron-down'} size={11} color={Theme.textMuted0} />
+        <FontAwesome name="clock-o" size={12} color={titleColor} style={{ marginLeft: 2 }} />
+        <RNText style={[styles.headerTitle, { color: titleColor }]}>
+          Triggers ({rows.length})
+        </RNText>
+        {nextIn !== undefined && (
+          <RNText style={styles.headerNext} numberOfLines={1}>
+            next {nextIn > 0 ? `in ${fmtDuration(nextIn)}` : 'due'}
+          </RNText>
+        )}
+        <RNView style={{ flex: 1 }} />
+        {unreadCount > 0 && (
+          <RNView style={styles.newPill}>
+            <RNText style={styles.newPillText}>{unreadCount} new</RNText>
+          </RNView>
+        )}
+      </TouchableOpacity>
+
+      {expanded && (
+        <RNView style={styles.rows}>
+          {rows.map((row) => {
+            const { task } = row;
+            const countdown =
+              task.status === 'scheduled' && task.run_at !== undefined ? taskStateLabel(task, now) : null;
+            return (
+              <TouchableOpacity
+                key={task._id}
+                style={styles.row}
+                activeOpacity={row.openId ? 0.6 : 1}
+                onPress={() => {
+                  if (row.openId) router.push(`/session/${row.openId}`);
+                }}
+              >
+                <RNView style={styles.rowMain}>
+                  {isTriggerFailing(task) && <RNView style={styles.failDot} />}
+                  <RNText style={styles.rowTitle} numberOfLines={1}>
+                    {taskDisplayTitle(task)}
+                  </RNText>
+                  {row.unread && (
+                    <RNView style={styles.rowNewPill}>
+                      <RNText style={styles.rowNewPillText}>new</RNText>
+                    </RNView>
+                  )}
+                </RNView>
+                <RNView style={styles.rowMeta}>
+                  <RNView style={styles.cadenceChip}>
+                    <RNText style={styles.cadenceChipText} numberOfLines={1}>{cadenceLabel(task)}</RNText>
+                  </RNView>
+                  {countdown && <RNText style={styles.rowCountdown}>{countdown}</RNText>}
+                </RNView>
+              </TouchableOpacity>
+            );
+          })}
+        </RNView>
+      )}
+    </RNView>
+  );
+}
+
+const styles = StyleSheet.create({
+  dock: {
+    borderTopWidth: 1,
+    borderTopColor: Theme.bgHighlight,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 14,
+    paddingHorizontal: Spacing.lg,
+  },
+  headerTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  headerNext: {
+    fontSize: 12,
+    color: Theme.textMuted0,
+    flexShrink: 1,
+  },
+  newPill: {
+    paddingHorizontal: 7,
+    paddingVertical: 1,
+    borderRadius: 9,
+    backgroundColor: Theme.orange,
+  },
+  newPillText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: Theme.bg,
+  },
+  rows: {
+    backgroundColor: Theme.bgAlt,
+  },
+  row: {
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: Theme.borderLight,
+  },
+  rowMain: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  failDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: Theme.red,
+  },
+  rowTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '500',
+    color: Theme.text,
+  },
+  rowNewPill: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 8,
+    backgroundColor: Theme.orange + '22',
+  },
+  rowNewPillText: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: Theme.orange,
+    textTransform: 'uppercase',
+  },
+  rowMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 3,
+  },
+  cadenceChip: {
+    paddingHorizontal: 7,
+    paddingVertical: 1,
+    borderRadius: 6,
+    backgroundColor: Theme.bgHighlight,
+    maxWidth: 160,
+  },
+  cadenceChipText: {
+    fontSize: 11,
+    color: Theme.textMuted,
+    fontWeight: '500',
+  },
+  rowCountdown: {
+    fontSize: 11,
+    color: Theme.textMuted0,
+    fontWeight: '500',
+  },
+});


### PR DESCRIPTION
## What

Ports the desktop inbox's schedule handling to the mobile app so both surfaces agree on which sessions triage as cards.

- Sessions that are the **resting home of an armed recurring/event trigger** are absorbed out of Needs Input / Working — in the grouped, label, and plan views. Flat (recent/time) views stay unabsorbed, mirroring web's `visualOrderSessions` mode gate.
- New **TriggerDock** component at the top of the inbox footer (above Stashed/Killed): collapsed it's the briefing line — `Triggers (N) · next in 1d 15h · M new`, red-tinted when a trigger is failing; expanded it's one row per armed schedule (title, cadence chip, countdown, unread pill) that opens the schedule's home conversation.
- Read watermark (`schedules_seen_at`) stamps on **collapse**, not open — same as desktop, so per-row "new" pills stay visible while the roster is open.

## Why

Mobile never implemented trigger absorption, so a session like "Cast schedule integration" (home of a weekly recurring trigger) showed as a loose Needs Input card on the phone while desktop tucked it behind the TRIGGERS section — the inboxes disagreed and it read as a sync bug (it wasn't).

## How

All membership/formatting logic is imported from the web package's pure modules — `partitionTriggerInbox` (packages/web/components/triggerTasks.ts) and `triggerCadence` — zero forked logic, so the two clients can't drift.

## Verification

- `npx tsc --noEmit` in packages/mobile: clean for the changed files (8 pre-existing errors in untouched files — expo-notifications version drift).
- `bun test` on the shared modules both surfaces now depend on: **46/46 pass**.
- Not yet rendered on-device; JS-only change, ships via EAS OTA update after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)