### PR TITLE
Fix inbox persistence, agent discovery, and machine routing

### DIFF
--- a/packages/cli/src/agentSpawnPath.test.ts
+++ b/packages/cli/src/agentSpawnPath.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { agentSpawnPath } from "./agentSpawnPath.js";
+
+const ORIGINAL_PATH = process.env.PATH;
+const ORIGINAL_HOME = process.env.HOME;
+
+afterEach(() => {
+  process.env.PATH = ORIGINAL_PATH;
+  process.env.HOME = ORIGINAL_HOME;
+});
+
+describe("agentSpawnPath", () => {
+  // The regression: launchd hands the daemon this exact PATH, and codex lives in
+  // ~/.local/bin. Omitting that entry made a machine WITH codex installed report
+  // "Codex is not installed" on every launchd-started daemon.
+  test("includes ~/.local/bin under a bare launchd PATH", () => {
+    process.env.HOME = "/Users/someone";
+    process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+    expect(agentSpawnPath().split(":")).toContain("/Users/someone/.local/bin");
+  });
+
+  test("user bins outrank the inherited PATH, so a stale system copy can't win", () => {
+    process.env.HOME = "/Users/someone";
+    process.env.PATH = "/usr/bin";
+    const parts = agentSpawnPath().split(":");
+    expect(parts.indexOf("/Users/someone/.local/bin")).toBeLessThan(parts.indexOf("/usr/bin"));
+  });
+
+  test("extra prefixes lead (opencode's private bin)", () => {
+    process.env.HOME = "/Users/someone";
+    expect(agentSpawnPath("/Users/someone/.opencode/bin").split(":")[0]).toBe("/Users/someone/.opencode/bin");
+  });
+
+  test("no HOME leaves the system entries intact rather than emitting empties", () => {
+    delete process.env.HOME;
+    process.env.PATH = "/usr/bin";
+    expect(agentSpawnPath().split(":").every((p) => p.length > 0)).toBe(true);
+  });
+
+  test("omits an unavailable optional prefix", () => {
+    delete process.env.HOME;
+    process.env.PATH = "/usr/bin";
+    expect(agentSpawnPath(process.env.HOME && `${process.env.HOME}/.opencode/bin`)).not.toContain("undefined/.opencode/bin");
+  });
+});

--- a/packages/cli/src/agentSpawnPath.ts
+++ b/packages/cli/src/agentSpawnPath.ts
@@ -1,0 +1,30 @@
+/**
+ * The PATH agent binaries are spawned with.
+ *
+ * The daemon usually runs under launchd, which hands it a bare
+ * `/usr/bin:/bin:/usr/sbin:/sbin` — none of the places a user actually installs
+ * a CLI. So every agent spawn has to re-add them itself; `process.env.PATH` is
+ * only rich enough when the daemon happened to be started from a terminal,
+ * which is why a missing entry here presents as "works until the next
+ * automatic restart".
+ *
+ * `~/.local/bin` is where codex (and codecast itself) install, and its absence
+ * from the three hand-maintained copies of this list is what made a machine
+ * with codex installed report "Codex is not installed". One list now, so the
+ * next agent can't be onboarded with a subtly different one.
+ */
+export function agentSpawnPath(...prefixes: Array<string | undefined>): string {
+  const home = process.env.HOME;
+  return [
+    ...prefixes,
+    home && `${home}/.local/bin`,
+    home && `${home}/bin`,
+    home && `${home}/.bun/bin`,
+    process.env.PATH,
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+  ]
+    .filter((entry): entry is string => Boolean(entry))
+    .join(":");
+}

--- a/packages/cli/src/codexAppServer.ts
+++ b/packages/cli/src/codexAppServer.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { spawn, type ChildProcess } from "child_process";
 import * as readline from "readline";
+import { agentSpawnPath } from "./agentSpawnPath.js";
 import type { ParsedMessage, ToolCall, ToolResult, ImageBlock } from "./parser.js";
 
 export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
@@ -279,7 +280,7 @@ export class CodexAppServer extends EventEmitter {
         stdio: ["pipe", "pipe", "pipe"],
         env: {
           ...process.env,
-          PATH: [process.env.HOME + "/.bun/bin", process.env.PATH, "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"].filter(Boolean).join(":"),
+          PATH: agentSpawnPath(),
         },
       });
     } catch (err: any) {

--- a/packages/cli/src/codexUsage.ts
+++ b/packages/cli/src/codexUsage.ts
@@ -21,6 +21,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import { spawn } from "child_process";
+import { agentSpawnPath } from "./agentSpawnPath.js";
 
 export interface CodexUsageWindow {
   percent: number;
@@ -143,8 +144,6 @@ export function fetchRateLimitsViaAppServer(
     try {
       child = spawn(binary, ["app-server"], {
         stdio: ["pipe", "pipe", "ignore"],
-        // The daemon's launchd environment may lack the Homebrew/user bins the
-        // codex binary lives in — mirror codexAppServer's PATH augmentation.
         env: {
           ...process.env,
           // Point the probe at a saved profile's auth snapshot instead of the
@@ -155,9 +154,7 @@ export function fetchRateLimitsViaAppServer(
           // the refresh token out from under the real login. For dormant
           // snapshots, copy a rewritten auth.json back to the profile store.
           ...(opts.codexHome ? { CODEX_HOME: opts.codexHome } : {}),
-          PATH: [process.env.HOME + "/.bun/bin", process.env.PATH, "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"]
-            .filter(Boolean)
-            .join(":"),
+          PATH: agentSpawnPath(),
         },
       });
     } catch {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -27,7 +27,7 @@ import { CursorWatcher, type CursorSessionEvent } from "./cursorWatcher.js";
 import { CursorTranscriptWatcher, type CursorTranscriptEvent } from "./cursorTranscriptWatcher.js";
 import { isAppServerManagedCodexSessionHead } from "./codexWatcher.js";
 import { getCodexAccountsHeartbeatPayload, refreshCodexUsageSnapshots, autoSaveActiveCodexProfile } from "./codexAccounts.js";
-import { TranscriptDirWatcher, transcriptDirWatcherConfig, decodePiCwdSlug, type TranscriptDirEvent, type DirEventWatcher } from "./transcriptDirWatcher.js";
+import { TranscriptDirWatcher, transcriptDirWatcherConfig, agentSessionFromTranscriptPath, decodePiCwdSlug, type TranscriptDirEvent, type DirEventWatcher } from "./transcriptDirWatcher.js";
 import {
   OpencodeStorageWatcher,
   opencodeDbPath,
@@ -64,6 +64,7 @@ import {
   isRecognizedAgentComm,
   isResumeInvocation,
   matchStartedConversation,
+  parseLsofPidPaths,
   parsePidPpidMap,
   resolveSpawnerSessionId,
 } from "./sessionProcessMatcher.js";
@@ -5078,6 +5079,29 @@ async function pidsWithFileOpen(filePath: string): Promise<number[]> {
   }
 }
 
+// Identify ancestors that write no pid registry (every client except claude) by
+// the transcript each one holds open — one lsof covers the whole chain, and the
+// first agent-owned path a process has open names its session.
+async function ancestorTranscriptSessionIds(pids: number[]): Promise<Map<number, string>> {
+  const byPid = new Map<number, string>();
+  if (pids.length === 0) return byPid;
+  try {
+    const { stdout } = await execAsync(`lsof -p ${pids.join(",")} -F pn 2>/dev/null`);
+    for (const [pid, paths] of parseLsofPidPaths(stdout)) {
+      for (const openPath of paths) {
+        const ref = agentSessionFromTranscriptPath(openPath);
+        if (ref) {
+          byPid.set(pid, ref.sessionId);
+          break;
+        }
+      }
+    }
+  } catch {
+    // lsof exits non-zero when a pid died mid-walk; the chain just goes unresolved
+  }
+  return byPid;
+}
+
 async function resolveSpawnerConversation(
   filePath: string,
   sessionId: string,
@@ -5093,13 +5117,18 @@ async function resolveSpawnerConversation(
   const { stdout: psOut } = await execAsync("ps -axo pid=,ppid=");
   const pidToPpid = parsePidPpidMap(psOut);
   for (const pid of pids) {
-    const spawnerSessionId = resolveSpawnerSessionId(
-      collectAncestorPids(pidToPpid, pid),
-      readPidRegistrySessionId,
-      sessionId,
-    );
-    if (spawnerSessionId && conversationCache[spawnerSessionId]) {
-      return conversationCache[spawnerSessionId];
+    const ancestors = collectAncestorPids(pidToPpid, pid);
+    // Claude Code's pid registry first: a plain file read, no subprocess.
+    const registrySessionId = resolveSpawnerSessionId(ancestors, readPidRegistrySessionId, sessionId);
+    if (registrySessionId && conversationCache[registrySessionId]) {
+      return conversationCache[registrySessionId];
+    }
+    // Then the open-transcript route, which is the only one that can name a
+    // codex/gemini/pi spawner (`claude -p` run from a codex exec tool).
+    const openTranscripts = await ancestorTranscriptSessionIds(ancestors);
+    const openSessionId = resolveSpawnerSessionId(ancestors, (p) => openTranscripts.get(p) ?? null, sessionId);
+    if (openSessionId && conversationCache[openSessionId]) {
+      return conversationCache[openSessionId];
     }
   }
   return null;
@@ -17203,6 +17232,7 @@ async function main(): Promise<void> {
   // debounces per-file syncs through InvalidateSync; the first event for a file fixes
   // the sync closure (sessionId/projectHash are derived from the path, so later events
   // for the same file carry identical values — same as before the collapse).
+  const dirEventWatchers: DirEventWatcher[] = [];
   const registerJsonlDirWatcher = (
     watcher: DirEventWatcher,
     label: string,
@@ -17238,6 +17268,7 @@ async function main(): Promise<void> {
     watcher.on("error", (error: Error) => {
       logError(`${label} watcher error`, error);
     });
+    dirEventWatchers.push(watcher);
     watcher.start();
   };
 
@@ -17784,6 +17815,9 @@ async function main(): Promise<void> {
     watcher.stop();
     cursorWatcher.stop();
     cursorTranscriptWatcher.stop();
+    for (const dirEventWatcher of dirEventWatchers) {
+      dirEventWatcher.stop();
+    }
     codexAppServerInstance?.stop();
     opencodeServerInstance?.stop();
 

--- a/packages/cli/src/opencodeServer.ts
+++ b/packages/cli/src/opencodeServer.ts
@@ -33,6 +33,7 @@
 import { EventEmitter } from "events";
 import { spawn, type ChildProcess } from "child_process";
 import * as readline from "readline";
+import { agentSpawnPath } from "./agentSpawnPath.js";
 
 /** Coarse work-state the daemon's `sendAgentStatus` understands. The SSE stream is
  *  mapped down to this; content deltas are ignored (the DB path owns content). */
@@ -308,14 +309,7 @@ export class OpencodeServer extends EventEmitter {
         stdio: ["ignore", "pipe", "pipe"],
         env: {
           ...process.env,
-          PATH: [
-            process.env.HOME + "/.opencode/bin",
-            process.env.HOME + "/.bun/bin",
-            process.env.PATH,
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/usr/bin",
-          ].filter(Boolean).join(":"),
+          PATH: agentSpawnPath(process.env.HOME && `${process.env.HOME}/.opencode/bin`),
         },
       });
     } catch (err: any) {

--- a/packages/cli/src/sessionProcessMatcher.test.ts
+++ b/packages/cli/src/sessionProcessMatcher.test.ts
@@ -7,6 +7,7 @@ import {
   isResumeInvocation,
   matchSingleFreshStartedConversation,
   matchStartedConversation,
+  parseLsofPidPaths,
   parsePidPpidMap,
   resolveSpawnerSessionId,
 } from "./sessionProcessMatcher.js";
@@ -287,5 +288,31 @@ describe("spawn-parent resolution", () => {
   test("resolveSpawnerSessionId returns null when no ancestor is registered", () => {
     const sid = resolveSpawnerSessionId([8123, 500, 400], () => null, "child-session");
     expect(sid).toBeNull();
+  });
+
+  test("parseLsofPidPaths groups each process's open files under its pid", () => {
+    // Real `lsof -p 46028 -F pn` shape: a p-line opens the block, n-lines follow.
+    const out = [
+      "p46028",
+      "n/Users/j/.codex/sessions/2026/08/01/rollout-2026-08-01T23-03-27-019fbf23-9395-7c32-9946-f420e4f967b4.jsonl",
+      "n/dev/null",
+      "p45992",
+      "n/Users/j/.claude/projects/-Users-j-code/abc.jsonl",
+      "",
+    ].join("\n");
+    expect(parseLsofPidPaths(out)).toEqual(
+      new Map([
+        [46028, [
+          "/Users/j/.codex/sessions/2026/08/01/rollout-2026-08-01T23-03-27-019fbf23-9395-7c32-9946-f420e4f967b4.jsonl",
+          "/dev/null",
+        ]],
+        [45992, ["/Users/j/.claude/projects/-Users-j-code/abc.jsonl"]],
+      ]),
+    );
+  });
+
+  test("parseLsofPidPaths ignores n-lines with no open process block and unparseable pids", () => {
+    const out = ["n/orphan/path", "pnotapid", "n/also/orphan", "p77junk", "n/still-orphan", "p77", "n/kept"].join("\n");
+    expect(parseLsofPidPaths(out)).toEqual(new Map([[77, ["/kept"]]]));
   });
 });

--- a/packages/cli/src/sessionProcessMatcher.ts
+++ b/packages/cli/src/sessionProcessMatcher.ts
@@ -119,6 +119,13 @@ export function matchStartedConversation(
 // with its CURRENT session id. These are the pure pieces: parse one
 // `ps -axo pid=,ppid=` snapshot, enumerate ancestors nearest-first, and map
 // the first registered ancestor to a session id (skipping the child itself).
+//
+// Only Claude Code writes that pid registry, so a codex/gemini/pi/opencode
+// spawner leaves every ancestor unregistered — the child used to stay a loose
+// first-class card no matter how deep the chain. The second identification
+// route covers those: an ancestor is named by the TRANSCRIPT IT HOLDS OPEN,
+// read from one `lsof -F pn` over the whole chain
+// (see agentSessionFromTranscriptPath).
 
 export function parsePidPpidMap(psOutput: string): Map<number, number> {
   const map = new Map<number, number>();
@@ -145,6 +152,28 @@ export function collectAncestorPids(
     pid = pidToPpid.get(pid);
   }
   return ancestors;
+}
+
+/** Parse `lsof -F pn` into pid → the paths that process has open. The -F stream
+ *  is flat: a `p<pid>` line opens a process block and every `n<path>` line after
+ *  it belongs to that process until the next `p` line. */
+export function parseLsofPidPaths(output: string): Map<number, string[]> {
+  const byPid = new Map<number, string[]>();
+  let current: string[] | null = null;
+  for (const line of output.split("\n")) {
+    if (line.startsWith("p")) {
+      const pid = Number(line.slice(1));
+      if (!Number.isSafeInteger(pid) || pid <= 0) {
+        current = null;
+        continue;
+      }
+      current = byPid.get(pid) || [];
+      byPid.set(pid, current);
+    } else if (line.startsWith("n") && current) {
+      current.push(line.slice(1));
+    }
+  }
+  return byPid;
 }
 
 export function resolveSpawnerSessionId(

--- a/packages/cli/src/transcriptDirWatcher.test.ts
+++ b/packages/cli/src/transcriptDirWatcher.test.ts
@@ -11,6 +11,7 @@ import { AGENT_CLIENTS } from "@codecast/shared/contracts";
 import {
   TranscriptDirWatcher,
   transcriptDirWatcherConfig,
+  agentSessionFromTranscriptPath,
   expandTranscriptRoot,
   encodePiCwdSlug,
   decodePiCwdSlug,
@@ -81,10 +82,11 @@ describe("transcriptDirWatcherConfig — gemini config matches the old GeminiWat
     expect(cfg.basePath).toBe(oldGemini.basePath());
     expect(cfg.basePath).toBe(expandTranscriptRoot(AGENT_CLIENTS.gemini.transcriptRoots[0]));
   });
-  test("watch filter requires .json under a chats path", () => {
+  test("watch filter requires .json under a chats path segment", () => {
     for (const rel of [`ph/chats${path.sep}a.json`, "chats/a.json", "a.json", "ph/chats/a.jsonl", "ph/other/a.json"]) {
       expect(cfg.watchFilter(rel)).toBe(oldGemini.watchFilter(rel));
     }
+    expect(cfg.watchFilter("ph/not-chats/a.json")).toBe(false);
   });
   test("scan predicate requires .json in a dir ending /chats", () => {
     for (const [dir, name] of [["/x/ph/chats", "a.json"], ["/x/ph", "a.json"], ["/x/ph/chats", "a.jsonl"]] as [string, string][]) {
@@ -280,5 +282,48 @@ describe("TranscriptDirWatcher — live behavior via the pi config", () => {
 
     watcher.stop();
     fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── Spawner identification: transcript path → agent session ─────────────────
+// A `claude -p` child launched from a CODEX session's exec tool has no pid
+// registry entry anywhere in its ancestor chain (only Claude Code writes those),
+// so the daemon names the ancestor by the transcript it holds open instead.
+describe("agentSessionFromTranscriptPath", () => {
+  const HOME = process.env.HOME || "";
+
+  test("names a codex session from its rollout filename's trailing uuid", () => {
+    // The real jx798rq parent: the codex process that spawned three top-level
+    // reviewers held exactly this file open.
+    const p = path.join(HOME, ".codex/sessions/2026/08/01/rollout-2026-08-01T23-03-27-019fbf23-9395-7c32-9946-f420e4f967b4.jsonl");
+    expect(agentSessionFromTranscriptPath(p)).toEqual({
+      agentType: "codex",
+      sessionId: "019fbf23-9395-7c32-9946-f420e4f967b4",
+    });
+  });
+
+  test("names claude, gemini, and pi sessions from their own layouts", () => {
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".claude/projects/-Users-j-code/828ac129-18e8-4a03-a18c-254037389be9.jsonl")))
+      .toEqual({ agentType: "claude", sessionId: "828ac129-18e8-4a03-a18c-254037389be9" });
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".gemini/tmp/abc123/chats/session-1.json")))
+      .toEqual({ agentType: "gemini", sessionId: "session-1" });
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".pi/agent/sessions/-Users-j-code/2026-08-02T11-10-00_019fbf23-9395-7c32-9946-f420e4f967b4.jsonl")))
+      .toEqual({ agentType: "pi", sessionId: "019fbf23-9395-7c32-9946-f420e4f967b4" });
+  });
+
+  test("refuses a claude subagent transcript: it names the child, not the process's session", () => {
+    // A live claude process holds its subagents' transcripts open alongside its
+    // own — linking a spawnee to one of those would be the wrong parent.
+    const p = path.join(HOME, ".claude/projects/-Users-j-code/parent-uuid/subagents/agent-child.jsonl");
+    expect(agentSessionFromTranscriptPath(p)).toBeNull();
+  });
+
+  test("ignores non-transcript files a process happens to hold open", () => {
+    expect(agentSessionFromTranscriptPath("/dev/null")).toBeNull();
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".claude/settings.json"))).toBeNull();
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".gemini/tmp/project/not-chats/session.json"))).toBeNull();
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".codex/sessions/rollout.json"))).toBeNull();
+    // opencode/cursor keep every session in one SQLite store — no per-session file.
+    expect(agentSessionFromTranscriptPath(path.join(HOME, ".local/share/opencode/opencode.db"))).toBeNull();
   });
 });

--- a/packages/cli/src/transcriptDirWatcher.ts
+++ b/packages/cli/src/transcriptDirWatcher.ts
@@ -54,6 +54,7 @@ export interface TranscriptDirWatcherEvents {
 export interface DirEventWatcher {
   on<K extends keyof TranscriptDirWatcherEvents>(event: K, listener: TranscriptDirWatcherEvents[K]): this;
   start(): void;
+  stop(): void;
 }
 
 export declare interface TranscriptDirWatcher {
@@ -230,8 +231,8 @@ export function transcriptDirWatcherConfig(
   // full filename and the parent-of-`chats` segment is the project hash.
   return {
     basePath,
-    watchFilter: (rel) => rel.endsWith(".json") && (rel.includes(`chats${path.sep}`) || rel.includes("chats/")),
-    scanMatch: (dir, name) => name.endsWith(".json") && dir.endsWith("/chats"),
+    watchFilter: (rel) => rel.endsWith(".json") && rel.split(/[\\/]/).includes("chats"),
+    scanMatch: (dir, name) => name.endsWith(".json") && path.basename(dir) === "chats",
     extractSessionId: (filePath) => path.basename(filePath, ".json"),
     extractProjectHash: (filePath) => {
       const parts = filePath.split(path.sep);
@@ -240,4 +241,43 @@ export function transcriptDirWatcherConfig(
     },
     debounceMs: 200,
   };
+}
+
+/** Clients that give every session its own transcript FILE, so a process holding
+ *  one open can be named from the path alone. opencode and cursor keep all their
+ *  sessions in a single SQLite store and are absent by construction — an open
+ *  handle on that store says "an agent", never "which session". */
+const FILE_PER_SESSION_CLIENTS = ["claude", "codex", "gemini", "pi"] as const;
+
+/**
+ * Which agent session (if any) a transcript path belongs to — the registry-driven
+ * inverse of the watchers' session-id extraction, used to identify a spawner
+ * process by the file it holds open. Adding client #7 with its own file-per-session
+ * layout teaches this for free: list it above, and its watcher config supplies the
+ * extraction.
+ *
+ * The id is only ever used as a conversation-cache lookup key, so an unrecognized
+ * filename costs a miss, not a bad write.
+ */
+export function agentSessionFromTranscriptPath(
+  filePath: string,
+): { agentType: AgentClientId; sessionId: string } | null {
+  for (const clientId of FILE_PER_SESSION_CLIENTS) {
+    const root = expandTranscriptRoot(AGENT_CLIENTS[clientId].transcriptRoots[0]);
+    if (!filePath.startsWith(root + path.sep)) continue;
+    const relativePath = path.relative(root, filePath);
+    if (clientId === "claude") {
+      // Claude has a bespoke watcher, so its rule lives here: the session id is the
+      // filename. A live claude process holds its SUBAGENTS' transcripts open next
+      // to its own, and those name the child rather than the session running the
+      // process — skipping them keeps the wrong id out of the lookup.
+      if (!filePath.endsWith(".jsonl") || relativePath.split(path.sep).length !== 2) return null;
+      return { agentType: "claude", sessionId: path.basename(filePath, ".jsonl") };
+    }
+    const config = transcriptDirWatcherConfig(clientId);
+    if (!config.watchFilter(relativePath)) continue;
+    const sessionId = config.extractSessionId(filePath);
+    if (sessionId) return { agentType: clientId, sessionId };
+  }
+  return null;
 }

--- a/packages/convex/convex/deviceRouting.test.ts
+++ b/packages/convex/convex/deviceRouting.test.ts
@@ -239,3 +239,61 @@ describe("pickOwnerDevice — cloud-only fallback (no local device exists)", () 
     expect(pickOwnerDevice([], {}, NOW)).toBeNull();
   });
 });
+
+describe("pickOwnerDevice — a machine that can't open the path doesn't win on recency", () => {
+  // The real roster this came from: a Linux box registered is_remote:false with
+  // zero project roots, heartbeating within seconds of the Mac. Rung 4 sorted on
+  // last_seen alone, so a /Users/... session could land on a machine with no
+  // /Users at all — roughly a coin flip, re-tossed every heartbeat.
+  test("Linux box heartbeat more recently, but the path is /Users/... → the Mac", () => {
+    const devices = [
+      local("nose", { platform: "linux", last_seen: NOW - 1_000 }),
+      local("mac", { platform: "darwin", last_seen: NOW - 30_000 }),
+    ];
+    expect(pickOwnerDevice(devices, { projectPath: "/Users/jasonbenn/.claude" }, NOW)).toBe("mac");
+  });
+
+  test("and symmetrically, a /home/... path skips the Mac", () => {
+    const devices = [
+      local("mac", { platform: "darwin", last_seen: NOW - 1_000 }),
+      local("nose", { platform: "linux", last_seen: NOW - 30_000 }),
+    ];
+    expect(pickOwnerDevice(devices, { projectPath: "/home/jasonbenn/src" }, NOW)).toBe("nose");
+  });
+
+  test("a shared namespace is not evidence — /opt still goes to the most recent", () => {
+    const devices = [
+      local("nose", { platform: "linux", last_seen: NOW - 1_000 }),
+      local("mac", { platform: "darwin", last_seen: NOW - 30_000 }),
+    ];
+    expect(pickOwnerDevice(devices, { projectPath: "/opt/shared" }, NOW)).toBe("nose");
+  });
+
+  test("preference, not a filter: nobody can open it → still owned, never null", () => {
+    const devices = [local("nose", { platform: "linux", last_seen: NOW - 1_000 })];
+    expect(pickOwnerDevice(devices, { projectPath: "/Users/jasonbenn/.claude" }, NOW)).toBe("nose");
+  });
+
+  test("devices with no platform reported are never excluded", () => {
+    const devices = [local("unknown", { last_seen: NOW - 1_000 }), local("mac", { platform: "darwin" })];
+    expect(pickOwnerDevice(devices, { projectPath: "/Users/j/app" }, NOW)).toBe("unknown");
+  });
+
+  test("the offline-queue rung applies it too — don't queue for a machine that can't serve", () => {
+    const devices = [
+      local("nose", { platform: "linux", last_seen: stale }),
+      local("mac", { platform: "darwin", last_seen: stale - 60_000 }),
+    ];
+    expect(pickOwnerDevice(devices, { projectPath: "/Users/jasonbenn/.claude" }, NOW)).toBe("mac");
+  });
+
+  test("an explicit pick still outranks it — you may target a box deliberately", () => {
+    const devices = [
+      local("nose", { platform: "linux" }),
+      local("mac", { platform: "darwin" }),
+    ];
+    expect(
+      pickOwnerDevice(devices, { projectPath: "/Users/jasonbenn/.claude", targetDeviceId: "nose" }, NOW),
+    ).toBe("nose");
+  });
+});

--- a/packages/convex/convex/deviceRouting.ts
+++ b/packages/convex/convex/deviceRouting.ts
@@ -30,7 +30,40 @@ export type RoutableDevice = {
   last_seen: number;
   is_remote?: boolean;
   local_project_roots?: string[];
+  /** `process.platform` as reported by the heartbeat: "darwin" | "linux" | "win32". */
+  platform?: string;
 };
+
+/**
+ * False only when the path lives in a directory namespace the device's platform
+ * provably does not have — `/Users/...` on Linux, `/home/...` on a Mac. Anything
+ * shared (`/opt`, `/tmp`, `/srv`, unknown platforms, relative paths) stays true:
+ * this exists to stop an obviously-impossible route, not to guess at checkouts.
+ *
+ * Without it the checkout-less rungs pick purely on recency, so a Linux box that
+ * heartbeat a second sooner could win a `/Users/<mac-user>/...` session it cannot
+ * even cd into.
+ */
+export function platformCanOpenPath(platform: string | undefined, p: string): boolean {
+  if (!platform) return true;
+  if (platform === "win32") return /^[A-Za-z]:[\\/]/.test(p) || !p.startsWith("/");
+  if (!p.startsWith("/")) return true;
+  if (platform === "darwin") return !p.startsWith("/home/") && !p.startsWith("/root/");
+  if (platform === "linux") return !p.startsWith("/Users/");
+  return true;
+}
+
+/**
+ * Most-recently-seen device, but a device that could actually open the path
+ * outranks every device that couldn't. Falls back to the whole pool when nothing
+ * qualifies — leaving a session unowned is worse than routing it imperfectly.
+ */
+function mostRecentPreferringOpenable(pool: RoutableDevice[], paths: string[]): string {
+  const byRecency = [...pool].sort((a, b) => b.last_seen - a.last_seen);
+  if (paths.length === 0) return byRecency[0].device_id;
+  const openable = byRecency.filter((d) => paths.every((p) => platformCanOpenPath(d.platform, p)));
+  return (openable[0] ?? byRecency[0]).device_id;
+}
 
 /**
  * Decide which device should OWN (and therefore run) a session.
@@ -114,9 +147,13 @@ export function pickOwnerDevice(
     if (matches.length > 0) return matches[0].device_id;
   }
 
-  // 4. Most-recently-active online local device.
+  // 4. Most-recently-active online local device — preferring one that could
+  //    actually cd into the path. A blind recency pick let a Linux box win a
+  //    /Users/... session by heartbeating a second sooner. Preference, not a
+  //    filter: if nothing can open it we still hand ownership to SOMEONE, because
+  //    an unowned session is the failure this ladder exists to prevent.
   if (onlineLocals.length > 0) {
-    return [...onlineLocals].sort((a, b) => b.last_seen - a.last_seen)[0].device_id;
+    return mostRecentPreferringOpenable(onlineLocals, paths);
   }
 
   // 5. No local is online, so serve from an online remote that has the checkout
@@ -131,12 +168,13 @@ export function pickOwnerDevice(
 
   // 6. No local online — queue for one anyway. Prefer the sticky owner (don't
   //    ping-pong ownership of an existing conversation between sleeping Macs),
-  //    else the local seen most recently.
+  //    else the local seen most recently. Same openability preference as rung 4:
+  //    queueing for a machine that can't open the path just delays the failure.
   if (locals.length > 0) {
     if (opts.ownerDeviceId && locals.some((d) => d.device_id === opts.ownerDeviceId)) {
       return opts.ownerDeviceId;
     }
-    return [...locals].sort((a, b) => b.last_seen - a.last_seen)[0].device_id;
+    return mostRecentPreferringOpenable(locals, paths);
   }
 
   // 7. Cloud-only user: an online remote is the only machine that can serve.

--- a/packages/web/components/ConversationView.tsx
+++ b/packages/web/components/ConversationView.tsx
@@ -852,16 +852,19 @@ function ProjectSwitcher({ conversation, handleRef }: { conversation: Conversati
     () => recentProjectPathsFromSessionKeys(loadedSessionProjectKeys, currentUser?._id ? String(currentUser._id) : null),
     [loadedSessionProjectKeys, currentUser?._id],
   );
-  // Narrowed: only _id/project_path/git_root/owner_device_id are read here, none of
-  // which change on a heartbeat — so the always-rendered ProjectSwitcher no longer
-  // re-renders ~1×/s.
+  // Narrowed: only _id/project_path/git_root/owner_device_id/target_device_id are
+  // read here, none of which change on a heartbeat — so the always-rendered
+  // ProjectSwitcher no longer re-renders ~1×/s. Anything the machine row needs
+  // must be listed HERE: a field left out reads back undefined, and reading it
+  // through an `as any` cast silently defeats that (which is how the empty-roster
+  // fallback below shipped broken once already). Keep the reads typed.
   // resolveLiveSessionId follows the row across the compose popup's stub→real rekey
   // (which deletes sessions[stub]); without it a folder click after the create lands
   // updates the backend but never moves the highlight, since storeSession goes stale.
   const storeSession = useInboxStore(useShallow((s) => {
     const sess = s.sessions[s.resolveLiveSessionId(conversation._id)];
     if (!sess) return undefined;
-    return { _id: sess._id, project_path: sess.project_path, git_root: sess.git_root, owner_device_id: sess.owner_device_id };
+    return { _id: sess._id, project_path: sess.project_path, git_root: sess.git_root, owner_device_id: sess.owner_device_id, target_device_id: sess.target_device_id };
   }));
   const isolated = useInboxStore((s) => s.isolatedWorktreeMode);
   const convCommand = useInboxStore((s) => s.convCommand);
@@ -896,10 +899,15 @@ function ProjectSwitcher({ conversation, handleRef }: { conversation: Conversati
     lastPicked: lastPickedDeviceId,
   };
   // The machine this session WILL run on, plus the two things that must agree
-  // with it: what gets stamped, and which machine's folders we offer.
+  // with it: what gets stamped, and which machine's folders we offer. The stamp
+  // already on the row is the last-resort rung — `devices` reads empty on mount
+  // and on any Convex reconnect, and without it that gap would drop the folder
+  // list back to the cross-machine union while the stamp survived.
+  const existingStamp = storeSession?.target_device_id ?? null;
   const { selectedDeviceId, scopeProjectsToDeviceId } = resolveMachineSelection(devices, {
     ...machineOpts,
     picked: pickedDeviceId,
+    existingStamp,
   });
 
   // The folder list is scoped to the machine we're about to stamp, ALWAYS. The

--- a/packages/web/components/ConversationView.tsx
+++ b/packages/web/components/ConversationView.tsx
@@ -153,7 +153,7 @@ import { MessageNavButton } from "./MessageBrowserPopover";
 import type { MentionItem } from "./editor/MentionList";
 import { CheckSquare, FileText, MessageSquare, Map as MapIcon, User, Users, Hash, FolderOpen, Keyboard, ListChecks, Target, Maximize2, Minimize2, Circle, CircleDot, CheckCircle2, ChevronDown, ChevronRight, ChevronUp, Clock, CornerDownRight, CornerUpRight, BookOpen, Check, Split, Workflow, Tag, MoveHorizontal, AlignJustify, ListCollapse, GalleryVerticalEnd, GitCommitVertical, BookOpenText, Wrench, Zap, Radar, Terminal, KeyRound, ExternalLink, Loader2 } from "lucide-react";
 import { useDevices, DeviceDot, DeviceIcon, deviceAccentClasses, deviceDisplayName, type Device } from "./DeviceBadge";
-import { defaultMachineId, pathOnMyMachines } from "../lib/machinePicker";
+import { pathOnMyMachines, resolveMachineSelection } from "../lib/machinePicker";
 import { useProviderKeyCommand, deviceManagedKeys } from "../lib/useProviderKeyCommand";
 import { ComposeEditor, type ComposeEditorHandle } from "./editor/ComposeEditor";
 import { useMentionQuery, useMentionServerSearch, SERVER_MENTION_TYPES, labelMentionItems, matchScore } from "../hooks/useMentionQuery";
@@ -886,31 +886,42 @@ function ProjectSwitcher({ conversation, handleRef }: { conversation: Conversati
   const currentPath = storeSession?.project_path || storeSession?.git_root || conversation.git_root || conversation.project_path || ctxPath;
   const currentName = currentPath?.split("/").filter(Boolean).pop() || "unknown";
 
-  // Feeding the previous answer back in pins the highlight against heartbeat
-  // ordering (see defaultMachineId); writing the ref during render is safe
-  // because it's a pure cache of the value we just computed.
-  const stickyDefaultRef = useRef<string | null>(null);
-  const defaultDeviceId = defaultMachineId(devices, {
+  // Where the picker opens. Deterministic (owner → your standing pick → the
+  // machine holding this checkout → stable tiebreak), so it can't change under
+  // the user between the render that shows a chip and the send that acts on it.
+  const lastPickedDeviceId = useInboxStore((s) => s.clientState.ui?.last_picked_device_id ?? null);
+  const machineOpts = {
     ownerDeviceId: storeSession?.owner_device_id ?? (conversation as any).owner_device_id ?? null,
     projectPath: currentPath,
-    sticky: stickyDefaultRef.current,
+    lastPicked: lastPickedDeviceId,
+  };
+  // The machine this session WILL run on, plus the two things that must agree
+  // with it: what gets stamped, and which machine's folders we offer.
+  const { selectedDeviceId, scopeProjectsToDeviceId } = resolveMachineSelection(devices, {
+    ...machineOpts,
+    picked: pickedDeviceId,
   });
-  stickyDefaultRef.current = defaultDeviceId;
 
-  // Only an explicit move OFF the machine this session would route to anyway
-  // scopes the folder list and rides along as target_device_id.
-  const scopedDeviceId = pickedDeviceId && pickedDeviceId !== defaultDeviceId ? pickedDeviceId : null;
-  // The unscoped query above stays mounted even while scoped — it's the shared
-  // subscription that keeps the store's recentProjects cache (which the other
-  // pickers read) warm. The scoped one only exists while a non-default machine
-  // is selected, and deliberately never feeds that cache.
+  // The folder list is scoped to the machine we're about to stamp, ALWAYS. The
+  // unscoped query is `getOnlineLocalRoots` — a union across every online local —
+  // so leaving it unscoped while the selection is forced would offer folders the
+  // target machine doesn't have, and the stamp wins rung 1 outright: the session
+  // would land on a machine that can't cd into its own project path. (Previously
+  // the same list was safe because an unstamped session could be re-routed to
+  // whichever machine actually held the checkout.)
+  const scopedDeviceId = scopeProjectsToDeviceId;
+  // The unscoped query stays mounted regardless — it's the shared subscription
+  // that keeps the store's recentProjects cache (which the other pickers read)
+  // warm. The scoped one deliberately never feeds that cache.
   const scopedProjects = useQuery(
     api.users.getRecentProjectPaths,
     scopedDeviceId ? { limit: 50, device_id: scopedDeviceId } : "skip",
   );
 
   // Memoized because five downstream useMemos take it as a dep — an identity
-  // that churned every render would defeat all of them.
+  // that churned every render would defeat all of them. While the scoped query is
+  // in flight we show nothing rather than the union: an empty list for a beat is
+  // recoverable, a path the target machine lacks is not.
   const recentProjects = useMemo<RecentProject[]>(
     () => scopedDeviceId
       ? (scopedProjects ?? [])
@@ -1045,21 +1056,32 @@ function ProjectSwitcher({ conversation, handleRef }: { conversation: Conversati
   // bites when the conversation already exists server-side; every new-session
   // surface defers its create, so the stamp below is what usually carries the
   // choice — see createSessionFromStub.
+  const updateClientUI = useInboxStore((s) => s.updateClientUI);
   const handleMachinePick = useCallback((d: Device) => {
-    const next = d.device_id === defaultDeviceId ? null : d.device_id;
-    setPickedDeviceId(next);
-    if (currentPath) handleSwitch(currentPath, undefined, next);
-  }, [defaultDeviceId, currentPath, handleSwitch]);
+    setPickedDeviceId(d.device_id);
+    // Remember the choice: it becomes the picker's default for subsequent NEW
+    // sessions, which is what makes "explicit every time" cost one click total
+    // rather than one click per session.
+    updateClientUI({ last_picked_device_id: d.device_id });
+    if (currentPath) handleSwitch(currentPath, undefined, d.device_id);
+  }, [currentPath, handleSwitch, updateClientUI]);
 
-  // Stamp the pick on the stub row so it rides the deferred create. Tracks
-  // scopedDeviceId rather than the raw click: if the default shifts under the
-  // user (a machine drops off, or a folder switch moves the route) the stamp
-  // clears itself, so we never pin what routing would pick anyway. The create
-  // path re-checks this too — a stub can outlive this component.
+  // Stamp the selection on the stub row so it rides the deferred create — the
+  // machine shown in the row is the machine it runs on, whether or not the user
+  // touched the picker. Previously only a move OFF the default was stamped, and
+  // an unstamped session was re-decided server-side at send time by a
+  // `last_seen` tiebreak that flips between idle machines on its own.
   const setSessionTargetDevice = useInboxStore((s) => s.setSessionTargetDevice);
   useWatchEffect(() => {
-    setSessionTargetDevice(storeSession?._id || conversation._id, scopedDeviceId);
-  }, [storeSession?._id, conversation._id, scopedDeviceId, setSessionTargetDevice]);
+    // Never clear on a null. Null now means only "the device roster hasn't
+    // loaded yet" — `useDevices()` starts empty, so defaultMachineId returns null
+    // on the first render(s). Writing that through would wipe a stamp an earlier
+    // mount already made, silently returning the session to server-side routing.
+    // There is no longer any path that intentionally clears the selection: every
+    // chip click names a machine.
+    if (!selectedDeviceId) return;
+    setSessionTargetDevice(storeSession?._id || conversation._id, selectedDeviceId);
+  }, [storeSession?._id, conversation._id, selectedDeviceId, setSessionTargetDevice]);
 
   // Hand the imperative surface up to NewSessionView's ⌥-chord router.
   // Re-assigned every render so isOpen/commitAndClose read fresh state.
@@ -1121,7 +1143,7 @@ function ProjectSwitcher({ conversation, handleRef }: { conversation: Conversati
       {machineChips.length > 1 && (
         <div className="flex flex-wrap justify-center gap-1.5">
           {machineChips.map((d) => {
-            const selected = d.device_id === (pickedDeviceId ?? defaultDeviceId);
+            const selected = d.device_id === selectedDeviceId;
             return (
               <button
                 key={d.device_id}

--- a/packages/web/hooks/reconcileCrawl.test.ts
+++ b/packages/web/hooks/reconcileCrawl.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { useInboxStore } from "../store/inboxStore";
-import { bootEagerArmed, crawlThrottledAt, runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
+import { bootEagerArmed, cancelReconcileCrawl, crawlThrottledAt, runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
+import { hiddenCrawlReady, inboxCrawlWsKey } from "./useSyncInboxSessions";
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -45,30 +46,25 @@ describe("crawlThrottledAt", () => {
 // offline: the parked dispatch hasn't reached the server, and the pending field
 // lock that would have protected the row is released as stale after 5 minutes.
 // The durable throttle used to mask this by skipping the boot crawl entirely.
-const MAX_WAIT = 10_000; // BOOT_OUTBOX_DRAIN_MAX_WAIT_MS
 describe("bootEagerArmed", () => {
   it("holds the bypass while the outbox still has an unreplayed boot backlog", () => {
-    expect(bootEagerArmed(false, 0, MAX_WAIT)).toBe(false);
-    expect(bootEagerArmed(false, MAX_WAIT - 1, MAX_WAIT)).toBe(false);
+    expect(bootEagerArmed(false)).toBe(false);
   });
 
   it("arms as soon as the boot drain reports every parked entry attempted", () => {
-    expect(bootEagerArmed(true, 0, MAX_WAIT)).toBe(true);
+    expect(bootEagerArmed(true)).toBe(true);
   });
 
-  it("arms at the deadline anyway — a wedged or unwired outbox must not disable healing", () => {
-    // No dispatch binding (or a drain that keeps aborting) leaves the signal false
-    // forever; the crawl is the only healer for killed sessions, so it still runs.
-    expect(bootEagerArmed(false, MAX_WAIT, MAX_WAIT)).toBe(true);
-    expect(bootEagerArmed(false, MAX_WAIT + 5_000, MAX_WAIT)).toBe(true);
+  it("never arms a crawl against an unreplayed durable outbox", () => {
+    expect(bootEagerArmed(false)).toBe(false);
   });
 
   it("composes with the throttle once armed", () => {
     // The hook holds the crawl entirely while unarmed. Once armed, the persisted
     // watermark is ignored and the crawl runs.
-    const armed = bootEagerArmed(false, 0, MAX_WAIT);
+    const armed = bootEagerArmed(false);
     expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, armed)).toBe(true);
-    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, bootEagerArmed(true, 0, MAX_WAIT))).toBe(false);
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, bootEagerArmed(true))).toBe(false);
   });
 });
 
@@ -107,4 +103,173 @@ describe("runReconcileCrawl — boot-eager wiring", () => {
     expect(calls).toBe(1);
   });
 
+});
+
+describe("inbox principal crawl keys", () => {
+  it("does not share a completion mark between accounts, and skips before identity resolves", async () => {
+    const namespace = `inbox-principal-${Math.random()}`;
+    let calls = 0;
+    const crawl = (wsKey: string) => runReconcileCrawl({
+      namespace,
+      wsKey,
+      throttleMs: THROTTLE,
+      pageDelayMs: 0,
+      maxPages: 1,
+      fetchPage: async () => {
+        calls++;
+        return { rows: [], isDone: true, continueCursor: null };
+      },
+      onPage: () => {},
+      onComplete: () => {},
+    });
+
+    crawl(inboxCrawlWsKey("account-a"));
+    await delay(40);
+    crawl(inboxCrawlWsKey("account-b"));
+    await delay(40);
+    crawl(inboxCrawlWsKey(undefined));
+    await delay(20);
+
+    expect(calls).toBe(2);
+    expect(inboxCrawlWsKey(undefined)).toBe("skip");
+  });
+
+  it("cancels an in-flight account crawl on identity loss without blocking the next account", async () => {
+    const namespace = `inbox-cancel-${Math.random()}`;
+    let releaseA: (() => void) | null = null;
+    let startedA: (() => void) | null = null;
+    const aPages: any[] = [];
+    const aCompletions: any[] = [];
+    const bPages: any[] = [];
+
+    runReconcileCrawl({
+      namespace,
+      wsKey: inboxCrawlWsKey("account-a"),
+      throttleMs: THROTTLE,
+      pageDelayMs: 0,
+      maxPages: 1,
+      fetchPage: () => new Promise((resolve) => {
+        startedA = () => resolve({ rows: [{ _id: "a" }], isDone: true, continueCursor: null });
+        releaseA = startedA;
+      }),
+      onPage: (rows) => aPages.push(rows),
+      onComplete: (rows) => aCompletions.push(rows),
+    });
+    await delay(10);
+    expect(startedA).not.toBeNull();
+
+    // This is the hook's identity-unknown transition: it must supersede A even
+    // though no replacement crawl is yet eligible to start.
+    runReconcileCrawl({
+      namespace,
+      wsKey: inboxCrawlWsKey(undefined),
+      throttleMs: THROTTLE,
+      pageDelayMs: 0,
+      maxPages: 1,
+      fetchPage: async () => ({ rows: [], isDone: true, continueCursor: null }),
+      onPage: () => {},
+      onComplete: () => {},
+    });
+
+    runReconcileCrawl({
+      namespace,
+      wsKey: inboxCrawlWsKey("account-b"),
+      throttleMs: THROTTLE,
+      pageDelayMs: 0,
+      maxPages: 1,
+      fetchPage: async () => ({ rows: [{ _id: "b" }], isDone: true, continueCursor: null }),
+      onPage: (rows) => bPages.push(rows),
+      onComplete: () => {},
+    });
+    releaseA?.();
+    await delay(40);
+
+    expect(aPages).toEqual([]);
+    expect(aCompletions).toEqual([]);
+    expect(bPages).toEqual([[{ _id: "b" }]]);
+  });
+
+  it("fences an awaited A completion after a principal switch, whether verification resolves or rejects", async () => {
+    for (const outcome of ["resolve", "reject"] as const) {
+      const namespace = `inbox-complete-fence-${outcome}-${Math.random()}`;
+      let release: (() => void) | null = null;
+      let reject: ((error: Error) => void) | null = null;
+      let verificationStarted = false;
+      const applied: string[] = [];
+
+      runReconcileCrawl({
+        namespace,
+        wsKey: inboxCrawlWsKey("account-a"),
+        throttleMs: THROTTLE,
+        pageDelayMs: 0,
+        maxPages: 1,
+        fetchPage: async () => ({ rows: [{ _id: "a" }], isDone: true, continueCursor: null }),
+        onPage: () => {},
+        onComplete: async (_rows, _complete, isCurrent) => {
+          verificationStarted = true;
+          try {
+            await new Promise<void>((resolve, rejectPromise) => {
+              release = resolve;
+              reject = rejectPromise;
+            });
+          } catch {}
+          if (isCurrent()) applied.push("a-clear");
+        },
+      });
+      await delay(10);
+      expect(verificationStarted).toBe(true);
+      cancelReconcileCrawl(namespace);
+      runReconcileCrawl({
+        namespace,
+        wsKey: inboxCrawlWsKey("account-b"),
+        throttleMs: THROTTLE,
+        pageDelayMs: 0,
+        maxPages: 1,
+        fetchPage: async () => ({ rows: [{ _id: "b" }], isDone: true, continueCursor: null }),
+        onPage: () => applied.push("b-page"),
+        onComplete: () => {},
+      });
+      if (outcome === "resolve") release?.();
+      else reject?.(new Error("offline"));
+      await delay(30);
+
+      expect(applied).toEqual(["b-page"]);
+    }
+  });
+
+  it("rechecks durable outbox readiness after a previously armed principal wakes", () => {
+    const key = inboxCrawlWsKey("account-a");
+    expect(hiddenCrawlReady(key, key, true)).toBe(true);
+    // A later failed/offline enqueue reopens the durable outbox; a wake must
+    // not use the old principal latch to launch a hidden-set CLEAR crawl.
+    expect(hiddenCrawlReady(key, key, false)).toBe(false);
+  });
+
+  it("does not complete a hidden CLEAR after the durable outbox reopens", async () => {
+    const namespace = `hidden-outbox-fence-${Math.random()}`;
+    let durableOutboxDrained = true;
+    let releaseFetch: (() => void) | null = null;
+    let clearCalls = 0;
+    runReconcileCrawl({
+      namespace,
+      wsKey: inboxCrawlWsKey("account-a"),
+      throttleMs: THROTTLE,
+      pageDelayMs: 0,
+      maxPages: 1,
+      isCurrent: () => durableOutboxDrained,
+      fetchPage: () => new Promise((resolve) => {
+        releaseFetch = () => resolve({ rows: [], isDone: true, continueCursor: null });
+      }),
+      onPage: () => {},
+      onComplete: () => { clearCalls++; },
+    });
+    await delay(10);
+    // A failed/offline enqueue makes the durable queue non-empty before this
+    // crawl can run its CLEAR phase.
+    durableOutboxDrained = false;
+    releaseFetch?.();
+    await delay(30);
+
+    expect(clearCalls).toBe(0);
+  });
 });

--- a/packages/web/hooks/reconcileCrawl.test.ts
+++ b/packages/web/hooks/reconcileCrawl.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { useInboxStore } from "../store/inboxStore";
+import { bootEagerArmed, crawlThrottledAt, runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const NOW = 1_750_000_000_000;
+const THROTTLE = 30 * 60 * 1000; // SESSIONS_RECONCILE_THROTTLE_MS
+
+// Regression coverage for the boot-eager hidden-set crawls. A dismiss/kill never
+// moves updated_at, so the "dismissed" / "stashed" crawls are the only channel
+// that heals a client which was asleep when the row was hidden elsewhere. While
+// they honored the DURABLE watermark, a client reloading on a stale cache showed
+// resurrected killed sessions for up to the full 30-minute throttle — and reload,
+// the user's instinctive fix, was exactly the gesture that couldn't help.
+describe("crawlThrottledAt", () => {
+  it("bootEager ignores a recent PERSISTED watermark on the first run of a page session", () => {
+    // Fresh module state (sessionDoneAt = 0) + a backfill that finished a minute
+    // ago in a PRIOR page session. Boot-eager must crawl anyway.
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, true)).toBe(false);
+  });
+
+  it("bootEager still honors the IN-SESSION mark (effect re-fires must not re-crawl)", () => {
+    // The effect behind these crawls re-runs on wsKey settle / every reconcileNonce
+    // tick; once the boot crawl completes, st.doneAt gates the rest of the session.
+    expect(crawlThrottledAt(NOW, THROTTLE, NOW - 60_000, 0, true)).toBe(true);
+  });
+
+  it("without bootEager a recent persisted watermark still skips (durable throttle intact)", () => {
+    // The sessions / tasks / docs crawls are expensive and must keep serving from
+    // the IDB cache on relaunch inside the window.
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, false)).toBe(true);
+  });
+
+  it("runs when neither watermark is inside the window", () => {
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, 0, false)).toBe(false);
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, 0, true)).toBe(false);
+    // An expired persisted mark is no different from none.
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - THROTTLE - 1, false)).toBe(false);
+  });
+});
+
+// The eager crawl's CLEAR pass un-hides rows the server's hidden set omits, so
+// running it before the durable outbox replays can resurrect a kill the user made
+// offline: the parked dispatch hasn't reached the server, and the pending field
+// lock that would have protected the row is released as stale after 5 minutes.
+// The durable throttle used to mask this by skipping the boot crawl entirely.
+const MAX_WAIT = 10_000; // BOOT_OUTBOX_DRAIN_MAX_WAIT_MS
+describe("bootEagerArmed", () => {
+  it("holds the bypass while the outbox still has an unreplayed boot backlog", () => {
+    expect(bootEagerArmed(false, 0, MAX_WAIT)).toBe(false);
+    expect(bootEagerArmed(false, MAX_WAIT - 1, MAX_WAIT)).toBe(false);
+  });
+
+  it("arms as soon as the boot drain reports every parked entry attempted", () => {
+    expect(bootEagerArmed(true, 0, MAX_WAIT)).toBe(true);
+  });
+
+  it("arms at the deadline anyway — a wedged or unwired outbox must not disable healing", () => {
+    // No dispatch binding (or a drain that keeps aborting) leaves the signal false
+    // forever; the crawl is the only healer for killed sessions, so it still runs.
+    expect(bootEagerArmed(false, MAX_WAIT, MAX_WAIT)).toBe(true);
+    expect(bootEagerArmed(false, MAX_WAIT + 5_000, MAX_WAIT)).toBe(true);
+  });
+
+  it("composes with the throttle once armed", () => {
+    // The hook holds the crawl entirely while unarmed. Once armed, the persisted
+    // watermark is ignored and the crawl runs.
+    const armed = bootEagerArmed(false, 0, MAX_WAIT);
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, armed)).toBe(true);
+    expect(crawlThrottledAt(NOW, THROTTLE, 0, NOW - 60_000, bootEagerArmed(true, 0, MAX_WAIT))).toBe(false);
+  });
+});
+
+// The predicate can be right while the option is unplumbed, so exercise the real
+// crawl: boot-eager must page despite a fresh persisted watermark, then throttle.
+describe("runReconcileCrawl — boot-eager wiring", () => {
+  beforeEach(() => {
+    useInboxStore.setState({ syncMeta: {}, syncProgress: {} });
+  });
+
+  it("crawls once past a recent persisted watermark, then throttles for the rest of the session", async () => {
+    useInboxStore.getState().recordSyncMeta(syncMetaKey("bEager", "wsBoot"), { backfilledAt: Date.now() });
+
+    let calls = 0;
+    const crawl = () => runReconcileCrawl({
+      namespace: "bEager",
+      wsKey: "wsBoot",
+      throttleMs: THROTTLE,
+      pageDelayMs: 0,
+      maxPages: 10,
+      bootEager: true,
+      fetchPage: async () => { calls++; return { rows: [{ _id: "d1" }], isDone: true, continueCursor: null }; },
+      onPage: () => {},
+      onComplete: () => {},
+    });
+
+    crawl();
+    await delay(40);
+    expect(calls).toBe(1);
+    // Watermark is still WRITTEN on completion — other consumers read backfilledAt.
+    expect(useInboxStore.getState().syncMeta[syncMetaKey("bEager", "wsBoot")]?.backfilledAt).toBeGreaterThan(0);
+
+    // Re-fire (reconcileNonce tick / wsKey settle) — the in-session mark gates it.
+    crawl();
+    await delay(40);
+    expect(calls).toBe(1);
+  });
+
+});

--- a/packages/web/hooks/reconcileCrawl.ts
+++ b/packages/web/hooks/reconcileCrawl.ts
@@ -53,7 +53,80 @@ export type CrawlOptions = {
    * CLEAR) must gate on `complete` so a truncated crawl can't drop real rows.
    */
   onComplete: (all: any[], complete: boolean) => void;
+  /** Ignore the durable watermark on the first run in this page session. */
+  bootEager?: boolean;
 };
+
+/**
+ * The skip decision, extracted so it's unit-testable without the async crawl.
+ *
+ * Normally the throttle honors BOTH watermarks: the module-scope `doneAt` (this
+ * page session) and the persisted `backfilledAt` (durable across reloads), so a
+ * relaunch inside the window serves the IDB cache instead of re-walking the table.
+ *
+ * `bootEager` consults ONLY the in-session mark. It exists for the "dismissed" /
+ * "stashed" crawls, which are the sole channel that heals cross-device dismissal
+ * state: a dismiss/kill doesn't move updated_at, so neither the live channel nor
+ * the sessions crawl carries it to a client that was asleep. With the durable
+ * throttle, a client reloading on a stale cache showed resurrected killed sessions
+ * for up to the full 30-minute SESSIONS_RECONCILE_THROTTLE_MS — reloading, the
+ * user's natural fix, could not clear them.
+ *
+ * This is not free, and the cost is per WINDOW LOAD, not per user: each eager pass
+ * is a full 30-day index range scan of the hidden set — one for `dismissed`, one
+ * for `stashed` — paged at 1000 rows. The rows are narrow ({_id, timestamp}) and
+ * the scans are bounded by DISMISS_RECONCILE_WINDOW_MS rather than table size, but
+ * a user who reloads often, or runs several tabs, pays two scans every time where
+ * they previously paid none. We take that trade deliberately: a resurrected killed
+ * session is a correctness bug the user cannot clear by any means available to
+ * them, and read amplification on a windowed index is the cheaper failure.
+ *
+ * The in-session mark still gates repeats: the effect behind these crawls re-fires
+ * on wsKey settle and every reconcileNonce tick, and once the first crawl completes
+ * `st.doneAt` is set, so bootEager throttles identically from then on — the eager
+ * pass happens once per page load, not on every re-render.
+ */
+export function crawlThrottledAt(
+  now: number,
+  throttleMs: number,
+  sessionDoneAt: number,
+  persistedDoneAt: number,
+  bootEager: boolean,
+): boolean {
+  const lastDoneAt = bootEager ? sessionDoneAt : Math.max(sessionDoneAt, persistedDoneAt);
+  return now - lastDoneAt < throttleMs;
+}
+
+/**
+ * Whether the boot-eager bypass may be armed yet.
+ *
+ * The eager crawl's CLEAR pass un-hides any row inside the window the server's
+ * hidden set omits — so it must not run on a PRE-REPLAY view of the server. The
+ * losing interleaving: the user kills a session while offline, the dispatch parks
+ * in the durable outbox, and `pending`'s field lock is persisted with its original
+ * timestamp. They reload more than HIDDEN_OVERRIDE_SETTLE_MS (5 min) later, so
+ * lockedLocal treats the override as stale and releases it — deliberately, that
+ * release is what stops an originating device pinning a row hidden forever. If the
+ * eager crawl's pages are fetched before the outbox replay lands, the server hasn't
+ * been told about the kill, the CLEAR pass un-hides it, and the killed session
+ * climbs back into the inbox until the next crawl up to 30 minutes later.
+ *
+ * The durable throttle used to mask this: a reload inside 30 minutes skipped the
+ * boot crawl entirely and let the outbox drain first. Boot-eager removes that
+ * accident, so we reinstate the ordering on purpose — hold the bypass until the
+ * boot replay has attempted every parked entry.
+ *
+ * `maxWaitMs` bounds the wait: an outbox that never settles (no dispatch binding,
+ * a wedged drain) must not disable the healing crawl forever. Waiting is also
+ * self-limiting in the case that matters — if the outbox is stuck because the
+ * client is offline, the crawl's own queries fail anyway, so the ordering is moot.
+ * Until this returns true the caller does not launch the hidden-set crawls at all
+ * — the durable throttle alone is not a safe fallback, since a client with no
+ * persisted watermark has nothing to be throttled by.
+ */
+export function bootEagerArmed(bootOutboxDrained: boolean, waitedMs: number, maxWaitMs: number): boolean {
+  return bootOutboxDrained || waitedMs >= maxWaitMs;
+}
 
 /**
  * Kick off a reconcile crawl if one isn't already running / recently done for
@@ -81,8 +154,7 @@ export function runReconcileCrawl(opts: CrawlOptions): void {
   // honors a backfill that finished in a prior session instead of re-crawling the
   // whole table on every launch. The module-scope doneAt covers the in-session case.
   const persistedDoneAt = useInboxStore.getState().syncMeta[metaKey]?.backfilledAt ?? 0;
-  const lastDoneAt = Math.max(st.doneAt.get(wsKey) ?? 0, persistedDoneAt);
-  if (Date.now() - lastDoneAt < throttleMs) return;
+  if (crawlThrottledAt(Date.now(), throttleMs, st.doneAt.get(wsKey) ?? 0, persistedDoneAt, !!opts.bootEager)) return;
   // A crawl for THIS workspace is already in flight → let it finish.
   if (st.runningKey === wsKey) return;
 

--- a/packages/web/hooks/reconcileCrawl.ts
+++ b/packages/web/hooks/reconcileCrawl.ts
@@ -26,6 +26,14 @@ function stateFor(namespace: string): ReconcileState {
   return s;
 }
 
+/** Abandon the active crawl in one namespace without affecting other crawls. */
+export function cancelReconcileCrawl(namespace: string): void {
+  const st = stateFor(namespace);
+  st.gen++;
+  st.runningKey = null;
+  setProgress(namespace, false, 0);
+}
+
 function setProgress(namespace: string, loading: boolean, loaded: number) {
   const prev = useInboxStore.getState().syncProgress;
   useInboxStore.setState({ syncProgress: { ...prev, [namespace]: { loading, loaded } } });
@@ -45,6 +53,8 @@ export type CrawlOptions = {
   fetchPage: (cursor: string | null) => Promise<CrawlPage>;
   /** Overlay a freshly-fetched page (delta — never prunes). */
   onPage: (rows: any[]) => void;
+  /** Dynamic lifecycle fence (principal changes, durable replay gates, etc.). */
+  isCurrent?: () => boolean;
   /**
    * Final overlay of the full set. `complete` is true only when the crawl
    * reached the true end (isDone / no next cursor), false when it stopped at
@@ -52,7 +62,7 @@ export type CrawlOptions = {
    * ignore it; a consumer that PRUNES on this pass (the dismiss reconcile's
    * CLEAR) must gate on `complete` so a truncated crawl can't drop real rows.
    */
-  onComplete: (all: any[], complete: boolean) => void;
+  onComplete: (all: any[], complete: boolean, isCurrent: () => boolean) => void | Promise<void>;
   /** Ignore the durable watermark on the first run in this page session. */
   bootEager?: boolean;
 };
@@ -114,18 +124,15 @@ export function crawlThrottledAt(
  * The durable throttle used to mask this: a reload inside 30 minutes skipped the
  * boot crawl entirely and let the outbox drain first. Boot-eager removes that
  * accident, so we reinstate the ordering on purpose — hold the bypass until the
- * boot replay has attempted every parked entry.
+ * durable outbox has been verified empty after replay.
  *
- * `maxWaitMs` bounds the wait: an outbox that never settles (no dispatch binding,
- * a wedged drain) must not disable the healing crawl forever. Waiting is also
- * self-limiting in the case that matters — if the outbox is stuck because the
- * client is offline, the crawl's own queries fail anyway, so the ordering is moot.
  * Until this returns true the caller does not launch the hidden-set crawls at all
  * — the durable throttle alone is not a safe fallback, since a client with no
- * persisted watermark has nothing to be throttled by.
+ * persisted watermark has nothing to be throttled by. A stalled outbox delays
+ * healing; it must never permit a pre-replay CLEAR pass.
  */
-export function bootEagerArmed(bootOutboxDrained: boolean, waitedMs: number, maxWaitMs: number): boolean {
-  return bootOutboxDrained || waitedMs >= maxWaitMs;
+export function bootEagerArmed(bootOutboxDrained: boolean): boolean {
+  return bootOutboxDrained;
 }
 
 /**
@@ -146,7 +153,11 @@ export function syncMetaKey(namespace: string, wsKey: string): string {
 
 export function runReconcileCrawl(opts: CrawlOptions): void {
   const { namespace, wsKey, throttleMs, pageDelayMs, maxPages } = opts;
-  if (wsKey === "skip") return;
+  if (wsKey === "skip") {
+    cancelReconcileCrawl(namespace);
+    return;
+  }
+  if (opts.isCurrent && !opts.isCurrent()) return;
   const st = stateFor(namespace);
   const metaKey = syncMetaKey(namespace, wsKey);
   // Recently completed for this workspace → serve from the IDB-cached store.
@@ -162,6 +173,13 @@ export function runReconcileCrawl(opts: CrawlOptions): void {
   const myGen = ++st.gen;
   st.runningKey = wsKey;
   const superseded = () => st.gen !== myGen;
+  const isCurrent = () => !superseded() && (opts.isCurrent?.() ?? true);
+  const stop = (loaded: number) => {
+    if (!superseded()) {
+      st.runningKey = null;
+      setProgress(namespace, false, loaded);
+    }
+  };
 
   (async () => {
     setProgress(namespace, true, 0);
@@ -174,7 +192,7 @@ export function runReconcileCrawl(opts: CrawlOptions): void {
       // the whole crawl and leave a partial list. Give up only after several tries.
       let page: CrawlPage | null = null;
       for (let attempt = 0; attempt < 5; attempt++) {
-        if (superseded()) return;
+        if (!isCurrent()) { stop(all.length); return; }
         try { page = await opts.fetchPage(cursor); break; }
         catch {
           if (attempt === 4) {
@@ -186,7 +204,7 @@ export function runReconcileCrawl(opts: CrawlOptions): void {
           await new Promise((r) => setTimeout(r, 400 * 2 ** attempt));
         }
       }
-      if (superseded() || !page) return; // a newer workspace crawl took over
+      if (!isCurrent() || !page) { stop(all.length); return; } // a newer workspace crawl took over
       const rows = page.rows ?? [];
       all.push(...rows);
       // Overlay each page immediately so the list fills in progressively.
@@ -202,13 +220,14 @@ export function runReconcileCrawl(opts: CrawlOptions): void {
       cursor = next;
       await new Promise((r) => setTimeout(r, pageDelayMs));
     }
-    if (superseded()) return;
+    if (!isCurrent()) { stop(all.length); return; }
     // Final completeness pass: re-overlay the full set. onComplete is a DELTA
     // overlay (the big collections are isDelta in SYNC_REGISTRY) — additive, never
     // prunes — so this only fills in rows onPage may have missed. Deletions arrive
     // as deltas, never by snapshot, so a short/truncated crawl can't gut the cache.
     // `completed` lets a pruning consumer (the dismiss CLEAR) know the set is whole.
-    opts.onComplete(all, completed);
+    await opts.onComplete(all, completed, isCurrent);
+    if (!isCurrent()) { stop(all.length); return; }
     // Persist the watermark: backfilledAt (durable throttle — skip the crawl on
     // the next launch) and cursor = the highest updated_at we just saw (so the
     // NEXT crawl resumes incrementally from here via `since`). cursor advances

--- a/packages/web/hooks/useSyncInboxSessions.ts
+++ b/packages/web/hooks/useSyncInboxSessions.ts
@@ -10,7 +10,7 @@ import { useRecoveryPoll } from "./useRecoveryPoll";
 import { useEnsureDispatch } from "./useEnsureDispatch";
 import { useLiveInboxSessions, applyLiveInboxIds } from "./useLiveInboxSessions";
 import { useWatchEffect } from "./useWatchEffect";
-import { runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
+import { bootEagerArmed, runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
 import { collectGhostSweepCandidates, collectHiddenResurrectionSuspects } from "./ghostSweep";
 
 // Background reconcile for the inbox session list. The live listInboxSessions
@@ -27,6 +27,12 @@ const SESSIONS_CRAWL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const SESSIONS_RECONCILE_PAGE_SIZE = 75;
 const SESSIONS_RECONCILE_PAGE_DELAY_MS = 60;
 const SESSIONS_RECONCILE_THROTTLE_MS = 30 * 60 * 1000;
+// How long the boot-eager hidden-set crawls wait for the durable outbox to replay
+// before running anyway. Long enough to cover a normal boot drain (an IDB load
+// plus a few dispatches), short enough that a client which never wires dispatch
+// still heals its killed sessions in seconds rather than at the 30-minute tick.
+const BOOT_OUTBOX_DRAIN_MAX_WAIT_MS = 10_000;
+const BOOT_OUTBOX_DRAIN_POLL_MS = 250;
 // Ghost-sweep policy (age floors + candidate selection) lives in ./ghostSweep
 // so the selection is unit-testable without this hook's React/Convex imports.
 
@@ -548,6 +554,28 @@ export function useSyncInboxSessions() {
     apply(rows, complete);
   }, [convex]);
 
+  // BOOT OUTBOX GATE — holds the hidden-set crawls until the durable outbox has
+  // replayed (or we've waited long enough). Without it, a hide the user made
+  // offline is still parked in the outbox while the crawl asks the server for the
+  // hidden set, and the CLEAR pass un-hides it — see bootEagerArmed. The wait is
+  // bounded, so a wedged or unwired outbox delays the healer, never disables it.
+  // Polled rather than subscribed: _hasBootOutboxDrained is a
+  // plain accessor injected by mutativeMiddleware, not reactive store state.
+  const [bootEagerReady, setBootEagerReady] = useState(false);
+  useEffect(() => {
+    if (!hydrated || bootEagerReady) return;
+    const startedAt = Date.now();
+    const check = () => {
+      const drained = !!(useInboxStore.getState() as any)._hasBootOutboxDrained?.();
+      if (!bootEagerArmed(drained, Date.now() - startedAt, BOOT_OUTBOX_DRAIN_MAX_WAIT_MS)) return;
+      setBootEagerReady(true);
+      clearInterval(id);
+    };
+    const id = setInterval(check, BOOT_OUTBOX_DRAIN_POLL_MS);
+    check();
+    return () => clearInterval(id);
+  }, [hydrated, bootEagerReady]);
+
   // DISMISS RECONCILE — durable cross-device dismiss/un-dismiss propagation.
   // The live listInboxSessions channel only reaches a CONNECTED client, and the
   // session crawl above can't carry a dismiss (dismiss doesn't move updated_at,
@@ -558,7 +586,9 @@ export function useSyncInboxSessions() {
   // each page, SET + CLEAR on completion. Full scan (no `since`) — a dismiss-only
   // write has no updated_at watermark to resume from, and the set is small.
   useEffect(() => {
-    if (!hydrated) return;
+    // The durable throttle is not a safe fallback while the outbox is replaying:
+    // a cold/expired watermark would still launch the CLEAR pass immediately.
+    if (!hydrated || !bootEagerReady) return;
     // STABLE window bound for the WHOLE crawl — computed once here, never inside
     // the server handler. The lite queries range-scan their index from this lower
     // bound; a per-page Date.now() would shift the range so each continuation
@@ -571,6 +601,12 @@ export function useSyncInboxSessions() {
       namespace: "dismissed",
       wsKey: sessWsKey,
       throttleMs: SESSIONS_RECONCILE_THROTTLE_MS,
+      // The first run after a page load ignores the durable watermark:
+      // this crawl is the only healer for cross-device dismisses, so honoring it
+      // left a reloading client staring at resurrected killed sessions for up to
+      // the full 30 minutes. The effect-level gate above prevents any pre-replay
+      // CLEAR pass; once here, the bypass is always armed.
+      bootEager: true,
       pageDelayMs: SESSIONS_RECONCILE_PAGE_DELAY_MS,
       maxPages: 50,
       fetchPage: async (cursor) => {
@@ -592,6 +628,7 @@ export function useSyncInboxSessions() {
       namespace: "stashed",
       wsKey: sessWsKey,
       throttleMs: SESSIONS_RECONCILE_THROTTLE_MS,
+      bootEager: true,
       pageDelayMs: SESSIONS_RECONCILE_PAGE_DELAY_MS,
       maxPages: 50,
       fetchPage: async (cursor) => {
@@ -605,7 +642,9 @@ export function useSyncInboxSessions() {
       onComplete: (all, complete) => applyHiddenReconcileVerified(all as any, complete, "inbox_stashed_at",
         (rows, final) => useInboxStore.getState().applyStashedReconcile(rows as any, final)),
     });
-  }, [convex, sessWsKey, reconcileNonce, hydrated]); // eslint-disable-line react-hooks/exhaustive-deps
+    // bootEagerReady flipping re-fires this effect to run the first pass; the
+    // crawls' own in-session doneAt keeps later re-fires from double-crawling.
+  }, [convex, sessWsKey, reconcileNonce, hydrated, bootEagerReady]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { activeSessions: inboxSessions };
 }

--- a/packages/web/hooks/useSyncInboxSessions.ts
+++ b/packages/web/hooks/useSyncInboxSessions.ts
@@ -442,6 +442,7 @@ export function useSyncInboxSessions() {
   // shared workspace: account A's completion mark must not throttle account B,
   // and no crawl may begin before Convex has identified the active principal.
   const sessWsKey = inboxCrawlWsKey(currentUser?._id?.toString());
+  // eslint-disable-next-line no-restricted-syntax -- cleanup keyed to the principal; cancels in-flight crawls on wsKey change
   useEffect(() => () => {
     cancelReconcileCrawl("sessions");
     cancelReconcileCrawl("dismissed");
@@ -578,6 +579,7 @@ export function useSyncInboxSessions() {
   // Polled rather than subscribed: _hasBootOutboxDrained is a
   // plain accessor injected by mutativeMiddleware, not reactive store state.
   const [bootEagerPrincipal, setBootEagerPrincipal] = useState<string | null>(null);
+  // eslint-disable-next-line no-restricted-syntax -- polled outbox-drain gate; effect manages its own interval
   useEffect(() => {
     if (!hydrated || sessWsKey === "skip" || bootEagerPrincipal === sessWsKey) return;
     const check = () => {

--- a/packages/web/hooks/useSyncInboxSessions.ts
+++ b/packages/web/hooks/useSyncInboxSessions.ts
@@ -10,7 +10,7 @@ import { useRecoveryPoll } from "./useRecoveryPoll";
 import { useEnsureDispatch } from "./useEnsureDispatch";
 import { useLiveInboxSessions, applyLiveInboxIds } from "./useLiveInboxSessions";
 import { useWatchEffect } from "./useWatchEffect";
-import { bootEagerArmed, runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
+import { bootEagerArmed, cancelReconcileCrawl, runReconcileCrawl, syncMetaKey } from "./reconcileCrawl";
 import { collectGhostSweepCandidates, collectHiddenResurrectionSuspects } from "./ghostSweep";
 
 // Background reconcile for the inbox session list. The live listInboxSessions
@@ -27,11 +27,6 @@ const SESSIONS_CRAWL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const SESSIONS_RECONCILE_PAGE_SIZE = 75;
 const SESSIONS_RECONCILE_PAGE_DELAY_MS = 60;
 const SESSIONS_RECONCILE_THROTTLE_MS = 30 * 60 * 1000;
-// How long the boot-eager hidden-set crawls wait for the durable outbox to replay
-// before running anyway. Long enough to cover a normal boot drain (an IDB load
-// plus a few dispatches), short enough that a client which never wires dispatch
-// still heals its killed sessions in seconds rather than at the 30-minute tick.
-const BOOT_OUTBOX_DRAIN_MAX_WAIT_MS = 10_000;
 const BOOT_OUTBOX_DRAIN_POLL_MS = 250;
 // Ghost-sweep policy (age floors + candidate selection) lives in ./ghostSweep
 // so the selection is unit-testable without this hook's React/Convex imports.
@@ -89,6 +84,18 @@ export function shouldPlayWaitingSound(
   }
 
   return { play, nextWaiting };
+}
+
+export function inboxCrawlWsKey(principalId: string | null | undefined): string {
+  return principalId ? `inbox:${principalId}` : "skip";
+}
+
+export function hiddenCrawlReady(
+  bootEagerPrincipal: string | null,
+  sessWsKey: string,
+  durableOutboxDrained: boolean,
+): boolean {
+  return sessWsKey !== "skip" && bootEagerPrincipal === sessWsKey && bootEagerArmed(durableOutboxDrained);
 }
 
 export function useSyncInboxSessions() {
@@ -431,9 +438,15 @@ export function useSyncInboxSessions() {
     store.redrivePendingMessages();
     store.resumePostCreateSessionIntents();
   }, [hydrated]);
-  // Stable crawl namespace — the live arg no longer varies, so the watermark
-  // never resets on a show/hide-old toggle.
-  const sessWsKey = "inbox";
+  // The module-scope crawl state is keyed by this value. The inbox is not a
+  // shared workspace: account A's completion mark must not throttle account B,
+  // and no crawl may begin before Convex has identified the active principal.
+  const sessWsKey = inboxCrawlWsKey(currentUser?._id?.toString());
+  useEffect(() => () => {
+    cancelReconcileCrawl("sessions");
+    cancelReconcileCrawl("dismissed");
+    cancelReconcileCrawl("stashed");
+  }, [sessWsKey]);
   const [reconcileNonce, setReconcileNonce] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setReconcileNonce((n) => n + 1), SESSIONS_RECONCILE_THROTTLE_MS);
@@ -457,7 +470,7 @@ export function useSyncInboxSessions() {
     };
   }, []);
   useEffect(() => {
-    if (!hydrated) return;
+    if (!hydrated || sessWsKey === "skip") return;
     // Incremental top-up after a full backfill; the FIRST pass seeds since=now-30d
     // so the completeness floor only pulls the last 30 days (older sessions stay
     // accessible via search/open). This MUST be a single stable value for the whole
@@ -535,7 +548,9 @@ export function useSyncInboxSessions() {
     complete: boolean,
     field: "inbox_dismissed_at" | "inbox_stashed_at",
     apply: (rows: Array<{ _id: string }>, final: boolean) => void,
+    isCurrent: () => boolean,
   ) => {
+    if (!isCurrent()) return;
     if (complete) {
       const suspects = collectHiddenResurrectionSuspects(
         useInboxStore.getState(),
@@ -545,36 +560,36 @@ export function useSyncInboxSessions() {
       if (suspects.length) {
         try {
           const existing: string[] = await convex.query(api.conversations.existingConversationIds, { ids: suspects });
+          if (!isCurrent()) return;
           const exists = new Set(existing);
           const gone = suspects.filter((id) => !exists.has(id));
           if (gone.length) useInboxStore.getState().pruneGhostSessions(gone);
         } catch {}
       }
     }
+    if (!isCurrent()) return;
     apply(rows, complete);
   }, [convex]);
 
   // BOOT OUTBOX GATE — holds the hidden-set crawls until the durable outbox has
-  // replayed (or we've waited long enough). Without it, a hide the user made
-  // offline is still parked in the outbox while the crawl asks the server for the
-  // hidden set, and the CLEAR pass un-hides it — see bootEagerArmed. The wait is
-  // bounded, so a wedged or unwired outbox delays the healer, never disables it.
+  // replayed and verified empty. Without it, a hide the user made offline is
+  // still parked in the outbox while the crawl asks the server for the hidden
+  // set, and the CLEAR pass un-hides it — see bootEagerArmed.
   // Polled rather than subscribed: _hasBootOutboxDrained is a
   // plain accessor injected by mutativeMiddleware, not reactive store state.
-  const [bootEagerReady, setBootEagerReady] = useState(false);
+  const [bootEagerPrincipal, setBootEagerPrincipal] = useState<string | null>(null);
   useEffect(() => {
-    if (!hydrated || bootEagerReady) return;
-    const startedAt = Date.now();
+    if (!hydrated || sessWsKey === "skip" || bootEagerPrincipal === sessWsKey) return;
     const check = () => {
       const drained = !!(useInboxStore.getState() as any)._hasBootOutboxDrained?.();
-      if (!bootEagerArmed(drained, Date.now() - startedAt, BOOT_OUTBOX_DRAIN_MAX_WAIT_MS)) return;
-      setBootEagerReady(true);
+      if (!bootEagerArmed(drained)) return;
+      setBootEagerPrincipal(sessWsKey);
       clearInterval(id);
     };
     const id = setInterval(check, BOOT_OUTBOX_DRAIN_POLL_MS);
     check();
     return () => clearInterval(id);
-  }, [hydrated, bootEagerReady]);
+  }, [hydrated, sessWsKey, bootEagerPrincipal]);
 
   // DISMISS RECONCILE — durable cross-device dismiss/un-dismiss propagation.
   // The live listInboxSessions channel only reaches a CONNECTED client, and the
@@ -588,7 +603,8 @@ export function useSyncInboxSessions() {
   useEffect(() => {
     // The durable throttle is not a safe fallback while the outbox is replaying:
     // a cold/expired watermark would still launch the CLEAR pass immediately.
-    if (!hydrated || !bootEagerReady) return;
+    const durableOutboxDrained = !!(useInboxStore.getState() as any)._hasBootOutboxDrained?.();
+    if (!hydrated || !hiddenCrawlReady(bootEagerPrincipal, sessWsKey, durableOutboxDrained)) return;
     // STABLE window bound for the WHOLE crawl — computed once here, never inside
     // the server handler. The lite queries range-scan their index from this lower
     // bound; a per-page Date.now() would shift the range so each continuation
@@ -607,6 +623,7 @@ export function useSyncInboxSessions() {
       // the full 30 minutes. The effect-level gate above prevents any pre-replay
       // CLEAR pass; once here, the bypass is always armed.
       bootEager: true,
+      isCurrent: () => !!(useInboxStore.getState() as any)._hasBootOutboxDrained?.(),
       pageDelayMs: SESSIONS_RECONCILE_PAGE_DELAY_MS,
       maxPages: 50,
       fetchPage: async (cursor) => {
@@ -620,8 +637,8 @@ export function useSyncInboxSessions() {
       // CLEAR (un-dismiss propagation) runs ONLY on a provably-complete crawl:
       // `complete` is false if the crawl stopped at maxPages, so a truncated set
       // can never wrongly un-dismiss the un-fetched tail.
-      onComplete: (all, complete) => applyHiddenReconcileVerified(all as any, complete, "inbox_dismissed_at",
-        (rows, final) => useInboxStore.getState().applyDismissedReconcile(rows as any, final)),
+      onComplete: (all, complete, isCurrent) => applyHiddenReconcileVerified(all as any, complete, "inbox_dismissed_at",
+        (rows, final) => useInboxStore.getState().applyDismissedReconcile(rows as any, final), isCurrent),
     });
     // Stashed twin — same mechanics, keyed on inbox_stashed_at.
     runReconcileCrawl({
@@ -629,6 +646,7 @@ export function useSyncInboxSessions() {
       wsKey: sessWsKey,
       throttleMs: SESSIONS_RECONCILE_THROTTLE_MS,
       bootEager: true,
+      isCurrent: () => !!(useInboxStore.getState() as any)._hasBootOutboxDrained?.(),
       pageDelayMs: SESSIONS_RECONCILE_PAGE_DELAY_MS,
       maxPages: 50,
       fetchPage: async (cursor) => {
@@ -639,12 +657,12 @@ export function useSyncInboxSessions() {
         return { rows: page.page ?? [], isDone: page.isDone, continueCursor: page.continueCursor };
       },
       onPage: (rows) => useInboxStore.getState().applyStashedReconcile(rows as any, false),
-      onComplete: (all, complete) => applyHiddenReconcileVerified(all as any, complete, "inbox_stashed_at",
-        (rows, final) => useInboxStore.getState().applyStashedReconcile(rows as any, final)),
+      onComplete: (all, complete, isCurrent) => applyHiddenReconcileVerified(all as any, complete, "inbox_stashed_at",
+        (rows, final) => useInboxStore.getState().applyStashedReconcile(rows as any, final), isCurrent),
     });
-    // bootEagerReady flipping re-fires this effect to run the first pass; the
+    // bootEagerPrincipal settling re-fires this effect to run the first pass; the
     // crawls' own in-session doneAt keeps later re-fires from double-crawling.
-  }, [convex, sessWsKey, reconcileNonce, hydrated, bootEagerReady]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [convex, sessWsKey, reconcileNonce, hydrated, bootEagerPrincipal]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { activeSessions: inboxSessions };
 }

--- a/packages/web/lib/machinePicker.test.ts
+++ b/packages/web/lib/machinePicker.test.ts
@@ -201,3 +201,41 @@ describe("resolveMachineSelection", () => {
     expect(resolveMachineSelection([], {}).scopeProjectsToDeviceId).toBeNull();
   });
 });
+
+describe("resolveMachineSelection — a transient empty roster", () => {
+  // `useDevices()` is `useQuery(...) ?? []`, so the roster reads EMPTY on every
+  // mount and again on any Convex reconnect. That gap used to resolve to null,
+  // and null scoping reverted the folder list to the cross-machine union while
+  // the stub's stamp survived — so the UI could offer a machine-B-only path for a
+  // session already pinned to machine A, and the create would send it to A.
+  const ROSTER = [dev("A"), dev("B")];
+
+  it("preserves BOTH the stamp and the project scoping across the gap", () => {
+    const loaded = resolveMachineSelection(ROSTER, { picked: "A" });
+    expect(loaded.stampDeviceId).toBe("A");
+
+    const duringGap = resolveMachineSelection([], { existingStamp: loaded.stampDeviceId });
+    expect(duringGap.stampDeviceId).toBe("A");
+    expect(duringGap.scopeProjectsToDeviceId).toBe("A"); // never null → never the union
+  });
+
+  it("keeps scope and stamp equal in the gap, so neither half can drift", () => {
+    const r = resolveMachineSelection([], { existingStamp: "A" });
+    expect(r.scopeProjectsToDeviceId).toBe(r.stampDeviceId);
+  });
+
+  it("is only a fallback — a live roster decides again, so a stale stamp can't stick", () => {
+    const r = resolveMachineSelection(ROSTER, { existingStamp: "B", lastPicked: "A" });
+    expect(r.selectedDeviceId).toBe("A");
+  });
+
+  it("an active pick still outranks the recorded stamp", () => {
+    expect(resolveMachineSelection(ROSTER, { picked: "B", existingStamp: "A" }).stampDeviceId).toBe("B");
+  });
+
+  it("still null when there is no roster AND no prior decision", () => {
+    const r = resolveMachineSelection([], {});
+    expect(r.stampDeviceId).toBeNull();
+    expect(r.scopeProjectsToDeviceId).toBeNull();
+  });
+});

--- a/packages/web/lib/machinePicker.test.ts
+++ b/packages/web/lib/machinePicker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { defaultMachineId, pathOnMyMachines, type MachineCandidate } from "./machinePicker";
+import { defaultMachineId, pathOnMyMachines, resolveMachineSelection, type MachineCandidate } from "./machinePicker";
 
 const dev = (id: string, over: Partial<MachineCandidate> = {}): MachineCandidate => ({
   device_id: id,
@@ -24,7 +24,24 @@ describe("defaultMachineId", () => {
     expect(defaultMachineId([dev("laptop")], { ownerDeviceId: "gone" })).toBe("laptop");
   });
 
-  it("prefers an online local that has the checkout over a more recent one that doesn't", () => {
+  it("opens on the machine you last picked", () => {
+    const devices = [dev("laptop"), dev("desktop")];
+    expect(defaultMachineId(devices, { lastPicked: "desktop" })).toBe("desktop");
+  });
+
+  it("does not let a standing pick move a session that already has an owner", () => {
+    // The pick is stamped now, so honouring lastPicked here would re-point an
+    // existing session onto another machine just by opening it.
+    const devices = [dev("laptop"), dev("desktop")];
+    expect(defaultMachineId(devices, { lastPicked: "desktop", ownerDeviceId: "laptop" })).toBe("laptop");
+  });
+
+  it("ignores a standing pick whose machine is offline or gone", () => {
+    expect(defaultMachineId([dev("laptop"), dev("desktop", { online: false })], { lastPicked: "desktop" })).toBe("laptop");
+    expect(defaultMachineId([dev("laptop")], { lastPicked: "retired" })).toBe("laptop");
+  });
+
+  it("prefers an online local that has the checkout over one that doesn't", () => {
     const devices = [
       dev("laptop", { last_seen: 9000 }),
       dev("desktop", { last_seen: 1000, local_project_roots: ["/Users/j/code/codecast"] }),
@@ -32,28 +49,53 @@ describe("defaultMachineId", () => {
     expect(defaultMachineId(devices, { projectPath: "/Users/j/code/codecast" })).toBe("desktop");
   });
 
-  it("falls back to the most-recently-seen online local when nobody has the checkout", () => {
-    const devices = [dev("laptop", { last_seen: 9000 }), dev("desktop", { last_seen: 1000 })];
-    expect(defaultMachineId(devices, { projectPath: "/Users/j/code/nowhere" })).toBe("laptop");
+  it("matches a checkout by prefix, so a repo subdir still finds its machine", () => {
+    const devices = [dev("laptop"), dev("desktop", { local_project_roots: ["/Users/j/code/app"] })];
+    expect(defaultMachineId(devices, { projectPath: "/Users/j/code/app/packages/web" })).toBe("desktop");
+    // …but not a sibling that merely shares a prefix string: nobody has that
+    // checkout, so it falls to the stable tiebreak across all online locals.
+    expect(defaultMachineId(devices, { projectPath: "/Users/j/code/app-other" })).toBe("desktop");
   });
 
-  it("holds a sticky answer against heartbeat churn, but only within the candidate pool", () => {
-    // Both online and idle: whichever heartbeated last would otherwise win, and
-    // that flips every ~30s.
-    const churned = [dev("laptop", { last_seen: 9000 }), dev("desktop", { last_seen: 8000 })];
-    expect(defaultMachineId(churned, { sticky: "desktop" })).toBe("desktop");
+  // THE REGRESSION this ladder exists to prevent. Two idle online locals
+  // re-heartbeat every ~30s; the old tiebreak was `last_seen`, so the answer
+  // flipped between the render that showed a chip and the send that acted on it.
+  it("is stable against heartbeat churn — last_seen never decides", () => {
+    const a = [dev("laptop", { last_seen: 9000 }), dev("desktop", { last_seen: 8000 })];
+    const b = [dev("laptop", { last_seen: 8000 }), dev("desktop", { last_seen: 9000 })];
+    expect(defaultMachineId(a)).toBe(defaultMachineId(b));
+  });
 
-    // A folder that only exists on the laptop still moves the highlight.
-    const scoped = [
-      dev("laptop", { last_seen: 9000, local_project_roots: ["/repo"] }),
-      dev("desktop", { last_seen: 8000 }),
+  it("is stable against roster reordering", () => {
+    const devices = [dev("laptop"), dev("desktop"), dev("studio")];
+    expect(defaultMachineId(devices)).toBe(defaultMachineId([...devices].reverse()));
+  });
+
+  // nose is registered is_remote:false with zero roots, so it competed for
+  // /Users/... sessions it cannot cd into. Now that the default is STAMPED,
+  // defaulting to it would pin the mistake instead of letting routing correct it.
+  it("skips a local that provably can't open the path", () => {
+    const devices = [
+      dev("aaa-linux", { platform: "linux" }),
+      dev("zzz-mac", { platform: "darwin" }),
     ];
-    expect(defaultMachineId(scoped, { sticky: "desktop", projectPath: "/repo" })).toBe("laptop");
+    expect(defaultMachineId(devices, { projectPath: "/Users/j/.claude" })).toBe("zzz-mac");
+    expect(defaultMachineId(devices, { projectPath: "/home/j/src" })).toBe("aaa-linux");
   });
 
-  it("ignores a sticky machine that went offline", () => {
-    const devices = [dev("laptop"), dev("desktop", { online: false, last_seen: 9000 })];
-    expect(defaultMachineId(devices, { sticky: "desktop" })).toBe("laptop");
+  it("still picks someone when no machine can open the path", () => {
+    const devices = [dev("aaa-linux", { platform: "linux" })];
+    expect(defaultMachineId(devices, { projectPath: "/Users/j/.claude" })).toBe("aaa-linux");
+  });
+
+  it("leaves shared namespaces alone — /opt is not evidence either way", () => {
+    const devices = [dev("aaa-linux", { platform: "linux" }), dev("zzz-mac", { platform: "darwin" })];
+    expect(defaultMachineId(devices, { projectPath: "/opt/thing" })).toBe("aaa-linux");
+  });
+
+  it("never auto-selects an online remote while a local is online", () => {
+    const devices = [dev("aaa-nose", { is_remote: true, local_project_roots: ["/repo"] }), dev("zzz-laptop")];
+    expect(defaultMachineId(devices, { projectPath: "/repo" })).toBe("zzz-laptop");
   });
 
   it("uses an online remote holding the checkout when no local is online", () => {
@@ -70,7 +112,7 @@ describe("defaultMachineId", () => {
       dev("desktop", { online: false, last_seen: 1000 }),
       dev("nose", { is_remote: true }),
     ];
-    expect(defaultMachineId(devices, { projectPath: "/repo" })).toBe("laptop");
+    expect(defaultMachineId(devices, { projectPath: "/repo" })).toBe("desktop");
   });
 
   it("falls back to an online remote for a cloud-only user", () => {
@@ -105,5 +147,57 @@ describe("pathOnMyMachines", () => {
   it("is false for an empty path", () => {
     expect(pathOnMyMachines(mine, undefined)).toBe(false);
     expect(pathOnMyMachines(mine, "")).toBe(false);
+  });
+});
+
+describe("resolveMachineSelection", () => {
+  const ROSTER = [
+    dev("aaa-mac", { platform: "darwin", local_project_roots: ["/Users/j/a"] }),
+    dev("zzz-mac2", { platform: "darwin", local_project_roots: ["/Users/j/b"] }),
+  ];
+
+  it("an explicit pick wins over the computed default", () => {
+    const r = resolveMachineSelection(ROSTER, { picked: "zzz-mac2" });
+    expect(r.selectedDeviceId).toBe("zzz-mac2");
+  });
+
+  it("falls back to the default when the user hasn't touched the picker", () => {
+    expect(resolveMachineSelection(ROSTER, {}).selectedDeviceId).toBe("aaa-mac");
+  });
+
+  // BLOCKER 1. useDevices() starts empty, so the first render(s) resolve to null.
+  // The caller must not write that through — an earlier mount's stamp would be
+  // wiped and the session would quietly fall back to server-side routing.
+  it("is null (not a machine) while the roster is still loading", () => {
+    const r = resolveMachineSelection([], {});
+    expect(r.selectedDeviceId).toBeNull();
+    expect(r.stampDeviceId).toBeNull();
+  });
+
+  it("an explicit pick survives a roster that hasn't loaded", () => {
+    expect(resolveMachineSelection([], { picked: "zzz-mac2" }).stampDeviceId).toBe("zzz-mac2");
+  });
+
+  // BLOCKER 2. The unscoped recents query is a union across ALL online locals.
+  // Since the stamp wins rung 1 outright, offering that union would let a user
+  // choose a folder the stamped machine cannot open. The folder list must be
+  // scoped to exactly the machine being stamped — in every case, not just when
+  // the user moved off the default.
+  it("scopes the folder list to exactly the machine it stamps", () => {
+    for (const opts of [
+      {},
+      { picked: "zzz-mac2" },
+      { lastPicked: "zzz-mac2" },
+      { ownerDeviceId: "zzz-mac2" },
+      { projectPath: "/Users/j/b" },
+      { picked: "aaa-mac", projectPath: "/Users/j/b" },
+    ]) {
+      const r = resolveMachineSelection(ROSTER, opts);
+      expect(r.scopeProjectsToDeviceId).toBe(r.stampDeviceId);
+    }
+  });
+
+  it("scopes to nothing while the roster is loading, rather than to the union", () => {
+    expect(resolveMachineSelection([], {}).scopeProjectsToDeviceId).toBeNull();
   });
 });

--- a/packages/web/lib/machinePicker.ts
+++ b/packages/web/lib/machinePicker.ts
@@ -68,8 +68,18 @@ const preferOpenable = (list: MachineCandidate[], p?: string | null): MachineCan
  * offering it alongside a forced target let a session be stamped to a machine
  * that couldn't cd into the folder the user chose from it.
  *
- * A null result means "roster hasn't loaded" — the caller must leave any existing
- * stamp alone rather than write the null through.
+ * `existingStamp` is the LAST rung, and it exists because the roster is not
+ * reliably present: `useDevices()` is `useQuery(...) ?? []`, so it reads empty on
+ * every mount and again on any Convex reconnect. Without this rung a transient
+ * empty roster resolves to null, and null scoping silently reverts the folder
+ * list to the cross-machine union while the session's stamp survives — i.e. the
+ * UI offers a machine-B path for a session already pinned to machine A. Falling
+ * back to the decision already recorded keeps BOTH halves consistent through the
+ * gap. It only ever applies when nothing can be computed: once the roster is
+ * back, the ladder decides again, so a stale stamp can't become sticky.
+ *
+ * A null result means "no roster AND no prior decision" — the caller must leave
+ * any existing stamp alone rather than write the null through.
  */
 export function resolveMachineSelection(
   devices: MachineCandidate[],
@@ -78,9 +88,10 @@ export function resolveMachineSelection(
     ownerDeviceId?: string | null;
     projectPath?: string | null;
     lastPicked?: string | null;
+    existingStamp?: string | null;
   } = {},
 ): { selectedDeviceId: string | null; stampDeviceId: string | null; scopeProjectsToDeviceId: string | null } {
-  const selectedDeviceId = opts.picked ?? defaultMachineId(devices, opts);
+  const selectedDeviceId = opts.picked ?? defaultMachineId(devices, opts) ?? opts.existingStamp ?? null;
   return {
     selectedDeviceId,
     stampDeviceId: selectedDeviceId,

--- a/packages/web/lib/machinePicker.ts
+++ b/packages/web/lib/machinePicker.ts
@@ -1,10 +1,22 @@
 /**
- * Which machine the new-session picker opens on: the one a send would route to
- * today. Mirrors convex/deviceRouting's ladder — sticky owner → an online local
- * that HAS this checkout → the most-recently-seen online local — so the
- * highlighted chip is a prediction the daemon will agree with, and the picker
- * can stay silent (no target_device_id) until the user moves off it. Stamping
- * the default would cost the session its offline fallback.
+ * Which machine the new-session picker opens on.
+ *
+ * This used to be a PREDICTION of where routing would land, deliberately left
+ * unstamped so the server could re-decide. That made the choice non-deterministic:
+ * the last rung was "most-recently-seen online local", and two idle laptops
+ * re-heartbeat every ~30s, so the answer flipped on its own between the render
+ * that showed you a chip and the send that acted on it.
+ *
+ * Now the picker's answer IS the decision — every new session stamps
+ * `target_device_id`, which wins rung 1 of convex/deviceRouting outright. So this
+ * ladder must be STABLE rather than predictive: it never consults `last_seen`,
+ * and every rung is a fact about intent or capability.
+ *
+ *   1. The conversation's owner, if it's still online (an existing session stays put).
+ *   2. The machine you last picked by hand, if it's still online.
+ *   3. An online local that actually HAS this checkout.
+ *   4. Any online local — tie broken by device_id, which never changes.
+ *   5. An online remote holding the checkout, then any local, then any online remote.
  *
  * Kept pure, and out of the component, so the ladder is testable.
  */
@@ -15,10 +27,66 @@ export type MachineCandidate = {
   online: boolean;
   last_seen: number;
   local_project_roots?: string[];
+  platform?: string;
 };
 
-const mostRecent = (list: MachineCandidate[]): string | null =>
-  [...list].sort((a, b) => b.last_seen - a.last_seen)[0]?.device_id ?? null;
+/**
+ * Deterministic tiebreak. device_id is a stable machine fingerprint, so the same
+ * candidate set always yields the same answer — the property `last_seen` lacked.
+ */
+const stable = (list: MachineCandidate[]): string | null =>
+  [...list].sort((a, b) => a.device_id.localeCompare(b.device_id))[0]?.device_id ?? null;
+
+/**
+ * Mirrors convex/deviceRouting's platformCanOpenPath — false only where the path
+ * lives in a namespace the platform provably lacks. The picker's answer is
+ * STAMPED now, so defaulting to a machine that can't cd into the folder would
+ * pin the mistake rather than let the server correct it.
+ */
+const canOpen = (d: MachineCandidate, p?: string | null): boolean => {
+  if (!p || !d.platform) return true;
+  if (d.platform === "win32") return !p.startsWith("/");
+  if (!p.startsWith("/")) return true;
+  if (d.platform === "darwin") return !p.startsWith("/home/") && !p.startsWith("/root/");
+  if (d.platform === "linux") return !p.startsWith("/Users/");
+  return true;
+};
+
+/** Openable candidates if any, else the whole pool — never return nothing. */
+const preferOpenable = (list: MachineCandidate[], p?: string | null): MachineCandidate[] => {
+  const openable = list.filter((d) => canOpen(d, p));
+  return openable.length > 0 ? openable : list;
+};
+
+/**
+ * The three decisions the new-session machine row makes, resolved together
+ * because they have to agree.
+ *
+ * `stampDeviceId === scopeProjectsToDeviceId` is the invariant: the pick now wins
+ * rung 1 of deviceRouting outright, so the folder list MUST be that machine's
+ * checkouts. The unscoped recents query is a union across every online local, and
+ * offering it alongside a forced target let a session be stamped to a machine
+ * that couldn't cd into the folder the user chose from it.
+ *
+ * A null result means "roster hasn't loaded" — the caller must leave any existing
+ * stamp alone rather than write the null through.
+ */
+export function resolveMachineSelection(
+  devices: MachineCandidate[],
+  opts: {
+    picked?: string | null;
+    ownerDeviceId?: string | null;
+    projectPath?: string | null;
+    lastPicked?: string | null;
+  } = {},
+): { selectedDeviceId: string | null; stampDeviceId: string | null; scopeProjectsToDeviceId: string | null } {
+  const selectedDeviceId = opts.picked ?? defaultMachineId(devices, opts);
+  return {
+    selectedDeviceId,
+    stampDeviceId: selectedDeviceId,
+    scopeProjectsToDeviceId: selectedDeviceId,
+  };
+}
 
 /**
  * Prefix semantics, mirroring the server's pathUnderRoot: a session in a repo
@@ -54,39 +122,47 @@ export function defaultMachineId(
     ownerDeviceId?: string | null;
     projectPath?: string | null;
     /**
-     * The answer we gave last time. Online machines re-heartbeat every ~30s, so
-     * "most-recently-seen" flips between two idle laptops on its own; without
-     * this the highlight would hop between chips under the user's cursor. It
-     * only breaks ties WITHIN the current candidate set, so a folder change that
-     * genuinely moves the route still moves the highlight.
+     * The machine the user last chose by hand, persisted across sessions. Intent
+     * beats every heuristic below it: if you work on your laptop, the picker opens
+     * on your laptop, and it stays there until you say otherwise.
      */
-    sticky?: string | null;
+    lastPicked?: string | null;
   } = {},
 ): string | null {
-  const { ownerDeviceId, projectPath, sticky } = opts;
-  // A stale owner id (device removed) isn't selectable — fall through to where
-  // routing would actually land rather than highlighting a chip that isn't there.
+  const { ownerDeviceId, projectPath, lastPicked } = opts;
+
+  // 1. An existing conversation stays on the machine that owns it. This OUTRANKS
+  //    your standing choice on purpose: the pick is now stamped, so defaulting an
+  //    already-owned session to a different machine would silently move it just by
+  //    opening it. A standing preference is about where NEW work starts.
   const owner = ownerDeviceId ? devices.find((d) => d.device_id === ownerDeviceId) : undefined;
   if (owner?.online) return owner.device_id;
+
+  // 2. Your standing choice. A stale id (machine removed or asleep) isn't
+  //    selectable, so fall through rather than highlight a chip that can't serve.
+  const picked = lastPicked ? devices.find((d) => d.device_id === lastPicked) : undefined;
+  if (picked?.online) return picked.device_id;
 
   const hasCheckout = (d: MachineCandidate) => !!projectPath && deviceSeesPath(d, projectPath);
 
   const onlineLocals = devices.filter((d) => !d.is_remote && d.online);
   if (onlineLocals.length > 0) {
+    // 3/4. The machine that has the folder, else any online local that could
+    //      plausibly open it.
     const withCheckout = onlineLocals.filter(hasCheckout);
-    const pool = withCheckout.length > 0 ? withCheckout : onlineLocals;
-    if (sticky && pool.some((d) => d.device_id === sticky)) return sticky;
-    return mostRecent(pool);
+    return stable(withCheckout.length > 0 ? withCheckout : preferOpenable(onlineLocals, projectPath));
   }
 
-  // No local is online. An online remote holding the checkout serves it now…
+  // 5. No local is online. An online remote holding the checkout serves it now…
   const remoteWithCheckout = devices.filter((d) => d.is_remote && d.online && hasCheckout(d));
-  if (remoteWithCheckout.length > 0) return mostRecent(remoteWithCheckout);
+  if (remoteWithCheckout.length > 0) return stable(remoteWithCheckout);
 
   // …otherwise the work queues for a local machine to pick up when it wakes.
   const locals = devices.filter((d) => !d.is_remote);
-  if (locals.length > 0) return owner && !owner.is_remote ? owner.device_id : mostRecent(locals);
+  if (locals.length > 0) {
+    return owner && !owner.is_remote ? owner.device_id : stable(preferOpenable(locals, projectPath));
+  }
 
   // Cloud-only user: an online remote is the only machine that can serve.
-  return mostRecent(devices.filter((d) => d.is_remote && d.online));
+  return stable(devices.filter((d) => d.is_remote && d.online));
 }

--- a/packages/web/src/providers.tsx
+++ b/packages/web/src/providers.tsx
@@ -3,6 +3,7 @@ import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import { ReactNode, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { useInboxStore } from "../store/inboxStore";
+import { subscribeGestures } from "../store/gestureBridge";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { NavigationProgress } from "@/components/NavigationProgress";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -12,6 +13,7 @@ import { OpenInDesktopHandoff } from "@/components/OpenInDesktopHandoff";
 import { ShortcutProvider } from "@/shortcuts";
 import { TipProvider } from "@/tips/TipProvider";
 import { useLocalStorageMigration } from "@/hooks/useLocalStorageMigration";
+import { useMountEffect } from "@/hooks/useMountEffect";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { identifyUser, resetUser } from "@/lib/analytics";
 import { durableAuthStorage } from "@/lib/durableAuthStorage";
@@ -20,6 +22,36 @@ import { PrincipalLocalStateProvider } from "@/components/PrincipalLocalStatePro
 
 function PrefsMigration() {
   useLocalStorageMigration();
+  return null;
+}
+
+// Cross-window gesture bridge receiver. Mounted here (not in DashboardLayout)
+// because EVERY same-origin window shares the one IndexedDB principal store and
+// can therefore clobber a sibling's gesture with a stale whole-row put — the
+// compose palette has its own store and no dashboard shell. Rebinding on the
+// signed-in user keeps two accounts on separate channels; the effect's cleanup
+// closes the old channel, so a switched-away account stops listening.
+function GestureBridge() {
+  useMountEffect(() => {
+    const currentUserId = () => useInboxStore.getState().currentUser?._id?.toString?.() ?? null;
+    const bind = () =>
+      subscribeGestures(currentUserId(), currentUserId, (msg) =>
+        useInboxStore.getState().applyGestureBridge(msg),
+      );
+    let boundTo = currentUserId();
+    let stop = bind();
+    const unsubscribe = useInboxStore.subscribe(() => {
+      const next = currentUserId();
+      if (next === boundTo) return;
+      boundTo = next;
+      stop();
+      stop = bind();
+    });
+    return () => {
+      unsubscribe();
+      stop();
+    };
+  });
   return null;
 }
 
@@ -103,6 +135,7 @@ export function Providers({ children }: { children: ReactNode }) {
           <OpenInDesktopHandoff />
         </ErrorBoundary>
         <PrefsMigration />
+        <GestureBridge />
         <AnalyticsIdentify />
         <DispatchFailureToast />
         <Toaster position="bottom-right" />

--- a/packages/web/store/__tests__/gestureBridge.test.ts
+++ b/packages/web/store/__tests__/gestureBridge.test.ts
@@ -1,0 +1,806 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { useInboxStore, type InboxSession } from "../inboxStore";
+import {
+  broadcastGesture,
+  gestureSourceToken,
+  setGestureChannelFactory,
+  subscribeGestures,
+  type GestureMessage,
+} from "../gestureBridge";
+import { declareViewNav } from "../viewNav";
+import { undoableHideSession, undoablePinSession } from "../undoActions";
+import { performUndo } from "../undoStack";
+
+// The desktop app's windows share ONE IndexedDB principal store and persist
+// rows with whole-row puts diffed against per-window memory, so a window that
+// never learned about a sibling's dismiss/kill/pin writes the pre-gesture row
+// back over it — killed sessions resurrect, pinned stubs become immortal. The
+// bridge converges sibling MEMORY so their later puts carry the gesture.
+
+const REAL_A = "a".repeat(32);
+const REAL_B = "b".repeat(32);
+const STUB = "stub-local-1";
+
+// Seeds that place the user ON a conversation must declare a view-nav source —
+// undeclared non-null view writes are reverted by the guard (viewNav.ts).
+function seed(partial: Record<string, unknown>) {
+  declareViewNav("gesture");
+  useInboxStore.setState({
+    sessions: {},
+    conversations: {},
+    messages: {},
+    pendingMessages: {},
+    pagination: {},
+    pendingSessionCreates: {},
+    pending: {},
+    currentSessionId: null,
+    viewingDismissedId: null,
+    currentUser: null,
+    clientState: {},
+    ...partial,
+  } as any);
+}
+
+function session(id: string, extra: Partial<InboxSession> = {}): InboxSession {
+  return {
+    _id: id,
+    session_id: `sess-${id}`,
+    updated_at: Date.now(),
+    agent_type: "claude_code",
+    message_count: 1,
+    is_idle: true,
+    has_pending: false,
+    ...extra,
+  } as InboxSession;
+}
+
+// ---------------------------------------------------------------------------
+// A fake BroadcastChannel hub: channels with the same name see each other's
+// posts, exactly like the real one (and, like the real one, a sender never
+// receives its own post — self-filtering is the source token's job across
+// WINDOWS, which share no channel object).
+// ---------------------------------------------------------------------------
+type Posted = { name: string; data: any };
+
+function makeHub() {
+  const posted: Posted[] = [];
+  const listeners = new Map<string, Set<(e: MessageEvent) => void>>();
+  const factory = (name: string) => {
+    const own = new Set<(e: MessageEvent) => void>();
+    const chan = {
+      postMessage(data: any) {
+        posted.push({ name, data: structuredClone(data) });
+        for (const [n, set] of listeners) {
+          if (n !== name) continue;
+          for (const fn of set) {
+            if (own.has(fn)) continue;
+            fn({ data: structuredClone(data) } as MessageEvent);
+          }
+        }
+      },
+      addEventListener(_type: string, fn: (e: MessageEvent) => void) {
+        own.add(fn);
+        if (!listeners.has(name)) listeners.set(name, new Set());
+        listeners.get(name)!.add(fn);
+      },
+      removeEventListener(_type: string, fn: (e: MessageEvent) => void) {
+        own.delete(fn);
+        listeners.get(name)?.delete(fn);
+      },
+      close() {},
+    };
+    return chan as unknown as BroadcastChannel;
+  };
+  return { posted, factory };
+}
+
+let hub: ReturnType<typeof makeHub>;
+
+beforeEach(() => {
+  hub = makeHub();
+  setGestureChannelFactory(hub.factory);
+});
+
+afterEach(() => {
+  setGestureChannelFactory(null);
+  // Middleware-injected bindings aren't declared on InboxStoreState (same
+  // reason outboxRetention.test.ts reaches for them off the wrapped store).
+  const store = useInboxStore.getState() as any;
+  store._setOutbox(null, null, null);
+  store._setDispatch(null);
+});
+
+describe("gesture bridge senders", () => {
+  it("killSession broadcasts exactly one hide with the resolved cascade set", () => {
+    const child = REAL_B;
+    seed({
+      sessions: {
+        [REAL_A]: session(REAL_A),
+        [child]: session(child, { parent_conversation_id: REAL_A } as any),
+      },
+      conversations: { [REAL_A]: { _id: REAL_A }, [child]: { _id: child } },
+    });
+
+    useInboxStore.getState().killSession(REAL_A);
+
+    expect(hub.posted).toHaveLength(1);
+    const msg = hub.posted[0].data;
+    expect(msg.kind).toBe("hide");
+    expect(msg.mode).toBe("kill");
+    expect(new Set(msg.ids)).toEqual(new Set([REAL_A, child]));
+    expect(msg.forget).toBeUndefined();
+    expect(typeof msg.ts).toBe("number");
+    expect(msg.source).toBe(gestureSourceToken());
+  });
+
+  it("stashSession broadcasts mode:stash", () => {
+    seed({ sessions: { [REAL_A]: session(REAL_A) }, conversations: { [REAL_A]: { _id: REAL_A } } });
+    useInboxStore.getState().stashSession(REAL_A);
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data.mode).toBe("stash");
+  });
+
+  it("a stub in the cascade rides the SAME message as a forget list", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A), [STUB]: session(STUB, { parent_conversation_id: REAL_A } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A }, [STUB]: { _id: STUB } },
+    });
+
+    useInboxStore.getState().killSession(REAL_A);
+
+    // One user gesture => one message, even though it both flags and deletes.
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data.ids).toEqual([REAL_A]);
+    expect(hub.posted[0].data.forget).toEqual([STUB]);
+  });
+
+  it("killSessions (bulk) broadcasts once for the whole gesture", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A), [REAL_B]: session(REAL_B) },
+      conversations: { [REAL_A]: { _id: REAL_A }, [REAL_B]: { _id: REAL_B } },
+    });
+    useInboxStore.getState().killSessions([REAL_A, REAL_B]);
+    expect(hub.posted).toHaveLength(1);
+    expect(new Set(hub.posted[0].data.ids)).toEqual(new Set([REAL_A, REAL_B]));
+  });
+
+  it("killSessions stamps every row with the ONE timestamp its message carries", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A), [REAL_B]: session(REAL_B) },
+      conversations: { [REAL_A]: { _id: REAL_A }, [REAL_B]: { _id: REAL_B } },
+    });
+
+    // Wall-clock drifts across a big sweep. With a per-row Date.now(), the merged
+    // message's timestamp matched only the LAST row, so the receiver planted a
+    // lock holding a value the server would never echo for every earlier row —
+    // and a lock that never matches an echo never retires.
+    const realNow = Date.now;
+    let t = 1_800_000_000_000;
+    Date.now = () => (t += 1000);
+    try {
+      useInboxStore.getState().killSessions([REAL_A, REAL_B]);
+    } finally {
+      Date.now = realNow;
+    }
+
+    const s = useInboxStore.getState();
+    const ts = hub.posted[0].data.ts;
+    expect(s.sessions[REAL_A].inbox_dismissed_at).toBe(ts);
+    expect(s.sessions[REAL_B].inbox_dismissed_at).toBe(ts);
+    expect((s.conversations[REAL_B] as any).inbox_dismissed_at).toBe(ts);
+  });
+
+  it("restoreSession broadcasts restore for the session and its hidden children", () => {
+    seed({
+      sessions: {
+        [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100 } as any),
+        [REAL_B]: session(REAL_B, { parent_conversation_id: REAL_A, inbox_dismissed_at: 100 } as any),
+      },
+      conversations: { [REAL_A]: { _id: REAL_A }, [REAL_B]: { _id: REAL_B } },
+    });
+
+    useInboxStore.getState().restoreSession(REAL_A);
+
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data.kind).toBe("restore");
+    expect(new Set(hub.posted[0].data.ids)).toEqual(new Set([REAL_A, REAL_B]));
+  });
+
+  it("pinSession broadcasts the RESOLVED pin value, not the toggle", () => {
+    seed({ sessions: { [REAL_A]: session(REAL_A) }, conversations: { [REAL_A]: { _id: REAL_A } } });
+
+    useInboxStore.getState().pinSession(REAL_A);
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data).toMatchObject({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: hub.posted[0].data.ts });
+
+    useInboxStore.getState().pinSession(REAL_A);
+    expect(hub.posted).toHaveLength(2);
+    expect(hub.posted[1].data).toMatchObject({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null });
+  });
+
+  it("pruneGhostSessions announces only the ids it actually removed", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A), [REAL_B]: session(REAL_B) },
+      conversations: { [REAL_A]: { _id: REAL_A }, [REAL_B]: { _id: REAL_B } },
+      currentSessionId: REAL_B, // guarded: never pruned
+    });
+
+    useInboxStore.getState().pruneGhostSessions([REAL_A, REAL_B]);
+
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data).toMatchObject({ kind: "forget", ids: [REAL_A] });
+  });
+
+  it("markKilling forgets ONLY the inbox row (the conversation is still live)", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    useInboxStore.getState().markKilling(REAL_A);
+
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data).toMatchObject({
+      kind: "forget", ids: [REAL_A], scope: "session-row",
+    });
+    // The sender kept the conversation cached — the message must not tell
+    // siblings to drop it.
+    expect(useInboxStore.getState().conversations[REAL_A]).toBeDefined();
+  });
+
+  it("markSessionsDismissed broadcasts one hide for the whole sweep", () => {
+    seed({
+      sessions: {
+        [REAL_A]: session(REAL_A),
+        [REAL_B]: session(REAL_B),
+      },
+      conversations: { [REAL_A]: { _id: REAL_A }, [REAL_B]: { _id: REAL_B } },
+    });
+
+    useInboxStore.getState().markSessionsDismissed([REAL_A, REAL_B]);
+
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data).toMatchObject({ kind: "hide", mode: "kill" });
+    expect(hub.posted[0].data.ids).toEqual([REAL_A, REAL_B]);
+  });
+
+  it("markSessionsDismissed's message excludes already-dismissed ids", () => {
+    seed({
+      sessions: {
+        [REAL_A]: session(REAL_A, { inbox_dismissed_at: 111 } as any),
+        [REAL_B]: session(REAL_B),
+      },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 111 }, [REAL_B]: { _id: REAL_B } },
+    });
+
+    useInboxStore.getState().markSessionsDismissed([REAL_A, REAL_B]);
+
+    // Only REAL_B was actually stamped, so only it is announced — and REAL_A
+    // keeps its original stamp rather than being re-dated.
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data.ids).toEqual([REAL_B]);
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(111);
+  });
+
+  it("a sweep that stamps nothing broadcasts nothing", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 111 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 111 } },
+    });
+    useInboxStore.getState().markSessionsDismissed([REAL_A]);
+    expect(hub.posted).toHaveLength(0);
+  });
+
+  it("a prune of an id this window doesn't hold does nothing at all", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    // Callers re-fire on ids they already pruned (ConversationView's 3s retry,
+    // ComposeView's unmount).
+    useInboxStore.getState().pruneGhostSessions([REAL_B]);
+
+    const s = useInboxStore.getState();
+    // No broadcast: this window has no evidence to order a sibling's delete on.
+    expect(hub.posted).toHaveLength(0);
+    // And no excludes — they're STICKY, so planting them for a row we never held
+    // blinds this window to that id if it ever arrives on a later crawl.
+    expect(s.pending[`sessions:${REAL_B}`]).toBeUndefined();
+    expect(s.pending[`conversations:${REAL_B}`]).toBeUndefined();
+    expect(s.sessions[REAL_A]).toBeDefined();
+  });
+
+  it("patchConversation announces the bridged fields the /sessions toggles write", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    // handleToggleDismiss's stash leg (app/sessions/page.tsx).
+    useInboxStore.getState().patchConversation(REAL_A, { inbox_stashed_at: 4242 });
+
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data).toMatchObject({
+      kind: "fields", id: REAL_A, fields: { inbox_stashed_at: 4242 },
+    });
+  });
+
+  it("patchConversation stays silent for fields the bridge doesn't carry", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+    useInboxStore.getState().patchConversation(REAL_A, { title: "renamed", project_path: "/tmp" });
+    expect(hub.posted).toHaveLength(0);
+  });
+
+  it("undoing a pin broadcasts the reverted value, not silence", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    undoablePinSession(REAL_A);
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data).toMatchObject({ kind: "pin", pinned: true });
+
+    // Undo must retract it: an un-announced undo leaves the sibling holding the
+    // pinned row, which both re-puts the undone pin and inverts its next toggle.
+    expect(performUndo()).toBe(true);
+
+    expect(hub.posted).toHaveLength(2);
+    expect(hub.posted[1].data).toMatchObject({
+      kind: "pin", id: REAL_A, pinned: false, pinnedAt: null,
+    });
+  });
+
+  it("undoing a hide broadcasts the snapshot flags per id, under one timestamp", () => {
+    // The child was STASHED when the parent was killed, so its undo is not a
+    // blanket un-hide: it has to land back in Stashed. That's why the undo rides
+    // a per-id "fields" message carrying the snapshot verbatim, not a "restore".
+    seed({
+      sessions: {
+        [REAL_A]: session(REAL_A),
+        [REAL_B]: session(REAL_B, { parent_conversation_id: REAL_A, inbox_stashed_at: 111 } as any),
+      },
+      conversations: { [REAL_A]: { _id: REAL_A }, [REAL_B]: { _id: REAL_B, inbox_stashed_at: 111 } },
+    });
+
+    undoableHideSession(REAL_A, "kill");
+    expect(hub.posted).toHaveLength(1);
+    expect(hub.posted[0].data.kind).toBe("hide");
+
+    // An un-announced undo leaves the sibling holding the KILLED row, and its
+    // next whole-row put writes the undone kill back into shared IDB.
+    expect(performUndo()).toBe(true);
+
+    const undo = hub.posted.slice(1).map((p) => p.data);
+    expect(undo).toHaveLength(2);
+    // One gesture, one timestamp — the sibling's locks for both rows key off it.
+    expect(new Set(undo.map((m) => m.ts)).size).toBe(1);
+    const byId = Object.fromEntries(undo.map((m) => [m.id, m]));
+    expect(byId[REAL_A]).toMatchObject({
+      kind: "fields", fields: { inbox_dismissed_at: null, inbox_stashed_at: null },
+    });
+    // Verbatim: the values applyUndoPatches dispatches, so the receiver's lock
+    // retires on the matching server echo.
+    expect(byId[REAL_B]).toMatchObject({
+      kind: "fields", fields: { inbox_dismissed_at: null, inbox_stashed_at: 111 },
+    });
+  });
+
+  it("the channel name is scoped to the acting user", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A, is_own: true } },
+      currentUser: { _id: "user-1" },
+    });
+    useInboxStore.getState().killSession(REAL_A);
+    expect(hub.posted[0].name).toBe("codecast-gesture:user-1");
+    expect(hub.posted[0].data.userId).toBe("user-1");
+  });
+});
+
+describe("gesture bridge receiver", () => {
+  it("hide sets the field on both the session and conversation rows", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].inbox_dismissed_at).toBe(500);
+    expect((s.conversations[REAL_A] as any).inbox_dismissed_at).toBe(500);
+  });
+
+  it("kill clears an existing stash and pin (the buckets are exclusive)", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_stashed_at: 100, is_pinned: true, inbox_pinned_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_stashed_at: 100, inbox_pinned_at: 100 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].inbox_dismissed_at).toBe(500);
+    expect(s.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(s.sessions[REAL_A].is_pinned).toBe(false);
+    expect(s.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect((s.conversations[REAL_A] as any).inbox_pinned_at).toBeNull();
+  });
+
+  it("restore clears both hide flags", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100, inbox_stashed_at: 90 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 100, inbox_stashed_at: 90 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 500 });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(s.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect((s.conversations[REAL_A] as any).inbox_dismissed_at).toBeNull();
+  });
+
+  it("pin sets both twins; unpin clears them", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 500, ts: 500 });
+    let s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].is_pinned).toBe(true);
+    expect(s.sessions[REAL_A].inbox_pinned_at).toBe(500);
+    expect((s.conversations[REAL_A] as any).inbox_pinned_at).toBe(500);
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 600 });
+    s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].is_pinned).toBe(false);
+    expect(s.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect((s.conversations[REAL_A] as any).inbox_pinned_at).toBeNull();
+  });
+
+  it("forget removes every trace of the row and plants the excludes", () => {
+    seed({
+      sessions: { [STUB]: session(STUB) },
+      conversations: { [STUB]: { _id: STUB } },
+      messages: { [STUB]: [{ _id: "m1" }] },
+      pagination: { [STUB]: { cursor: "x" } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "forget", ids: [STUB], ts: 500 });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[STUB]).toBeUndefined();
+    expect(s.conversations[STUB]).toBeUndefined();
+    expect(s.messages[STUB]).toBeUndefined();
+    expect(s.pagination[STUB]).toBeUndefined();
+    // The exclude is what authorizes the durable IDB row delete — a bare
+    // store-shrink is ignored by the collection diff.
+    expect(s.pending[`sessions:${STUB}`]).toMatchObject({ type: "exclude" });
+    expect(s.pending[`conversations:${STUB}`]).toMatchObject({ type: "exclude" });
+  });
+
+  it("scope:session-row drops the inbox row but spares the cached conversation", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+      messages: { [REAL_A]: [{ _id: "m1" }] },
+    });
+
+    useInboxStore.getState().applyGestureBridge({
+      kind: "forget", ids: [REAL_A], scope: "session-row", ts: 500,
+    });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A]).toBeUndefined();
+    expect(s.pending[`sessions:${REAL_A}`]).toMatchObject({ type: "exclude" });
+    // The conversation still exists server-side (killed, marked completed) —
+    // an exclude here would blind this window to it forever.
+    expect(s.conversations[REAL_A]).toBeDefined();
+    expect(s.messages[REAL_A]).toBeDefined();
+    expect(s.pending[`conversations:${REAL_A}`]).toBeUndefined();
+  });
+
+  it("a hide carrying a forget list applies both halves", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A), [STUB]: session(STUB) },
+      conversations: { [REAL_A]: { _id: REAL_A }, [STUB]: { _id: STUB } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({
+      kind: "hide", mode: "kill", ids: [REAL_A], forget: [STUB], ts: 500,
+    });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].inbox_dismissed_at).toBe(500);
+    expect(s.sessions[STUB]).toBeUndefined();
+  });
+
+  it("forget spares the row this window's user is currently reading", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+      currentSessionId: REAL_A,
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "forget", ids: [REAL_A], ts: 500 });
+
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A]).toBeDefined();
+    expect(s.currentSessionId).toBe(REAL_A);
+    expect(s.pending[`sessions:${REAL_A}`]).toBeUndefined();
+  });
+
+  it("forget spares a row holding unsent user text in THIS window", () => {
+    seed({
+      sessions: { [STUB]: session(STUB) },
+      conversations: { [STUB]: { _id: STUB } },
+      pendingMessages: { [STUB]: [{ content: "half-typed thought" }] },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "forget", ids: [STUB], ts: 500 });
+
+    const s = useInboxStore.getState();
+    // A queued message means this window knows something the sender did not.
+    expect(s.pendingMessages[STUB]).toHaveLength(1);
+    expect(s.sessions[STUB]).toBeDefined();
+  });
+
+  it("forget spares a session whose create is still in flight here", () => {
+    seed({
+      sessions: { [STUB]: session(STUB) },
+      conversations: { [STUB]: { _id: STUB } },
+      pendingSessionCreates: { [STUB]: { ts: 1 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "forget", ids: [STUB], ts: 500 });
+
+    expect(useInboxStore.getState().sessions[STUB]).toBeDefined();
+  });
+
+  it("ignores ids this window has never heard of", () => {
+    seed({ sessions: {}, conversations: {} });
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+    expect(useInboxStore.getState().sessions[REAL_A]).toBeUndefined();
+  });
+
+  it("never touches the view: a sibling's kill does not move this window", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+      currentSessionId: REAL_A,
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    expect(useInboxStore.getState().currentSessionId).toBe(REAL_A);
+  });
+});
+
+describe("gesture bridge ordering guards", () => {
+  it("an older hide does not regress a newer local hide", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 900 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(900);
+  });
+
+  it("an older restore does not un-hide a newer local kill", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 900 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 500 });
+
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(900);
+  });
+
+  it("an older unpin does not undo a newer local pin", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 900 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 500 });
+
+    expect(useInboxStore.getState().sessions[REAL_A].is_pinned).toBe(true);
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_pinned_at).toBe(900);
+  });
+
+  it("an older kill does not clear a newer local pin", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 900 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    expect(useInboxStore.getState().sessions[REAL_A].is_pinned).toBe(true);
+  });
+
+  it("a repeated hide is idempotent (same ts re-applied)", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+    const msg: GestureMessage = { kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 };
+    useInboxStore.getState().applyGestureBridge(msg);
+    useInboxStore.getState().applyGestureBridge(msg);
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(500);
+  });
+});
+
+describe("gesture bridge delivery filters", () => {
+  it("drops a window's own broadcast (source token)", () => {
+    const seen: GestureMessage[] = [];
+    const stop = subscribeGestures("user-1", () => "user-1", (m) => seen.push(m));
+    // Same process, same source token — as if the window heard itself.
+    broadcastGesture({ kind: "restore", ids: [REAL_A], ts: 1 }, "user-1");
+    stop();
+    expect(seen).toHaveLength(0);
+  });
+
+  it("drops a message stamped with a different user", () => {
+    const seen: GestureMessage[] = [];
+    // Subscribe on the "user-2" channel but with our account since switched.
+    const stop = subscribeGestures("user-2", () => "user-1", (m) => seen.push(m));
+    // A foreign sender: same channel, different source token and user id.
+    hub.factory("codecast-gesture:user-2").postMessage({
+      v: 1, source: "other-window", userId: "user-2",
+      kind: "restore", ids: [REAL_A], ts: 1,
+    });
+    stop();
+    expect(seen).toHaveLength(0);
+  });
+
+  it("delivers a sibling's message on the matching channel and user", () => {
+    const seen: GestureMessage[] = [];
+    const stop = subscribeGestures("user-1", () => "user-1", (m) => seen.push(m));
+    hub.factory("codecast-gesture:user-1").postMessage({
+      v: 1, source: "other-window", userId: "user-1",
+      kind: "hide", mode: "kill", ids: [REAL_A], ts: 7,
+    });
+    stop();
+    expect(seen).toEqual([{ kind: "hide", mode: "kill", ids: [REAL_A], ts: 7 }]);
+  });
+
+  it("ignores malformed and wrong-version payloads", () => {
+    const seen: GestureMessage[] = [];
+    const stop = subscribeGestures("user-1", () => "user-1", (m) => seen.push(m));
+    const ch = hub.factory("codecast-gesture:user-1");
+    ch.postMessage({ v: 2, source: "o", userId: "user-1", kind: "restore", ids: [], ts: 1 });
+    ch.postMessage({ v: 1, source: "o", userId: "user-1", kind: "nope", ts: 1 });
+    ch.postMessage({ v: 1, source: "o", userId: "user-1", kind: "pin", id: REAL_A, ts: 1 });
+    ch.postMessage("garbage");
+    stop();
+    expect(seen).toHaveLength(0);
+  });
+
+  it("a stopped subscription receives nothing", () => {
+    const seen: GestureMessage[] = [];
+    subscribeGestures("user-1", () => "user-1", (m) => seen.push(m))();
+    hub.factory("codecast-gesture:user-1").postMessage({
+      v: 1, source: "other-window", userId: "user-1", kind: "restore", ids: [REAL_A], ts: 1,
+    });
+    expect(seen).toHaveLength(0);
+  });
+});
+
+describe("gesture bridge receiver is local-only", () => {
+  // sync() actions never dispatch and never enqueue an outbox entry — that is
+  // the whole reason the receiver is a sync(): the ACTING window already owns
+  // the single server write, and a receiver that re-dispatched would multiply
+  // one gesture by the number of open windows.
+  it("creates no outbox entry and no dispatch", () => {
+    const enqueued: any[] = [];
+    const dispatched: string[] = [];
+    seed({
+      sessions: { [REAL_A]: session(REAL_A), [STUB]: session(STUB) },
+      conversations: { [REAL_A]: { _id: REAL_A }, [STUB]: { _id: STUB } },
+    });
+    const store = useInboxStore.getState() as any;
+    store._setOutbox((e: any) => { enqueued.push(e); }, () => {}, async () => []);
+    store._setDispatch((action: string) => { dispatched.push(action); return Promise.resolve(); });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], forget: [STUB], ts: 500 });
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 600 });
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 700, ts: 700 });
+
+    expect(enqueued).toEqual([]);
+    expect(dispatched).toEqual([]);
+  });
+
+  it("does not re-broadcast what it just applied (no echo storm)", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+    expect(hub.posted).toHaveLength(0);
+  });
+
+  // NOTE: an earlier version of this test asserted `pending` stayed EMPTY after
+  // a bridged hide. That assertion encoded the bug below — the field lock is
+  // what keeps the bridged value alive against this window's own sync channels,
+  // and {type:"field"} entries are consumed only by the local sync appliers, so
+  // planting them does not reach the server.
+  it("plants the same pending field locks the sender's action() gets", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    const p = useInboxStore.getState().pending;
+    expect(p[`sessions:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: 500, ts: 500 });
+    expect(p[`conversations:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: 500, ts: 500 });
+  });
+
+  // THE regression test for the field-lock defect. A sessions crawl already in
+  // flight in the receiving window (a wake reconcile pages for seconds) lands a
+  // snapshot taken BEFORE the gesture. Without the planted lock, applySyncTable
+  // replaces the row wholesale, the bridged hide silently vanishes here, and
+  // this window's next whole-row put writes the un-hidden row over the acting
+  // window's in the shared principal IDB store.
+  it("a stale server row mid-crawl does NOT revert the bridged hide", () => {
+    const serverRow = session(REAL_A); // pre-gesture: no inbox_dismissed_at
+    seed({ sessions: {}, conversations: {} });
+    useInboxStore.getState().syncTable("sessions", [serverRow]);
+    expect(useInboxStore.getState().sessions[REAL_A]).toBeDefined();
+
+    // The user kills REAL_A in the OTHER window mid-crawl.
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(500);
+
+    // The in-flight crawl now delivers its pre-kill snapshot.
+    useInboxStore.getState().syncTable("sessions", [serverRow]);
+
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(500);
+  });
+
+  it("the lock retires once the server echoes the gesture back", () => {
+    seed({ sessions: {}, conversations: {} });
+    useInboxStore.getState().syncTable("sessions", [session(REAL_A)]);
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    // The acting window's server write lands; the crawl now carries the hide.
+    useInboxStore.getState().syncTable("sessions", [session(REAL_A, { inbox_dismissed_at: 500 } as any)]);
+
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(500);
+    // Self-clearing: the lock exists to bridge the gap until the echo, and
+    // applyFieldOverrides drops it once the server agrees. A lock that never
+    // retired would pin the row against every later server change.
+    expect(useInboxStore.getState().pending[`sessions:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+  });
+
+  it("locks the cleared fields on restore, and the pin fields on pin", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 100 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 500 });
+    expect(useInboxStore.getState().pending[`sessions:${REAL_A}:inbox_dismissed_at`])
+      .toEqual({ type: "field", value: null, ts: 500 });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 600, ts: 600 });
+    const p = useInboxStore.getState().pending;
+    expect(p[`sessions:${REAL_A}:is_pinned`]).toEqual({ type: "field", value: true, ts: 600 });
+    // The locked value must equal what the SENDER dispatched — the lock retires
+    // only when the server echo matches it, so a re-derived timestamp would
+    // stick forever.
+    expect(p[`sessions:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: 600, ts: 600 });
+  });
+});

--- a/packages/web/store/__tests__/gestureBridge.test.ts
+++ b/packages/web/store/__tests__/gestureBridge.test.ts
@@ -606,6 +606,425 @@ describe("gesture bridge ordering guards", () => {
     expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBe(900);
   });
 
+  it("a delayed older hide cannot overwrite a newer restore lock", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 100 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    expect(useInboxStore.getState().sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(useInboxStore.getState().conversations[REAL_A].inbox_dismissed_at).toBeNull();
+  });
+
+  it("a no-op restore plants twin tombstones that reject a delayed kill", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: null, inbox_stashed_at: null } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: null, inbox_stashed_at: null } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 900 });
+    const locks = useInboxStore.getState().pending;
+    expect(locks[`sessions:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: null, ts: 900 });
+    expect(locks[`conversations:${REAL_A}:inbox_stashed_at`]).toEqual({ type: "field", value: null, ts: 900 });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeNull();
+  });
+
+  it("a delayed kill cannot split a newer stash across the session and conversation twins", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "stash", ids: [REAL_A], ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeUndefined();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBe(900);
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBeUndefined();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBe(900);
+  });
+
+  it("stash clears the sender's pin state on both twins", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 100 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "stash", ids: [REAL_A], ts: 900 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBe(900);
+    expect(state.sessions[REAL_A].is_pinned).toBe(false);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBe(900);
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+  });
+
+  it("does not let an older stash clear a newer pin", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 900 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "stash", ids: [REAL_A], ts: 500 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeUndefined();
+    expect(state.sessions[REAL_A].is_pinned).toBe(true);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBe(900);
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeUndefined();
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBe(900);
+  });
+
+  it("does not let a delayed pin undo a newer stash", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 100 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "stash", ids: [REAL_A], ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 500, ts: 500 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBe(900);
+    expect(state.sessions[REAL_A].is_pinned).toBe(false);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBe(900);
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+  });
+
+  it("keeps divergent twins unchanged for an older hide, then applies a newer hide to both", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_stashed_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_stashed_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+    let state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeUndefined();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBe(100);
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBeUndefined();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBe(900);
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 1_000 });
+    state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBe(1_000);
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBe(1_000);
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeNull();
+  });
+
+  it("keeps divergent twins unchanged for an older restore, then restores both", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 500 });
+    let state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBe(100);
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBe(900);
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 1_000 });
+    state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeNull();
+  });
+
+  it("keeps divergent twins unchanged for older generic fields, then applies them to both", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 900 } },
+    });
+
+    const fields = { inbox_dismissed_at: null, inbox_stashed_at: null };
+    useInboxStore.getState().applyGestureBridge({ kind: "fields", id: REAL_A, fields, ts: 500 });
+    let state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBe(100);
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBe(900);
+
+    useInboxStore.getState().applyGestureBridge({ kind: "fields", id: REAL_A, fields, ts: 1_000 });
+    state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeNull();
+  });
+
+  it("keeps divergent twins unchanged for an older pin, then applies the newer unpin to both", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 900 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 500 });
+    let state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].is_pinned).toBe(true);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBe(100);
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBe(900);
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 1_000 });
+    state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].is_pinned).toBe(false);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+  });
+
+  it("a newer kill atomically replaces an older stash", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A) },
+      conversations: { [REAL_A]: { _id: REAL_A } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "stash", ids: [REAL_A], ts: 500 });
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 900 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBe(900);
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBe(900);
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeNull();
+  });
+
+  it("a no-op unpin plants twin tombstones that reject a delayed pin", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: false, inbox_pinned_at: null } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: null } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 900 });
+    const locks = useInboxStore.getState().pending;
+    expect(locks[`sessions:${REAL_A}:is_pinned`]).toEqual({ type: "field", value: false, ts: 900 });
+    expect(locks[`sessions:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: null, ts: 900 });
+    expect(locks[`conversations:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: null, ts: 900 });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 500, ts: 500 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].is_pinned).toBe(false);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+  });
+
+  it("a hide or stash plants pin tombstones on already-unpinned twins", () => {
+    const originalNow = Date.now;
+    Date.now = () => 1_000;
+    try {
+      for (const [mode, hiddenField] of [["kill", "inbox_dismissed_at"], ["stash", "inbox_stashed_at"]] as const) {
+        const enqueued: any[] = [];
+        const dispatched: string[] = [];
+        seed({
+          sessions: { [REAL_A]: session(REAL_A, { is_pinned: false, inbox_pinned_at: null } as any) },
+          conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: null } },
+        });
+        const store = useInboxStore.getState() as any;
+        store._setOutbox((entry: any) => { enqueued.push(entry); }, () => {}, async () => []);
+        store._setDispatch((action: string) => { dispatched.push(action); return Promise.resolve(); });
+
+        useInboxStore.getState().applyGestureBridge({ kind: "hide", mode, ids: [REAL_A], ts: 900 });
+        let state = useInboxStore.getState();
+        expect(state.sessions[REAL_A][hiddenField]).toBe(900);
+        expect(state.pending[`sessions:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: null, ts: 900, hideAck: 900 });
+        expect(state.pending[`conversations:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: null, ts: 900, hideAck: 900 });
+
+        // The late pin is older than the hide's pin-clear tombstone.
+        useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 500, ts: 500 });
+        state = useInboxStore.getState();
+        expect(state.sessions[REAL_A].is_pinned).toBe(false);
+        expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+        expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+        expect(enqueued).toEqual([]);
+        expect(dispatched).toEqual([]);
+
+        // A stale hidden-reconcile page cannot retire the coupled locks.
+        if (mode === "kill") {
+          useInboxStore.getState().applyDismissedReconcile([{ _id: REAL_A, inbox_dismissed_at: 500 }], false);
+        } else {
+          useInboxStore.getState().applyStashedReconcile([{ _id: REAL_A, inbox_stashed_at: 500 }], false);
+        }
+        expect(useInboxStore.getState().pending[`conversations:${REAL_A}:inbox_pinned_at`]).toBeDefined();
+
+        // Hidden rows never reach normal sessions sync. Their one-field
+        // reconcile acknowledgement retires every lock from this hide transition.
+        if (mode === "kill") {
+          useInboxStore.getState().applyDismissedReconcile([{ _id: REAL_A, inbox_dismissed_at: 900 }], false);
+        } else {
+          useInboxStore.getState().applyStashedReconcile([{ _id: REAL_A, inbox_stashed_at: 900 }], false);
+        }
+        const pending = useInboxStore.getState().pending;
+        for (const coll of ["sessions", "conversations"]) {
+          expect(pending[`${coll}:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+          expect(pending[`${coll}:${REAL_A}:inbox_stashed_at`]).toBeUndefined();
+          expect(pending[`${coll}:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+        }
+
+        // With the hidden acknowledgement retired, a later authoritative pin is
+        // no longer overwritten by the old null tombstone on either twin.
+        useInboxStore.getState().syncTable("sessions", [session(REAL_A, { is_pinned: true, [hiddenField]: 900, inbox_pinned_at: 1_000 } as any)]);
+        useInboxStore.getState().syncRecord("conversations", REAL_A, { _id: REAL_A, [hiddenField]: 900, inbox_pinned_at: 1_000 });
+        state = useInboxStore.getState();
+        expect(state.sessions[REAL_A].is_pinned).toBe(true);
+        expect(state.sessions[REAL_A].inbox_pinned_at).toBe(1_000);
+        expect(state.conversations[REAL_A].inbox_pinned_at).toBe(1_000);
+      }
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("a local hide uses its visible timestamp as the hidden-reconcile acknowledgement anchor", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 100 } },
+    });
+    const originalNow = Date.now;
+    let calls = 0;
+    Date.now = () => (++calls === 1 ? 1_001 : 1_002);
+    try {
+      // hideSessionInDraft samples 1001 for the durable dismiss value; the
+      // middleware samples 1002 separately for local lock freshness.
+      useInboxStore.getState().killSession(REAL_A);
+      let state = useInboxStore.getState();
+      expect(state.sessions[REAL_A].inbox_dismissed_at).toBe(1_001);
+      expect(state.pending[`sessions:${REAL_A}:inbox_pinned_at`]).toMatchObject({
+        type: "field", value: null, ts: 1_002, hideAck: 1_001,
+      });
+      expect(state.pending[`conversations:${REAL_A}:inbox_pinned_at`]).toMatchObject({
+        type: "field", value: null, ts: 1_002, hideAck: 1_001,
+      });
+
+      useInboxStore.getState().applyDismissedReconcile([{ _id: REAL_A, inbox_dismissed_at: 1_000 }], false);
+      expect(useInboxStore.getState().pending[`conversations:${REAL_A}:inbox_pinned_at`]).toBeDefined();
+
+      // A newer hide supersedes the local transition. Its acknowledgement
+      // anchor must not be retired by the older operation's eventual echo.
+      useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 1_003 });
+      useInboxStore.getState().applyDismissedReconcile([{ _id: REAL_A, inbox_dismissed_at: 1_001 }], false);
+      expect(useInboxStore.getState().pending[`conversations:${REAL_A}:inbox_pinned_at`]).toMatchObject({ hideAck: 1_003 });
+
+      useInboxStore.getState().applyDismissedReconcile([{ _id: REAL_A, inbox_dismissed_at: 1_003 }], false);
+      state = useInboxStore.getState();
+      for (const coll of ["sessions", "conversations"]) {
+        expect(state.pending[`${coll}:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+        expect(state.pending[`${coll}:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+      }
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("an undo pin with an older pinnedAt still orders after delayed hide or stash", () => {
+    for (const [mode, hiddenField] of [["kill", "inbox_dismissed_at"], ["stash", "inbox_stashed_at"]] as const) {
+      seed({
+        sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 100 } as any) },
+        conversations: { [REAL_A]: { _id: REAL_A, inbox_pinned_at: 100 } },
+      });
+
+      // Undo restores the original pinnedAt value, while its fresh message ts
+      // is the causal ordering stamp. This is visibly a no-op but not a
+      // causally empty transition.
+      useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 100, ts: 900 });
+      let state = useInboxStore.getState();
+      expect(state.pending[`sessions:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: 100, ts: 900 });
+      expect(state.pending[`conversations:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: 100, ts: 900 });
+
+      useInboxStore.getState().applyGestureBridge({ kind: "hide", mode, ids: [REAL_A], ts: 500 });
+      state = useInboxStore.getState();
+      expect(state.sessions[REAL_A][hiddenField]).toBeUndefined();
+      expect(state.sessions[REAL_A].is_pinned).toBe(true);
+      expect(state.conversations[REAL_A].inbox_pinned_at).toBe(100);
+
+      // The old payload is also the exact server echo value, so it retires the
+      // fresh ordering lock rather than pinning the field indefinitely.
+      useInboxStore.getState().syncTable("sessions", [session(REAL_A, { is_pinned: true, inbox_pinned_at: 100 } as any)]);
+      useInboxStore.getState().syncRecord("conversations", REAL_A, { _id: REAL_A, inbox_pinned_at: 100 });
+      expect(useInboxStore.getState().pending[`sessions:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+      expect(useInboxStore.getState().pending[`conversations:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+
+      useInboxStore.getState().applyGestureBridge({ kind: "hide", mode, ids: [REAL_A], ts: 1_000 });
+      state = useInboxStore.getState();
+      expect(state.sessions[REAL_A][hiddenField]).toBe(1_000);
+      expect(state.sessions[REAL_A].is_pinned).toBe(false);
+      expect(state.conversations[REAL_A][hiddenField]).toBe(1_000);
+      expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+    }
+  });
+
+  it("no-op undo fields plant twin tombstones that reject delayed hide and pin gestures", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: false, inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } },
+    });
+
+    // This is undoableHideSession's real sibling payload when its snapshot was
+    // already visible in this window.
+    useInboxStore.getState().applyGestureBridge({
+      kind: "fields",
+      id: REAL_A,
+      fields: { inbox_dismissed_at: null, inbox_stashed_at: null },
+      ts: 900,
+    });
+    let locks = useInboxStore.getState().pending;
+    expect(locks[`sessions:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: null, ts: 900 });
+    expect(locks[`conversations:${REAL_A}:inbox_stashed_at`]).toEqual({ type: "field", value: null, ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
+
+    // Generic pin patches also need their no-op ordering tombstone.
+    useInboxStore.getState().applyGestureBridge({
+      kind: "fields",
+      id: REAL_A,
+      fields: { inbox_pinned_at: null },
+      ts: 900,
+    });
+    locks = useInboxStore.getState().pending;
+    expect(locks[`sessions:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: null, ts: 900 });
+    expect(locks[`conversations:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: null, ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: true, pinnedAt: 500, ts: 500 });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.sessions[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.sessions[REAL_A].is_pinned).toBe(false);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_stashed_at).toBeNull();
+    expect(state.conversations[REAL_A].inbox_pinned_at).toBeNull();
+  });
+
+  it("delayed pin and hide field writes cannot overwrite newer field locks", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: 100, is_pinned: true, inbox_pinned_at: 100 } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: 100, inbox_pinned_at: 100 } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 900 });
+    useInboxStore.getState().applyGestureBridge({
+      kind: "fields",
+      id: REAL_A,
+      fields: { inbox_dismissed_at: 500, is_pinned: true, inbox_pinned_at: 500 },
+      ts: 500,
+    });
+
+    const state = useInboxStore.getState();
+    expect(state.sessions[REAL_A].inbox_dismissed_at).toBeNull();
+    expect(state.sessions[REAL_A].is_pinned).toBe(false);
+    expect(state.sessions[REAL_A].inbox_pinned_at).toBeNull();
+  });
+
   it("an older unpin does not undo a newer local pin", () => {
     seed({
       sessions: { [REAL_A]: session(REAL_A, { is_pinned: true, inbox_pinned_at: 900 } as any) },
@@ -744,8 +1163,8 @@ describe("gesture bridge receiver is local-only", () => {
     useInboxStore.getState().applyGestureBridge({ kind: "hide", mode: "kill", ids: [REAL_A], ts: 500 });
 
     const p = useInboxStore.getState().pending;
-    expect(p[`sessions:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: 500, ts: 500 });
-    expect(p[`conversations:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: 500, ts: 500 });
+    expect(p[`sessions:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: 500, ts: 500, hideAck: 500 });
+    expect(p[`conversations:${REAL_A}:inbox_dismissed_at`]).toEqual({ type: "field", value: 500, ts: 500, hideAck: 500 });
   });
 
   // THE regression test for the field-lock defect. A sessions crawl already in
@@ -802,5 +1221,54 @@ describe("gesture bridge receiver is local-only", () => {
     // only when the server echo matches it, so a re-derived timestamp would
     // stick forever.
     expect(p[`sessions:${REAL_A}:inbox_pinned_at`]).toEqual({ type: "field", value: 600, ts: 600 });
+  });
+
+  it("retires no-op restore and unpin tombstones on matching server echoes", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { is_pinned: false, inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({ kind: "restore", ids: [REAL_A], ts: 900 });
+    useInboxStore.getState().applyGestureBridge({ kind: "pin", id: REAL_A, pinned: false, pinnedAt: null, ts: 900 });
+    useInboxStore.getState().syncTable("sessions", [
+      session(REAL_A, { is_pinned: false, inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } as any),
+    ]);
+    // Production conversation echoes omit clear optional inbox timestamps.
+    useInboxStore.getState().syncRecord("conversations", REAL_A, { _id: REAL_A });
+
+    const pending = useInboxStore.getState().pending;
+    expect(pending[`sessions:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+    expect(pending[`sessions:${REAL_A}:inbox_stashed_at`]).toBeUndefined();
+    expect(pending[`sessions:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+    expect(pending[`conversations:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+    expect(pending[`conversations:${REAL_A}:inbox_stashed_at`]).toBeUndefined();
+    expect(pending[`conversations:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+  });
+
+  it("retires no-op generic fields tombstones on matching server echoes", () => {
+    seed({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } as any) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } },
+    });
+
+    useInboxStore.getState().applyGestureBridge({
+      kind: "fields",
+      id: REAL_A,
+      fields: { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null },
+      ts: 900,
+    });
+    useInboxStore.getState().syncTable("sessions", [
+      session(REAL_A, { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_pinned_at: null } as any),
+    ]);
+    useInboxStore.getState().syncRecord("conversations", REAL_A, { _id: REAL_A });
+
+    const pending = useInboxStore.getState().pending;
+    expect(pending[`sessions:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+    expect(pending[`sessions:${REAL_A}:inbox_stashed_at`]).toBeUndefined();
+    expect(pending[`sessions:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
+    expect(pending[`conversations:${REAL_A}:inbox_dismissed_at`]).toBeUndefined();
+    expect(pending[`conversations:${REAL_A}:inbox_stashed_at`]).toBeUndefined();
+    expect(pending[`conversations:${REAL_A}:inbox_pinned_at`]).toBeUndefined();
   });
 });

--- a/packages/web/store/__tests__/inboxStore.test.ts
+++ b/packages/web/store/__tests__/inboxStore.test.ts
@@ -3387,6 +3387,21 @@ describe("applyDismissedReconcile — durable cross-device dismiss", () => {
     expect(useInboxStore.getState().sessions[A].inbox_dismissed_at).toBeNull();
   });
 
+  it("CLEARS a conversation-only dismiss only on the final pass", () => {
+    const at = Date.now() - 1_000;
+    useInboxStore.setState({
+      sessions: {},
+      conversations: { [A]: { _id: A, inbox_dismissed_at: at } },
+      pending: {},
+    } as any);
+
+    useInboxStore.getState().applyDismissedReconcile([], false);
+    expect((useInboxStore.getState().conversations[A] as any).inbox_dismissed_at).toBe(at);
+
+    useInboxStore.getState().applyDismissedReconcile([], true);
+    expect((useInboxStore.getState().conversations[A] as any).inbox_dismissed_at).toBeNull();
+  });
+
   it("never CLEARs a dismissed BLANK session — its absence usually means the empty-conversation GC deleted it", () => {
     // A dismissed 0-message row leaving the server's dismissed set is (almost
     // always) cleanup.gcEmptyConversations hard-deleting it. Un-dismissing
@@ -3584,6 +3599,17 @@ describe("applyStashedReconcile — cross-device stash propagation", () => {
     } as any);
     useInboxStore.getState().applyStashedReconcile([], true);
     expect(useInboxStore.getState().sessions[realId].inbox_stashed_at ?? null).toBeNull();
+  });
+
+  it("CLEAR (final pass) un-stashes a conversation-only cached row", () => {
+    useInboxStore.setState({
+      sessions: {},
+      conversations: { [realId]: { _id: realId, inbox_stashed_at: Date.now() - 5_000 } },
+      pending: {},
+    } as any);
+
+    useInboxStore.getState().applyStashedReconcile([], true);
+    expect((useInboxStore.getState().conversations[realId] as any).inbox_stashed_at).toBeNull();
   });
 
   it("a pending local override blocks the SET (local-first)", () => {

--- a/packages/web/store/__tests__/outboxRetention.test.ts
+++ b/packages/web/store/__tests__/outboxRetention.test.ts
@@ -1063,6 +1063,43 @@ describe("boot outbox drain signal (_hasBootOutboxDrained)", () => {
     wrapped._clearRuntimeBindings();
     expect(wrapped._hasBootOutboxDrained()).toBe(false);
   });
+
+  it("stays closed when a failed replay is re-queued", async () => {
+    const { wrapped, outbox } = makeHarness();
+    outbox.set("e1", seedEntry());
+
+    wrapped._setDispatch(async () => { throw new Error("offline"); });
+    await settle();
+
+    expect(outbox.has("e1")).toBe(true);
+    expect(wrapped._hasBootOutboxDrained()).toBe(false);
+  });
+
+  it("invalidates readiness for a new enqueue and reopens only after a later empty verification", async () => {
+    const { wrapped, outbox } = makeHarness();
+    let commit: (() => void) | null = null;
+    wrapped._setOutbox(
+      (entry: Entry) => new Promise<void>((resolve) => {
+        commit = () => {
+          outbox.set(entry.id, entry);
+          resolve();
+        };
+      }),
+      (id: string) => { outbox.delete(id); },
+      async () => [...outbox.values()],
+    );
+    wrapped._setDispatch(async () => "ok");
+    await settle();
+    expect(wrapped._hasBootOutboxDrained()).toBe(true);
+
+    wrapped.poke("race");
+    expect(wrapped._hasBootOutboxDrained()).toBe(false);
+
+    commit?.();
+    await settle();
+    expect(outbox.size).toBe(0);
+    expect(wrapped._hasBootOutboxDrained()).toBe(true);
+  });
 });
 
 describe("principal-bound dispatch ownership", () => {

--- a/packages/web/store/__tests__/outboxRetention.test.ts
+++ b/packages/web/store/__tests__/outboxRetention.test.ts
@@ -1042,6 +1042,29 @@ describe("opportunistic re-drive (_drainOutbox)", () => {
   });
 });
 
+// The boot-replay signal the hidden-set reconcile crawls wait on. Their CLEAR
+// pass un-hides every local row the server's hidden set omits, so reading the
+// server before the parked hides ship resurrects a kill the user made offline.
+describe("boot outbox drain signal (_hasBootOutboxDrained)", () => {
+  it("reports drained only after a replay pass, and resets on a principal rebind", async () => {
+    const { wrapped, outbox } = makeHarness();
+    outbox.set("e1", seedEntry());
+    // Unwired: nothing has been replayed, so consumers must keep waiting.
+    expect(wrapped._hasBootOutboxDrained()).toBe(false);
+
+    wrapped._setDispatch(async () => "ok");
+    await settle();
+    expect(outbox.size).toBe(0);
+    expect(wrapped._hasBootOutboxDrained()).toBe(true);
+
+    // An account switch clears the runtime bindings. The successor principal has
+    // its own outbox rows and has replayed none of them, so a `true` carried
+    // across would tell the crawls a replay they never saw already happened.
+    wrapped._clearRuntimeBindings();
+    expect(wrapped._hasBootOutboxDrained()).toBe(false);
+  });
+});
+
 describe("principal-bound dispatch ownership", () => {
   it("A→B invalidates an in-flight A dispatch without letting A cleanup clear B", async () => {
     registerPrincipalDispatchRuntime({

--- a/packages/web/store/__tests__/syncProtocol.test.ts
+++ b/packages/web/store/__tests__/syncProtocol.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { applySyncTable } from "../syncProtocol";
+import { applySyncRecord, applySyncTable } from "../syncProtocol";
 
 type Row = { _id: string; updated_at: number; status: "open" | "done" | "dropped" };
 
@@ -56,6 +56,32 @@ describe("applySyncTable — delta mode", () => {
     const pending = { "tasks:a": { type: "exclude" as const } };
     const { pending: nextPending } = applySyncTable("tasks", incoming, pending, prev, { isDelta: true });
     expect(nextPending["tasks:a"]?.type).toBe("exclude");
+  });
+});
+
+describe("optional inbox timestamp echoes", () => {
+  it("treats omitted timestamps as null acknowledgements without relaxing other fields", () => {
+    const pending = {
+      "conversations:a:inbox_dismissed_at": { type: "field" as const, value: null },
+      "conversations:a:inbox_stashed_at": { type: "field" as const, value: null },
+      "conversations:a:inbox_pinned_at": { type: "field" as const, value: null },
+      "conversations:a:title": { type: "field" as const, value: null },
+    };
+    const incoming = { _id: "a", updated_at: 1, status: "open" as const };
+
+    const table = applySyncTable("conversations", [incoming], pending, { a: incoming });
+    expect(table.pending["conversations:a:inbox_dismissed_at"]).toBeUndefined();
+    expect(table.pending["conversations:a:inbox_stashed_at"]).toBeUndefined();
+    expect(table.pending["conversations:a:inbox_pinned_at"]).toBeUndefined();
+    expect(table.pending["conversations:a:title"]).toEqual({ type: "field", value: null });
+    expect((table.table.a as any).title).toBeNull();
+
+    const record = applySyncRecord("conversations", "a", incoming, pending);
+    expect(record.pending["conversations:a:inbox_dismissed_at"]).toBeUndefined();
+    expect(record.pending["conversations:a:inbox_stashed_at"]).toBeUndefined();
+    expect(record.pending["conversations:a:inbox_pinned_at"]).toBeUndefined();
+    expect(record.pending["conversations:a:title"]).toEqual({ type: "field", value: null });
+    expect(record.record.title).toBeNull();
   });
 });
 

--- a/packages/web/store/gestureBridge.ts
+++ b/packages/web/store/gestureBridge.ts
@@ -1,0 +1,210 @@
+// Cross-window gesture bridge.
+//
+// The desktop app runs several SAME-ORIGIN windows (main, compose palette, …)
+// against ONE IndexedDB principal store, and each window persists rows with
+// per-row WHOLE-ROW puts diffed against its own in-memory shadow
+// (idbCache.ts → writePatchesToIDB → diffCollection). That makes stale memory
+// destructive, not merely stale: a window that never learned about a gesture
+// made in a sibling window still holds the pre-gesture row, and the next time
+// anything about that row changes it writes the whole row back — clobbering
+// the sibling's write in shared IDB. That is the mechanism behind killed
+// sessions resurrecting and pinned stubs becoming immortal.
+//
+// The fix is to converge SIBLING MEMORY at gesture time: the acting window
+// broadcasts what the user did, and every other window applies the same field
+// edits locally (store.applyGestureBridge, a sync() action — local only, no
+// dispatch, no outbox). Their later whole-row puts then carry the gesture
+// instead of undoing it.
+//
+// Why an event and not a merge-on-write in the persistence layer: the hidden
+// fields are nullable, and `null` is ambiguous on disk — it means both "this
+// window never knew" and "the user just restored this". Only an event carries
+// the intent, so only an event can be merged correctly.
+//
+// Delivery is best-effort by construction. A missed broadcast (window closed,
+// no BroadcastChannel) degrades to today's behaviour — the server round-trip
+// and the dismiss/stash reconcile crawls remain the durable path; the bridge
+// only closes the window between the gesture and that reconcile.
+
+// The four row fields the bridge carries. Every one of them is written by a
+// user gesture and read by the inbox's bucket/sort logic, and every one is
+// nullable — which is what makes a stale sibling's whole-row put destructive.
+export const BRIDGED_FIELDS = [
+  "inbox_dismissed_at",
+  "inbox_stashed_at",
+  "inbox_pinned_at",
+  "is_pinned",
+] as const;
+export type BridgedField = (typeof BRIDGED_FIELDS)[number];
+
+/** One user gesture, as seen by the window that performed it. */
+export type GestureMessage =
+  // `ids` is the SENDER's already-resolved cascade set (the session plus its
+  // nested children), not a parent id the receiver would have to re-derive:
+  // the two windows can disagree about which children exist, and the visual
+  // group the user took down is the sender's.
+  //
+  // One cascade can both flag and delete rows — a stub or an injected teammate
+  // row can't be hidden durably, so hiding it means deleting it. `forget`
+  // carries that half INLINE rather than as a second broadcast, so one user
+  // gesture is exactly one message (a receiver that saw only half of a split
+  // pair would converge to a state the user never asked for).
+  | { kind: "hide"; mode: "kill" | "stash"; ids: string[]; forget?: string[]; ts: number }
+  | { kind: "restore"; ids: string[]; ts: number }
+  // `pinnedAt` is the EXACT value the sender wrote, carried separately from
+  // `ts` (the ordering stamp) because undo restores the ORIGINAL pin time, not
+  // the time of the undo. The receiver plants a pending field lock holding this
+  // value, and that lock only retires when the server echo matches it — so a
+  // receiver that re-derived the timestamp would pin a value the server will
+  // never send and the lock would stick forever.
+  | { kind: "pin"; id: string; pinned: boolean; pinnedAt: number | null; ts: number }
+  // A verbatim write of the bridged fields, for the generic `patchConversation`
+  // path: the /sessions surface drives its own pin and stash/restore toggles
+  // through it, writing whichever subset of these four fields it wants. Copying
+  // the exact field/value pairs is the only shape that mirrors it without
+  // guessing, and it keeps the receiver's planted locks equal to the values the
+  // sender dispatched.
+  | { kind: "fields"; id: string; fields: Partial<Record<BridgedField, number | boolean | null>>; ts: number }
+  // Rows the sender DELETED outright rather than flagged: local-only stubs,
+  // injected teammate rows, and server-verified ghosts. A sibling holding one
+  // in memory would re-put it, so it has to drop it too.
+  //
+  // `scope` mirrors HOW MUCH the sender dropped, because the receiver plants
+  // the excludes that make its delete durable and an over-broad exclude is
+  // itself a bug. "all" (the default) is a whole-entity forget. "session-row"
+  // drops only the inbox row: markKilling removes the card for a session the
+  // server still has (killed, marked completed), so a receiver that also
+  // dropped conversations[id] would blind itself to a live conversation.
+  | { kind: "forget"; ids: string[]; scope?: "session-row" | "all"; ts: number };
+
+type Envelope = GestureMessage & {
+  v: 1;
+  /** Per-window random token, so a window ignores its own broadcast. */
+  source: string;
+  /** The acting user. A receiver on another account drops the message. */
+  userId: string | null;
+};
+
+export type ChannelFactory = (name: string) => BroadcastChannel | null;
+
+const PROTOCOL_VERSION = 1;
+
+// Same-origin is already enforced by BroadcastChannel; the remaining way two
+// windows can differ is the signed-in account, so the channel name carries it.
+// The payload repeats the user id and the receiver re-checks it — the name
+// alone would be trusted state, and an account switch races the rebind.
+function channelName(userId: string | null): string {
+  return `codecast-gesture:${userId ?? "anon"}`;
+}
+
+const defaultChannelFactory: ChannelFactory = (name) => {
+  if (typeof BroadcastChannel === "undefined") return null;
+  try {
+    return new BroadcastChannel(name);
+  } catch {
+    return null;
+  }
+};
+
+let channelFactory: ChannelFactory = defaultChannelFactory;
+
+/** Test seam — swap the BroadcastChannel constructor. Pass null to restore. */
+export function setGestureChannelFactory(factory: ChannelFactory | null): void {
+  channelFactory = factory ?? defaultChannelFactory;
+}
+
+let sourceToken: string | null = null;
+
+/** This window's identity on the bridge. Stable for the window's lifetime. */
+export function gestureSourceToken(): string {
+  if (sourceToken) return sourceToken;
+  sourceToken =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return sourceToken;
+}
+
+/**
+ * Announce a gesture to sibling windows. Fire-and-forget: a fresh channel per
+ * post (the composeBridge idiom) so there is no long-lived handle to keep in
+ * sync with account switches — posted messages are still delivered after the
+ * synchronous close().
+ */
+export function broadcastGesture(msg: GestureMessage, userId: string | null): void {
+  const ch = channelFactory(channelName(userId));
+  if (!ch) return;
+  const envelope: Envelope = { ...msg, v: PROTOCOL_VERSION, source: gestureSourceToken(), userId };
+  try {
+    ch.postMessage(envelope);
+  } catch {
+    // A structured-clone or closed-channel failure must never break the
+    // gesture itself — the local state change already landed.
+  } finally {
+    try {
+      ch.close();
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
+function isGestureMessage(data: unknown): data is Envelope {
+  if (!data || typeof data !== "object") return false;
+  const e = data as Partial<Envelope>;
+  if (e.v !== PROTOCOL_VERSION || typeof e.ts !== "number") return false;
+  if (e.kind === "pin") {
+    return typeof e.id === "string" && typeof e.pinned === "boolean" &&
+      (e.pinnedAt === null || typeof e.pinnedAt === "number");
+  }
+  if (e.kind === "fields") {
+    if (typeof e.id !== "string" || !e.fields || typeof e.fields !== "object") return false;
+    // Only the four bridged fields may cross — this message writes verbatim, so
+    // an unrecognized key would let a malformed post edit arbitrary row state.
+    return Object.entries(e.fields).every(([k, v]) =>
+      (BRIDGED_FIELDS as readonly string[]).includes(k) &&
+      (v === null || typeof v === "number" || typeof v === "boolean"));
+  }
+  if (e.kind === "hide") {
+    if (e.forget !== undefined && !Array.isArray(e.forget)) return false;
+    return Array.isArray(e.ids) && (e.mode === "kill" || e.mode === "stash");
+  }
+  if (e.kind === "forget") {
+    if (e.scope !== undefined && e.scope !== "session-row" && e.scope !== "all") return false;
+    return Array.isArray(e.ids);
+  }
+  if (e.kind === "restore") return Array.isArray(e.ids);
+  return false;
+}
+
+/**
+ * Listen for sibling gestures for `userId`. `currentUserId` is read at DELIVERY
+ * time (not bind time) so an account switch that races an in-flight message
+ * still drops it; the caller separately rebinds the channel when the user
+ * changes, which is what keeps the two accounts on different channel names.
+ */
+export function subscribeGestures(
+  userId: string | null,
+  currentUserId: () => string | null,
+  apply: (msg: GestureMessage) => void,
+): () => void {
+  const ch = channelFactory(channelName(userId));
+  if (!ch) return () => {};
+  const handler = (event: MessageEvent) => {
+    const data = event.data;
+    if (!isGestureMessage(data)) return;
+    if (data.source === gestureSourceToken()) return; // our own gesture
+    if ((data.userId ?? null) !== (currentUserId() ?? null)) return;
+    const { v: _v, source: _source, userId: _userId, ...msg } = data;
+    apply(msg as GestureMessage);
+  };
+  ch.addEventListener("message", handler);
+  return () => {
+    ch.removeEventListener("message", handler);
+    try {
+      ch.close();
+    } catch {
+      /* already closed */
+    }
+  };
+}

--- a/packages/web/store/inboxStore.ts
+++ b/packages/web/store/inboxStore.ts
@@ -62,7 +62,7 @@ export async function awaitTrackedSessionCreateResult(
 // Imported for internal use AND re-exported so the many call sites that import
 // `isConvexId` from the store keep working.
 import { isConvexId } from "../lib/entityLinks";
-import { defaultMachineId, pathOnMyMachines, type MachineCandidate } from "../lib/machinePicker";
+import { pathOnMyMachines, type MachineCandidate } from "../lib/machinePicker";
 export { isConvexId };
 
 // Canonical entity-derivation helpers live in lib/liveEntities. Re-exported here
@@ -700,6 +700,11 @@ export type ClientUI = {
   plan_view?: PlanViewPrefs;
   saved_views?: SavedView[];
   show_subagents?: boolean;
+  // The machine you last chose by hand in the new-session picker — the default
+  // the picker opens on for NEW work (defaultMachineId rung 2). Deliberately
+  // UNSTAMPED, i.e. per-device: "where should this run" is answered differently
+  // from a phone than from the laptop that holds the checkouts.
+  last_picked_device_id?: string;
   // User-set height (px) of the trigger full-prompt viewport (TriggerPromptView
   // drag handle). Layout pref → unstamped, per-device local_wins.
   trigger_prompt_height?: number;
@@ -4979,26 +4984,21 @@ export const useInboxStore = create<InboxStoreState>(
     // key ("opus") — findModelOption matches on key. A model left on a different
     // agent's id (after an agent switch) resolves to "default" and is dropped.
     const modelKey = modelOptionKey(cur?.model, agentType);
-    // The machine the user picked in the new-session row — re-checked HERE, at
-    // the moment the create fires, not at pick time. Devices go offline and
-    // reorder in between, and a stamp that has since become the machine routing
-    // would choose anyway is worse than no stamp: an explicit target wins the
-    // FIRST rung of deviceRouting, jumping the queue ahead of the rung that
-    // prefers whichever machine actually holds the checkout. An empty roster
-    // (query hasn't landed yet) can't prove that, so the user's pick stands.
+    // The machine shown in the new-session row, passed through verbatim. This
+    // used to be re-checked here and DROPPED when it matched what routing would
+    // pick anyway — an optimization that quietly became a bug: the picker's
+    // default was decided by `last_seen`, which flips between two idle laptops
+    // every ~30s, so a heartbeat landing between the click and the create could
+    // discard an explicit pick and hand the choice back to a server-side
+    // coin flip. The selection is now deterministic and always stamped, so
+    // there is nothing left to second-guess.
     const targetDeviceId = cur?.target_device_id as string | null | undefined;
-    const routedAnyway = targetDeviceId
-      ? targetDeviceId === defaultMachineId(s.machineRoster, {
-          ownerDeviceId: cur?.owner_device_id ?? null,
-          projectPath: projectPath ?? gitRoot ?? null,
-        })
-      : false;
     return s.createSession({
       agent_type: agentType,
       project_path: projectPath,
       git_root: gitRoot || undefined,
       session_id: stubId,
-      ...(targetDeviceId && !routedAnyway ? { target_device_id: targetDeviceId } : {}),
+      ...(targetDeviceId ? { target_device_id: targetDeviceId } : {}),
       ...(cur?._linkedObject?.type && cur?._linkedObject?.id
         ? { linked_object: cur._linkedObject }
         : {}),

--- a/packages/web/store/inboxStore.ts
+++ b/packages/web/store/inboxStore.ts
@@ -3785,6 +3785,19 @@ function applyHiddenReconcileInDraft(
     const conv = draft.conversations[id];
     if (conv) conv[field] = null;
   }
+
+  // A direct conversation view (and markKilling) can retain metadata after its
+  // inbox row is absent. SET already updates that conversation-only twin, so a
+  // complete hidden-set pass must clear it symmetrically on a remote restore.
+  // There is no inbox card here, so the session-only blank-GC guard does not
+  // apply; clearing metadata cannot resurrect a row into the inbox.
+  for (const id of Object.keys(draft.conversations)) {
+    if (draft.sessions[id] || !isConvexId(id)) continue;
+    const conv = draft.conversations[id];
+    const at = conv[field];
+    if (!at || at < cutoff || server.has(id) || lockedLocal(id)) continue;
+    conv[field] = null;
+  }
 }
 
 // Shared body of stashSession/killSession: hide `id` (and its nested

--- a/packages/web/store/inboxStore.ts
+++ b/packages/web/store/inboxStore.ts
@@ -18,6 +18,7 @@ import type { PrincipalEpoch } from "./local-first/types";
 import type { DispatchAuthorizationCapture } from "./local-first/dispatchGate";
 import { HYDRATION_CRITICAL_KEYS, HYDRATION_DEFERRED_KEYS, hydrationMergeStrategy } from "./clientSyncRegistry";
 import { makeCollectionSig } from "./wakeSig";
+import { broadcastGesture, BRIDGED_FIELDS, type BridgedField, type GestureMessage } from "./gestureBridge";
 // Single source of truth for the agent-status contract, shared with the Convex
 // backend and the CLI daemon. See packages/shared/contracts/agentStatus.ts.
 import { type AgentStatus, ACTIVE_AGENT_STATUSES, isLivenessStale, modelOptionKey } from "@codecast/shared/contracts";
@@ -2505,6 +2506,8 @@ interface InboxStoreState {
   // deleted (the empty-conversation GC). Plants the exclude pending entries that
   // authorize the IDB row delete and block crawl re-adds.
   pruneGhostSessions: (ids: string[]) => void;
+  // Receiver for the cross-window gesture bridge — see gestureBridge.ts.
+  applyGestureBridge: (msg: GestureMessage) => void;
   pruneFeedEntities: (collection: FeedCollection, ids: string[]) => void;
   clearFeedExcludes: (collection: FeedCollection, ids: string[]) => void;
   markServerDeleted: (convId: string) => void;
@@ -3761,8 +3764,25 @@ function applyHiddenReconcileInDraft(
 // children) out of the active buckets, advancing the current selection past the
 // removed set. Stash writes inbox_stashed_at; dismiss writes inbox_dismissed_at
 // and clears any stash (the row MOVES to Dismissed — the buckets are exclusive).
-function hideSessionInDraft(draft: any, id: string, mode: "stash" | "kill") {
-  const now = Date.now();
+//
+// Returns the two resolved id sets so the calling action can announce them on
+// the cross-window gesture bridge (gestureBridge.ts): `hidden` are the rows
+// that got a hide timestamp, `forgotten` the rows deleted outright. Only this
+// function knows the cascade (nested children) and which members turned out to
+// be stubs/foreign, so returning them is the least invasive way to surface it —
+// the action body must NOT return them onward, since an action()'s return value
+// becomes its server dispatch payload.
+//
+// `now` is the gesture's timestamp. Bulk kill passes ONE for the whole sweep so
+// every row it stamps carries the same value its single broadcast does — a
+// per-row Date.now() drifts across a long sweep, and a receiver's field lock
+// holding a value the server never echoes back never retires.
+function hideSessionInDraft(
+  draft: any,
+  id: string,
+  mode: "stash" | "kill",
+  now: number = Date.now(),
+): { hidden: string[]; forgotten: string[]; ts: number } {
   const field = mode === "kill" ? "inbox_dismissed_at" : "inbox_stashed_at";
   const sessionValues = Object.values(draft.sessions) as InboxSession[];
   // The removed set must match what the card visually contains, so the sweep
@@ -3779,6 +3799,8 @@ function hideSessionInDraft(draft: any, id: string, mode: "stash" | "kill") {
   // The viewer. A session whose user_id isn't ours was injected into this cache
   // by viewing/searching a TEAMMATE's session — we can't durably hide it.
   const me = draft.currentUser?._id?.toString?.();
+  const hidden: string[] = [];
+  const forgotten: string[] = [];
   let newSessionId = draft.currentSessionId;
   if (draft.currentSessionId && allIds.includes(draft.currentSessionId)) {
     // Advance in the order the user is LOOKING at (active view mode, same as
@@ -3809,8 +3831,10 @@ function hideSessionInDraft(draft: any, id: string, mode: "stash" | "kill") {
       delete draft.conversations[sid];
       delete draft.messages[sid];
       delete draft.pendingMessages[sid];
+      forgotten.push(sid);
       continue;
     }
+    hidden.push(sid);
     const sess = draft.sessions[sid];
     const wasPinned = sess?.is_pinned;
     if (sess) {
@@ -3839,6 +3863,240 @@ function hideSessionInDraft(draft: any, id: string, mode: "stash" | "kill") {
   // effect snaps the view back onto it (resurfacing the dismissed/killed session
   // as a peek) the next time it runs — e.g. when the tab is re-activated.
   syncActiveInboxTabPath(draft, newSessionId);
+  return { hidden, forgotten, ts: now };
+}
+
+// The signed-in user, as the gesture bridge stamps it on outbound messages and
+// matches it on inbound ones. Exported for undoActions, whose undo closures
+// broadcast the reverted value (an un-announced undo leaves a sibling holding
+// the pre-undo row — see gestureBridge.ts).
+export function bridgeUserId(state: any): string | null {
+  return state.currentUser?._id?.toString?.() ?? null;
+}
+
+// The bridged subset of a generic field patch, or null if it touches none of
+// them. Values pass through verbatim so the receiver's planted locks hold
+// exactly what the sender dispatched (see applyGestureInDraft's `write`).
+function pickBridgedFields(
+  fields: Record<string, any>,
+): Partial<Record<BridgedField, number | boolean | null>> | null {
+  let out: Partial<Record<BridgedField, number | boolean | null>> | null = null;
+  for (const field of BRIDGED_FIELDS) {
+    if (!Object.prototype.hasOwnProperty.call(fields, field)) continue;
+    const value = fields[field];
+    if (value !== null && typeof value !== "number" && typeof value !== "boolean") continue;
+    out ??= {};
+    out[field] = value;
+  }
+  return out;
+}
+
+// Sender half for the hide gestures. Called from inside the action body (the
+// mutative recipe), alongside soundDismiss/soundKill — the local mutation is
+// already fully computed on the draft at this point and lands synchronously
+// when the middleware commits it, so a sibling can never observe the broadcast
+// "before" this window's own state change.
+function announceHide(
+  draft: any,
+  mode: "stash" | "kill",
+  result: { hidden: string[]; forgotten: string[]; ts: number },
+) {
+  if (result.hidden.length === 0 && result.forgotten.length === 0) return;
+  broadcastGesture(
+    {
+      kind: "hide",
+      mode,
+      ids: result.hidden,
+      ...(result.forgotten.length ? { forget: result.forgotten } : {}),
+      ts: result.ts,
+    },
+    bridgeUserId(draft),
+  );
+}
+
+// Receiver half of the cross-window gesture bridge (see gestureBridge.ts for
+// the clobber mechanism this defends against). Applies a SIBLING window's
+// gesture to this window's in-memory rows, so this window's next whole-row IDB
+// put carries the gesture instead of writing the pre-gesture row back over it.
+//
+// Deliberately narrow — fields and row removal only. It never touches
+// currentSessionId, the tab path, or any navigation state: the user is looking
+// at THIS window, and a dismiss they made in another one must not move their
+// view here. It runs under sync(), so it neither dispatches nor enqueues an
+// outbox entry; the acting window owns the single server write.
+//
+// Every write is timestamp-guarded so a late, duplicated, or reordered message
+// can never regress newer local state. `notNewer` treats an absent value as 0:
+// a row that was never hidden always accepts a hide, and a row hidden AFTER the
+// incoming gesture keeps its own newer stamp.
+function applyGestureInDraft(draft: any, msg: GestureMessage) {
+  const notNewer = (current: unknown, ts: number) =>
+    typeof current === "number" ? current <= ts : true;
+
+  // Write a field AND plant the pending field lock the sender's action() gets
+  // for free from generateAutoPending (mutativeMiddleware). The lock is not
+  // bookkeeping — it is the only thing that makes the bridged value survive:
+  //   • applySyncTable's applyFieldOverrides re-asserts it over an incoming
+  //     server row (delta mode replaces the row wholesale), and
+  //   • applyHiddenReconcileInDraft's SET/CLEAR passes skip a locked row
+  //     (lockedLocal).
+  // Without it, a sessions crawl already in flight in THIS window — a wake
+  // reconcile pages for seconds — lands the pre-gesture server row, the bridged
+  // hide silently vanishes, and this window's next whole-row put writes the
+  // un-hidden row over the acting window's in shared IDB. That is precisely the
+  // bug the bridge exists to prevent, so an unlocked apply is worse than none.
+  //
+  // This does NOT breach the receiver's no-server-write contract: {type:"field"}
+  // pendings are consumed only by the local sync appliers (applySyncTable,
+  // applySyncRecord, applyHiddenReconcileInDraft). They are never dispatched and
+  // never enqueued — only action()/asyncAction() reach the outbox.
+  //
+  // The planted value must equal what the SENDER dispatched, because the lock
+  // retires only when the server echo matches it (applyFieldOverrides). Every
+  // call below therefore passes a value carried in the message, never one
+  // re-derived here.
+  const write = (coll: "sessions" | "conversations", id: string, field: string, value: any) => {
+    const row = draft[coll][id];
+    if (!row) return;
+    row[field] = value;
+    draft.pending[`${coll}:${id}:${field}`] = { type: "field", value, ts: msg.ts };
+  };
+
+  const forget = (ids: string[], ts: number, scope: "session-row" | "all" = "all") => {
+    for (const fid of ids) {
+      // Mirror ALL of pruneGhostSessions' IN-USE guards, not just the first.
+      // (Its skip for a row this window doesn't hold does NOT carry over: there
+      // the absence means no evidence, here the sender is the evidence, and the
+      // exclude is what stops an in-flight crawl re-adding what it just deleted.)
+      // Declining only ever makes the receiver more conservative — the sender
+      // still owns its own durable delete — while deleting here would destroy
+      // state this window knows about and the sender did not:
+      //   • currentSessionId: the conversation view would blank out mid-read.
+      //   • pendingMessages: unsent user TEXT queued in this window.
+      //   • pendingSessionCreates: a create still in flight, about to rekey.
+      if (draft.currentSessionId === fid) continue;
+      if (draft.pendingMessages[fid]?.length) continue;
+      if (fid in draft.pendingSessionCreates) continue;
+      delete draft.sessions[fid];
+      // The exclude is what authorizes the durable IDB row delete — a bare
+      // store-shrink is ignored by the collection diff (same reason
+      // pruneGhostSessions plants them) — and it also stops a delta crawl from
+      // re-adding the row this window was just told is gone.
+      draft.pending[`sessions:${fid}`] = { type: "exclude", ts };
+      // markKilling drops the inbox CARD but keeps the conversation cached (the
+      // server still has it, marked completed). Mirroring that exactly matters:
+      // an exclude planted here for a conversation that still exists would
+      // blind this window to it on every later crawl.
+      if (scope === "session-row") continue;
+      delete draft.conversations[fid];
+      delete draft.messages[fid];
+      delete draft.pendingMessages[fid];
+      delete draft.pagination[fid];
+      draft.pending[`conversations:${fid}`] = { type: "exclude", ts };
+    }
+  };
+
+  if (msg.kind === "forget") {
+    forget(msg.ids, msg.ts, msg.scope ?? "all");
+    return;
+  }
+
+  if (msg.kind === "hide") {
+    // A mixed cascade (real rows flagged, stubs/foreign rows deleted) rides
+    // ONE message, so the deletions are applied here rather than as a separate
+    // forget broadcast — see gestureBridge.ts.
+    if (msg.forget?.length) forget(msg.forget, msg.ts);
+    const field = msg.mode === "kill" ? "inbox_dismissed_at" : "inbox_stashed_at";
+    for (const sid of msg.ids) {
+      const sess = draft.sessions[sid];
+      if (sess) {
+        if (notNewer(sess[field], msg.ts)) write("sessions", sid, field, msg.ts);
+        // Kill MOVES the row to the Killed bucket: the buckets are exclusive
+        // and a killed session can't stay pinned. Mirrors hideSessionInDraft.
+        if (msg.mode === "kill") {
+          if (sess.inbox_stashed_at && notNewer(sess.inbox_stashed_at, msg.ts)) {
+            write("sessions", sid, "inbox_stashed_at", null);
+          }
+          if ((sess.is_pinned || sess.inbox_pinned_at != null) && notNewer(sess.inbox_pinned_at, msg.ts)) {
+            write("sessions", sid, "is_pinned", false);
+            write("sessions", sid, "inbox_pinned_at", null);
+          }
+        }
+      }
+      const conv = draft.conversations[sid];
+      if (conv) {
+        if (notNewer(conv[field], msg.ts)) write("conversations", sid, field, msg.ts);
+        if (msg.mode === "kill") {
+          if (conv.inbox_stashed_at && notNewer(conv.inbox_stashed_at, msg.ts)) {
+            write("conversations", sid, "inbox_stashed_at", null);
+          }
+          if (conv.inbox_pinned_at != null && notNewer(conv.inbox_pinned_at, msg.ts)) {
+            write("conversations", sid, "inbox_pinned_at", null);
+          }
+        }
+      }
+    }
+    return;
+  }
+
+  if (msg.kind === "restore") {
+    // Un-hiding is un-hiding: both flags clear, but only if this window's value
+    // is no newer than the restore (a re-kill here must survive).
+    for (const sid of msg.ids) {
+      const sess = draft.sessions[sid];
+      if (sess) {
+        if (sess.inbox_dismissed_at != null && notNewer(sess.inbox_dismissed_at, msg.ts)) {
+          write("sessions", sid, "inbox_dismissed_at", null);
+        }
+        if (sess.inbox_stashed_at != null && notNewer(sess.inbox_stashed_at, msg.ts)) {
+          write("sessions", sid, "inbox_stashed_at", null);
+        }
+      }
+      const conv = draft.conversations[sid];
+      if (conv) {
+        if (conv.inbox_dismissed_at != null && notNewer(conv.inbox_dismissed_at, msg.ts)) {
+          write("conversations", sid, "inbox_dismissed_at", null);
+        }
+        if (conv.inbox_stashed_at != null && notNewer(conv.inbox_stashed_at, msg.ts)) {
+          write("conversations", sid, "inbox_stashed_at", null);
+        }
+      }
+    }
+    return;
+  }
+
+  if (msg.kind === "fields") {
+    // Verbatim mirror of a patchConversation gesture. patchConversation
+    // Object.assigns the same fields onto BOTH twins, so both get them here.
+    // The hide/pin fields are all timestamps or a boolean paired with one, so
+    // the ordering guard keys off the row's current pin/hide stamp.
+    for (const [field, value] of Object.entries(msg.fields)) {
+      const stampField = field === "is_pinned" ? "inbox_pinned_at" : field;
+      for (const coll of ["sessions", "conversations"] as const) {
+        const row = draft[coll][msg.id];
+        if (!row) continue;
+        if (!notNewer(row[stampField], msg.ts)) continue;
+        if (row[field] === value) continue;
+        write(coll, msg.id, field, value);
+      }
+    }
+    return;
+  }
+
+  // pin — `pinnedAt` is the sender's exact written value (see gestureBridge.ts:
+  // undo restores the ORIGINAL pin time, so it cannot be re-derived from ts).
+  // Already-matching rows are left untouched so a duplicate message produces no
+  // patch, and therefore no IDB write.
+  const sess = draft.sessions[msg.id];
+  if (sess && !!sess.is_pinned !== msg.pinned && notNewer(sess.inbox_pinned_at, msg.ts)) {
+    write("sessions", msg.id, "is_pinned", msg.pinned);
+    write("sessions", msg.id, "inbox_pinned_at", msg.pinnedAt);
+  }
+  const conv = draft.conversations[msg.id];
+  if (conv && (conv.inbox_pinned_at != null) !== msg.pinned && notNewer(conv.inbox_pinned_at, msg.ts)) {
+    write("conversations", msg.id, "inbox_pinned_at", msg.pinnedAt);
+    if (msg.pinned) write("conversations", msg.id, "inbox_killed_at", undefined);
+  }
 }
 
 export const useInboxStore = create<InboxStoreState>(
@@ -4121,7 +4379,7 @@ export const useInboxStore = create<InboxStoreState>(
   // Stash = set aside WITHOUT killing (Stashed bucket, agent keeps running).
   stashSession: action(function (this: Draft, id: string) {
     soundDismiss();
-    hideSessionInDraft(this, id, "stash");
+    announceHide(this, "stash", hideSessionInDraft(this, id, "stash"));
   }),
 
   // Kill = done with it. The server tears the agent down on the hide data
@@ -4131,7 +4389,7 @@ export const useInboxStore = create<InboxStoreState>(
   // historical name inbox_dismissed_at; the UI calls the bucket "Killed".)
   killSession: action(function (this: Draft, id: string) {
     soundKill();
-    hideSessionInDraft(this, id, "kill");
+    announceHide(this, "kill", hideSessionInDraft(this, id, "kill"));
   }),
 
   // Bulk kill ("Kill all" on the Stashed bucket): one action so the patches
@@ -4142,7 +4400,19 @@ export const useInboxStore = create<InboxStoreState>(
   killSessions: action(function (this: Draft, ids: string[]) {
     if (ids.length === 0) return;
     soundKill();
-    for (const id of ids) hideSessionInDraft(this, id, "kill");
+    // "Kill all" is ONE user gesture: one timestamp for every row it stamps and
+    // for the single merged broadcast (the sound plays once for the same reason).
+    // Per-row Date.now() drifts across a long sweep, so the message's timestamp
+    // matched only the last row — every sibling lock planted for an earlier row
+    // held a value the server would never echo, and so would never retire.
+    const now = Date.now();
+    const merged = { hidden: [] as string[], forgotten: [] as string[], ts: now };
+    for (const id of ids) {
+      const r = hideSessionInDraft(this, id, "kill", now);
+      merged.hidden.push(...r.hidden);
+      merged.forgotten.push(...r.forgotten);
+    }
+    announceHide(this, "kill", merged);
   }),
 
   // Bulk-dismiss a precomputed set of sessions locally (instant, optimistic). A
@@ -4153,12 +4423,28 @@ export const useInboxStore = create<InboxStoreState>(
   // rows. Used by the "dismiss old sessions" inbox prompt.
   markSessionsDismissed: sync(function (this: Draft, ids: string[]) {
     const now = Date.now();
+    const stamped: string[] = [];
     for (const id of ids) {
       const sess = this.sessions[id];
-      if (sess && !sess.inbox_dismissed_at) sess.inbox_dismissed_at = now;
+      if (sess && !sess.inbox_dismissed_at) {
+        sess.inbox_dismissed_at = now;
+        stamped.push(id);
+      }
       if (this.conversations[id] && !(this.conversations[id] as any).inbox_dismissed_at) {
         (this.conversations[id] as any).inbox_dismissed_at = now;
       }
+    }
+    // The bulk sweep is the highest-volume dismissal path there is, and every
+    // row it stamps is one a sibling window would otherwise re-put un-dismissed
+    // — dozens of sessions climbing back into the inbox at once. One message
+    // for the whole sweep, carrying only the ids actually stamped.
+    //
+    // mode:"kill" is the shape (it writes inbox_dismissed_at). The receiver's
+    // kill also clears stash/pin, which this action doesn't — a no-op in
+    // practice, since the caller's stale set already excludes hidden and pinned
+    // rows, and the receiver's ts guard protects a sibling's newer pin anyway.
+    if (stamped.length) {
+      broadcastGesture({ kind: "hide", mode: "kill", ids: stamped, ts: now }, bridgeUserId(this));
     }
   }),
 
@@ -4207,10 +4493,19 @@ export const useInboxStore = create<InboxStoreState>(
   // manually (only action() auto-plants).
   pruneGhostSessions: sync(function (this: Draft, ids: string[]) {
     const now = Date.now();
+    const removed: string[] = [];
     for (const id of ids) {
+      // Nothing here to remove → do nothing at all. Callers re-fire on ids they
+      // already pruned (ConversationView's 3s retry, ComposeView's unmount), and
+      // acting on an absent row is pure downside: the excludes are STICKY, so
+      // planting them for a row this window never held blinds it if that id ever
+      // arrives on a later crawl, and the broadcast would order sibling windows
+      // to drop a row on evidence this window doesn't have.
+      if (!(id in this.sessions) && !(id in this.conversations)) continue;
       if (this.currentSessionId === id) continue;
       if (this.pendingMessages[id]?.length) continue;
       if (id in this.pendingSessionCreates) continue;
+      removed.push(id);
       delete this.sessions[id];
       delete this.conversations[id];
       delete this.messages[id];
@@ -4219,6 +4514,18 @@ export const useInboxStore = create<InboxStoreState>(
       this.pending[`sessions:${id}`] = { type: "exclude", ts: now };
       this.pending[`conversations:${id}`] = { type: "exclude", ts: now };
     }
+    // A sibling window still holding the ghost in memory would re-put the whole
+    // row and resurrect it (see gestureBridge.ts). Only the ids actually removed
+    // are announced — the guards above are per-window.
+    if (removed.length) broadcastGesture({ kind: "forget", ids: removed, ts: now }, bridgeUserId(this));
+  }),
+
+  // Apply a gesture a sibling window performed (cross-window gesture bridge).
+  // sync(): purely local convergence — the acting window already dispatched the
+  // single server write, so this must never dispatch or enqueue an outbox entry.
+  // Mechanics and guards in applyGestureInDraft.
+  applyGestureBridge: sync(function (this: Draft, msg: GestureMessage) {
+    applyGestureInDraft(this, msg);
   }),
 
   // Change-feed prune: the entity is gone or no longer visible to this user, so
@@ -4334,6 +4641,7 @@ export const useInboxStore = create<InboxStoreState>(
   // Bring a stashed/dismissed session (and its hidden children) back into the
   // active inbox. Clears BOTH hide flags — un-hiding is un-hiding.
   restoreSession: action(function (this: Draft, id: string) {
+    const now = Date.now();
     const childIds = Object.values(this.sessions as Record<string, InboxSession>)
       .filter((s) => isSessionHidden(s) && s.parent_conversation_id === id)
       .map((s) => s._id);
@@ -4353,6 +4661,9 @@ export const useInboxStore = create<InboxStoreState>(
     this.currentSessionId = id;
     this.viewingDismissedId = null;
     recordCurrentConversationPointer(this, id);
+    // Sibling windows converge on the same clear (gestureBridge.ts) — but only
+    // the flags: the view move above is this window's alone.
+    broadcastGesture({ kind: "restore", ids: allIds, ts: now }, bridgeUserId(this));
   }),
 
   deferSession: action(function (this: Draft, id: string) {
@@ -4369,7 +4680,8 @@ export const useInboxStore = create<InboxStoreState>(
 
   pinSession: action(function (this: Draft, id: string) {
     const newPinned = !this.sessions[id]?.is_pinned;
-    const pinnedAt = newPinned ? Date.now() : null;
+    const now = Date.now();
+    const pinnedAt = newPinned ? now : null;
     if (this.sessions[id]) {
       this.sessions[id].is_pinned = newPinned;
       this.sessions[id].inbox_pinned_at = pinnedAt;
@@ -4378,6 +4690,11 @@ export const useInboxStore = create<InboxStoreState>(
       (this.conversations[id] as any).inbox_pinned_at = pinnedAt;
       if (newPinned) (this.conversations[id] as any).inbox_killed_at = undefined;
     }
+    // Pin is a TOGGLE read off this window's row, so a sibling that never saw
+    // the flip computes the opposite value from its stale row on the next
+    // toggle (and its whole-row put un-pins what the user just pinned). The
+    // broadcast therefore carries the RESOLVED value, not "toggle".
+    broadcastGesture({ kind: "pin", id, pinned: newPinned, pinnedAt, ts: now }, bridgeUserId(this));
   }),
 
   renameSession: action(function (this: Draft, id: string, title: string) {
@@ -4411,6 +4728,17 @@ export const useInboxStore = create<InboxStoreState>(
     if (this.sessions[id]) Object.assign(this.sessions[id], fields);
     if (!this.conversations[id]) this.conversations[id] = { _id: id } as any;
     Object.assign(this.conversations[id], fields);
+    // Both of this action's real callers are USER GESTURES on the /sessions
+    // surface, and both write the bridged hide/pin fields: handleTogglePin
+    // sends { inbox_pinned_at }, handleToggleDismiss sends { inbox_stashed_at }
+    // or { inbox_dismissed_at: null, inbox_stashed_at: null }. A hidden row
+    // drops out of listInboxSessions, so a sibling inbox window can never learn
+    // about them through the live channel either — its next whole-row put would
+    // strip the flag in shared IDB and the session would climb back out of
+    // Stashed. Announce the exact subset written; a patch touching none of the
+    // four (rename, project switch, …) broadcasts nothing.
+    const bridged = pickBridgedFields(fields);
+    if (bridged) broadcastGesture({ kind: "fields", id, fields: bridged, ts: Date.now() }, bridgeUserId(this));
   }),
 
   // Rekey-only durable server flush. Stub writes are protected locally but
@@ -5390,6 +5718,11 @@ export const useInboxStore = create<InboxStoreState>(
       newSessionId = next?._id ?? null;
     }
     delete this.sessions[id];
+    // Killing an already-dismissed session HARD-REMOVES its inbox row, so a
+    // sibling window still holding that row would re-put it and the killed card
+    // would come back (gestureBridge.ts). Scoped to the session row because
+    // that is all this action drops — the conversation stays cached.
+    broadcastGesture({ kind: "forget", ids: [id], scope: "session-row", ts: Date.now() }, bridgeUserId(this));
     declareViewNav("gesture");
     this.currentSessionId = newSessionId;
     recordCurrentConversationPointer(this, newSessionId ?? undefined);

--- a/packages/web/store/inboxStore.ts
+++ b/packages/web/store/inboxStore.ts
@@ -3716,6 +3716,27 @@ function applyHiddenReconcileInDraft(
 ) {
   const server = new Map<string, number | null>();
   for (const e of entries) server.set(e._id, e[field] ?? null);
+  // A bridge hide stamps its visible hide field with the SAME timestamp used
+  // for every coupled pending lock. Hidden rows never return through normal
+  // sessions sync, so this lightweight hidden-set row is the only production
+  // acknowledgement those pin/no-op locks can receive. Match the explicit
+  // hide acknowledgement anchor rather than lock `ts`: the acting window's
+  // auto-pending freshness clock can be sampled after its hide value. An older
+  // or otherwise stale hidden result must leave every lock intact.
+  const retireAcknowledgedHide = (id: string, ts: number) => {
+    const anchors = ["sessions", "conversations"].map((coll) => draft.pending[`${coll}:${id}:${field}`]);
+    const matches = anchors.some((entry: any) =>
+      entry?.type === "field" && entry.hideAck === ts,
+    );
+    if (!matches) return false;
+    for (const coll of ["sessions", "conversations"]) {
+      for (const coupled of ["inbox_dismissed_at", "inbox_stashed_at", "inbox_pinned_at", "is_pinned"]) {
+        const key = `${coll}:${id}:${coupled}`;
+        if (draft.pending[key]?.type === "field" && draft.pending[key].hideAck === ts) delete draft.pending[key];
+      }
+    }
+    return true;
+  };
   // Locked = a pending field override is still inside its settle window.
   // Stale overrides are released (deleted) so the authoritative set can land.
   const lockedLocal = (id: string) => {
@@ -3730,6 +3751,7 @@ function applyHiddenReconcileInDraft(
   };
 
   for (const [id, ts] of server) {
+    if (ts) retireAcknowledgedHide(id, ts);
     if (!ts || lockedLocal(id)) continue;
     const sess = draft.sessions[id];
     if (sess && sess[field] !== ts) sess[field] = ts;
@@ -3926,12 +3948,23 @@ function announceHide(
 // outbox entry; the acting window owns the single server write.
 //
 // Every write is timestamp-guarded so a late, duplicated, or reordered message
-// can never regress newer local state. `notNewer` treats an absent value as 0:
-// a row that was never hidden always accepts a hide, and a row hidden AFTER the
-// incoming gesture keeps its own newer stamp.
+// can never regress newer local state. An absent visible value counts as 0, but
+// a pending field lock still carries the timestamp of a newer restore/unpin.
 function applyGestureInDraft(draft: any, msg: GestureMessage) {
-  const notNewer = (current: unknown, ts: number) =>
-    typeof current === "number" ? current <= ts : true;
+  const notNewer = (coll: "sessions" | "conversations", id: string, field: string, current: unknown, ts: number) => {
+    const pending = draft.pending[`${coll}:${id}:${field}`];
+    const currentTs = typeof current === "number" ? current : 0;
+    const pendingTs = pending?.type === "field" && typeof pending.ts === "number" ? pending.ts : 0;
+    return Math.max(currentTs, pendingTs) <= ts;
+  };
+  // A bridged gesture changes the session row and its conversation twin as one
+  // transition. Accept only when every extant twin agrees it is not older; a
+  // per-twin decision can otherwise leave one row moved and the other behind.
+  const transitionNotNewer = (id: string, fields: string[], ts: number) =>
+    (["sessions", "conversations"] as const).every((coll) => {
+      const row = draft[coll][id];
+      return !row || fields.every((field) => notNewer(coll, id, field, row[field], ts));
+    });
 
   // Write a field AND plant the pending field lock the sender's action() gets
   // for free from generateAutoPending (mutativeMiddleware). The lock is not
@@ -3951,15 +3984,53 @@ function applyGestureInDraft(draft: any, msg: GestureMessage) {
   // applySyncRecord, applyHiddenReconcileInDraft). They are never dispatched and
   // never enqueued — only action()/asyncAction() reach the outbox.
   //
-  // The planted value must equal what the SENDER dispatched, because the lock
-  // retires only when the server echo matches it (applyFieldOverrides). Every
-  // call below therefore passes a value carried in the message, never one
-  // re-derived here.
-  const write = (coll: "sessions" | "conversations", id: string, field: string, value: any) => {
+  // The planted value must equal the transition's post-state, because the lock
+  // retires only when the server echo matches it (applyFieldOverrides).
+  const write = (
+    coll: "sessions" | "conversations",
+    id: string,
+    field: string,
+    value: any,
+    hideAck?: number,
+  ) => {
     const row = draft[coll][id];
     if (!row) return;
-    row[field] = value;
-    draft.pending[`${coll}:${id}:${field}`] = { type: "field", value, ts: msg.ts };
+    if (row[field] !== value) row[field] = value;
+    draft.pending[`${coll}:${id}:${field}`] = { type: "field", value, ts: msg.ts, ...(hideAck !== undefined ? { hideAck } : {}) };
+  };
+
+  // An accepted gesture is one causal transition, even if every visible value
+  // already matches.  Record fresh locks for all of its constrained fields
+  // before returning to a branch-specific effect.  Otherwise an undo pin that
+  // restores the old pinnedAt payload, for example, leaves an old visible stamp
+  // and lets a delayed hide incorrectly win.
+  const acceptTransition = (
+    id: string,
+    constrained: string[],
+    changes: {
+      shared?: Record<string, any>;
+      sessions?: Record<string, any>;
+      conversations?: Record<string, any>;
+    },
+    hideAck?: number,
+  ) => {
+    if (!transitionNotNewer(id, constrained, msg.ts)) return false;
+    for (const coll of ["sessions", "conversations"] as const) {
+      const row = draft[coll][id];
+      if (!row) continue;
+      const next = {
+        ...changes.shared,
+        ...(changes[coll] ?? {}),
+      };
+      // A coupled field the message does not visibly change still takes part
+      // in its ordering barrier. Lock its retained value at this transition's
+      // timestamp so a delayed coupled gesture cannot cross the barrier.
+      for (const field of constrained) {
+        if (!Object.prototype.hasOwnProperty.call(next, field)) next[field] = row[field];
+      }
+      for (const [field, value] of Object.entries(next)) write(coll, id, field, value, hideAck);
+    }
+    return true;
   };
 
   const forget = (ids: string[], ts: number, scope: "session-row" | "all" = "all") => {
@@ -4008,33 +4079,16 @@ function applyGestureInDraft(draft: any, msg: GestureMessage) {
     if (msg.forget?.length) forget(msg.forget, msg.ts);
     const field = msg.mode === "kill" ? "inbox_dismissed_at" : "inbox_stashed_at";
     for (const sid of msg.ids) {
-      const sess = draft.sessions[sid];
-      if (sess) {
-        if (notNewer(sess[field], msg.ts)) write("sessions", sid, field, msg.ts);
-        // Kill MOVES the row to the Killed bucket: the buckets are exclusive
-        // and a killed session can't stay pinned. Mirrors hideSessionInDraft.
-        if (msg.mode === "kill") {
-          if (sess.inbox_stashed_at && notNewer(sess.inbox_stashed_at, msg.ts)) {
-            write("sessions", sid, "inbox_stashed_at", null);
-          }
-          if ((sess.is_pinned || sess.inbox_pinned_at != null) && notNewer(sess.inbox_pinned_at, msg.ts)) {
-            write("sessions", sid, "is_pinned", false);
-            write("sessions", sid, "inbox_pinned_at", null);
-          }
-        }
-      }
-      const conv = draft.conversations[sid];
-      if (conv) {
-        if (notNewer(conv[field], msg.ts)) write("conversations", sid, field, msg.ts);
-        if (msg.mode === "kill") {
-          if (conv.inbox_stashed_at && notNewer(conv.inbox_stashed_at, msg.ts)) {
-            write("conversations", sid, "inbox_stashed_at", null);
-          }
-          if (conv.inbox_pinned_at != null && notNewer(conv.inbox_pinned_at, msg.ts)) {
-            write("conversations", sid, "inbox_pinned_at", null);
-          }
-        }
-      }
+      if (!acceptTransition(sid, ["inbox_dismissed_at", "inbox_stashed_at", "inbox_pinned_at"], {
+        shared: {
+          [field]: msg.ts,
+          ...(msg.mode === "kill" ? { inbox_stashed_at: null } : {}),
+          inbox_pinned_at: null,
+        },
+        // Both hide modes move the row out of Pinned. Mirrors
+        // hideSessionInDraft, which clears a pre-existing pin for stash too.
+        sessions: { is_pinned: false },
+      }, msg.ts)) continue;
     }
     return;
   }
@@ -4043,24 +4097,11 @@ function applyGestureInDraft(draft: any, msg: GestureMessage) {
     // Un-hiding is un-hiding: both flags clear, but only if this window's value
     // is no newer than the restore (a re-kill here must survive).
     for (const sid of msg.ids) {
-      const sess = draft.sessions[sid];
-      if (sess) {
-        if (sess.inbox_dismissed_at != null && notNewer(sess.inbox_dismissed_at, msg.ts)) {
-          write("sessions", sid, "inbox_dismissed_at", null);
-        }
-        if (sess.inbox_stashed_at != null && notNewer(sess.inbox_stashed_at, msg.ts)) {
-          write("sessions", sid, "inbox_stashed_at", null);
-        }
-      }
-      const conv = draft.conversations[sid];
-      if (conv) {
-        if (conv.inbox_dismissed_at != null && notNewer(conv.inbox_dismissed_at, msg.ts)) {
-          write("conversations", sid, "inbox_dismissed_at", null);
-        }
-        if (conv.inbox_stashed_at != null && notNewer(conv.inbox_stashed_at, msg.ts)) {
-          write("conversations", sid, "inbox_stashed_at", null);
-        }
-      }
+      // A no-op restore still carries a newer causal tombstone. Without these
+      // locks, a delayed older kill sees two visible nulls and re-applies.
+      acceptTransition(sid, ["inbox_dismissed_at", "inbox_stashed_at"], {
+        shared: { inbox_dismissed_at: null, inbox_stashed_at: null },
+      });
     }
     return;
   }
@@ -4068,35 +4109,31 @@ function applyGestureInDraft(draft: any, msg: GestureMessage) {
   if (msg.kind === "fields") {
     // Verbatim mirror of a patchConversation gesture. patchConversation
     // Object.assigns the same fields onto BOTH twins, so both get them here.
-    // The hide/pin fields are all timestamps or a boolean paired with one, so
-    // the ordering guard keys off the row's current pin/hide stamp.
-    for (const [field, value] of Object.entries(msg.fields)) {
-      const stampField = field === "is_pinned" ? "inbox_pinned_at" : field;
-      for (const coll of ["sessions", "conversations"] as const) {
-        const row = draft[coll][msg.id];
-        if (!row) continue;
-        if (!notNewer(row[stampField], msg.ts)) continue;
-        if (row[field] === value) continue;
-        write(coll, msg.id, field, value);
-      }
-    }
+    // A fields message is one causal transition: guard all touched hidden/pin
+    // state before writing any subset, so a delayed partial patch cannot leave
+    // conflicting bucket timestamps behind.
+    const fields = Object.entries(msg.fields);
+    const guardFields = [
+      ...(fields.some(([key]) => key === "inbox_dismissed_at" || key === "inbox_stashed_at")
+        ? ["inbox_dismissed_at", "inbox_stashed_at"]
+        : []),
+      ...(fields.some(([key]) => key === "is_pinned" || key === "inbox_pinned_at")
+        ? ["inbox_pinned_at"]
+        : []),
+    ];
+    acceptTransition(msg.id, guardFields, { shared: Object.fromEntries(fields) });
     return;
   }
 
   // pin — `pinnedAt` is the sender's exact written value (see gestureBridge.ts:
   // undo restores the ORIGINAL pin time, so it cannot be re-derived from ts).
-  // Already-matching rows are left untouched so a duplicate message produces no
-  // patch, and therefore no IDB write.
-  const sess = draft.sessions[msg.id];
-  if (sess && !!sess.is_pinned !== msg.pinned && notNewer(sess.inbox_pinned_at, msg.ts)) {
-    write("sessions", msg.id, "is_pinned", msg.pinned);
-    write("sessions", msg.id, "inbox_pinned_at", msg.pinnedAt);
-  }
-  const conv = draft.conversations[msg.id];
-  if (conv && (conv.inbox_pinned_at != null) !== msg.pinned && notNewer(conv.inbox_pinned_at, msg.ts)) {
-    write("conversations", msg.id, "inbox_pinned_at", msg.pinnedAt);
-    if (msg.pinned) write("conversations", msg.id, "inbox_killed_at", undefined);
-  }
+  // Repeated pin messages leave matching rows untouched; an unpin deliberately
+  // plants a null tombstone even when the row already appears unpinned.
+  acceptTransition(msg.id, ["inbox_pinned_at"], {
+    shared: { inbox_pinned_at: msg.pinnedAt },
+    sessions: { is_pinned: msg.pinned },
+    ...(msg.pinned ? { conversations: { inbox_killed_at: undefined } } : {}),
+  });
 }
 
 export const useInboxStore = create<InboxStoreState>(

--- a/packages/web/store/local-first/__tests__/convergenceMatrix.test.ts
+++ b/packages/web/store/local-first/__tests__/convergenceMatrix.test.ts
@@ -352,10 +352,20 @@ describe("convergence matrix — engine ordering and lifecycle", () => {
       expect(seenB.latest().rows).toEqual([]);
 
       await engineB.reconcileDurableHead();
-      // Republish is asynchronous behind the commit listener.
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      await sessionB.settled();
-      expect(seenB.latest().rows.map((row) => (row.value as Row).body)).toEqual(["from-a"]);
+      // Republish is asynchronous behind the commit listener, and `settled()` can
+      // only await work already in flight — so a single macrotask hop races the
+      // republish on a loaded runner and reads back []. Poll for the publication
+      // instead of assuming one turn is enough; the assertion stays exact.
+      const republishedBodies = async () => {
+        await sessionB.settled();
+        return seenB.latest().rows.map((row) => (row.value as Row).body);
+      };
+      let bodies = await republishedBodies();
+      for (let attempt = 0; attempt < 100 && bodies.length === 0; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        bodies = await republishedBodies();
+      }
+      expect(bodies).toEqual(["from-a"]);
       sessionA.close();
       sessionB.close();
     } finally {

--- a/packages/web/store/machineStamp.test.ts
+++ b/packages/web/store/machineStamp.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 import { useInboxStore } from "./inboxStore";
 
-// The new-session machine row stamps the picked machine on the stub row
-// (setSessionTargetDevice); createSessionFromStub is where that stamp turns into
-// the create's target_device_id — or is deliberately dropped. Dropping matters:
-// an explicit target wins the FIRST rung of convex/deviceRouting, so stamping
-// the machine routing would have chosen anyway silently pins the session ahead
-// of the rung that prefers whichever machine holds the checkout.
+// The new-session machine row stamps the selected machine on the stub row
+// (setSessionTargetDevice); createSessionFromStub is where that stamp becomes the
+// create's target_device_id.
+//
+// This used to second-guess the stamp and DROP it whenever it matched what
+// routing would have picked anyway. That optimization rested on the picker's
+// default being stable, and it wasn't: the default was decided by `last_seen`,
+// which flips between two idle online machines every ~30s. A heartbeat landing
+// between the click and the create could therefore discard an explicit pick and
+// hand the decision back to a server-side recency race. The selection is now
+// deterministic and always carried through.
 
 const REAL_ID = "jx70000000000000000000000000pick"; // 32 chars => isConvexId
 
@@ -46,8 +51,6 @@ function seedStub(targetDeviceId: string | null) {
   } as any);
 }
 
-// desktop holds the checkout, laptop is merely the most recently seen — so
-// routing (and defaultMachineId) resolves "desktop" for /repo.
 const ROSTER = [
   { device_id: "laptop", is_remote: false, online: true, last_seen: 9000, local_project_roots: [] },
   { device_id: "desktop", is_remote: false, online: true, last_seen: 1000, local_project_roots: ["/repo"] },
@@ -71,17 +74,20 @@ describe("createSessionFromStub target_device_id", () => {
     expect(createOpts(calls).target_device_id).toBe("laptop");
   });
 
-  it("drops a pick that has become the machine routing picks anyway", async () => {
+  // THE REGRESSION. "desktop" is also what routing would land on for /repo, and
+  // the old code read that agreement as licence to drop the stamp — reopening the
+  // question at send time, when the roster may have reordered.
+  it("carries a pick that AGREES with routing — agreement is not a reason to drop it", async () => {
     const { calls } = installFakeDispatch();
     seedStub("desktop");
     useInboxStore.setState({ machineRoster: ROSTER } as any);
 
     await useInboxStore.getState().createSessionFromStub(STUB);
 
-    expect(createOpts(calls)).not.toHaveProperty("target_device_id");
+    expect(createOpts(calls).target_device_id).toBe("desktop");
   });
 
-  it("honours the pick when the roster hasn't loaded — an empty roster proves nothing", async () => {
+  it("carries the pick when the roster hasn't loaded", async () => {
     const { calls } = installFakeDispatch();
     seedStub("desktop");
 
@@ -90,29 +96,27 @@ describe("createSessionFromStub target_device_id", () => {
     expect(createOpts(calls).target_device_id).toBe("desktop");
   });
 
-  it("sends no target at all when the user never picked a machine", async () => {
-    const { calls } = installFakeDispatch();
-    seedStub(null);
-    useInboxStore.setState({ machineRoster: ROSTER } as any);
-
-    await useInboxStore.getState().createSessionFromStub(STUB);
-
-    expect(createOpts(calls)).not.toHaveProperty("target_device_id");
-  });
-
-  it("re-checks against the CURRENT project: a folder switch can retire the pick", async () => {
+  it("keeps the pick across a folder switch — the machine row is not the folder row", async () => {
     const { calls } = installFakeDispatch();
     seedStub("laptop");
     useInboxStore.setState({ machineRoster: ROSTER } as any);
-    // The user picked laptop for /repo (which only desktop has), then switched to
-    // a folder only laptop has — routing now lands on laptop on its own.
     useInboxStore.getState().updateSessionProject(STUB, "/laptop-only");
     useInboxStore.setState({
-      machineRoster: [
-        { ...ROSTER[0], local_project_roots: ["/laptop-only"] },
-        ROSTER[1],
-      ],
+      machineRoster: [{ ...ROSTER[0], local_project_roots: ["/laptop-only"] }, ROSTER[1]],
     } as any);
+
+    await useInboxStore.getState().createSessionFromStub(STUB);
+
+    expect(createOpts(calls).target_device_id).toBe("laptop");
+  });
+
+  // Non-picker entry points (cast spawn, triggers, forks, mobile) still create
+  // sessions with no stamp at all, and must keep falling through to the server
+  // ladder — that fallback is what stops a session being left unowned.
+  it("sends no target when there is no selection to carry", async () => {
+    const { calls } = installFakeDispatch();
+    seedStub(null);
+    useInboxStore.setState({ machineRoster: ROSTER } as any);
 
     await useInboxStore.getState().createSessionFromStub(STUB);
 

--- a/packages/web/store/mutativeMiddleware.ts
+++ b/packages/web/store/mutativeMiddleware.ts
@@ -801,6 +801,14 @@ export function mutativeMiddleware(config: any, opts?: {
 
     let draining = false;
     let drainAgain = false;
+    // Whether a drain pass has loaded the outbox and attempted every entry in it
+    // (delivered, re-queued, or given up on). Consumers that must not act on a
+    // PRE-REPLAY view of server state wait on this — the boot-eager hidden-set
+    // crawls, whose CLEAR pass would otherwise un-hide a dismiss still parked here
+    // (see bootEagerArmed in hooks/reconcileCrawl.ts). Stays false while the
+    // outbox is unwired or a drain aborts on a rotated binding; those consumers
+    // bound their own wait rather than blocking forever.
+    let bootOutboxDrained = false;
     async function drainOutbox(countAttempts = true) {
       const captured = dispatchBinding;
       const capturedLoad = outboxLoadFn;
@@ -922,6 +930,10 @@ export function mutativeMiddleware(config: any, opts?: {
             }
           }
         }
+        // Every parked entry has now been attempted — the replay is no longer
+        // racing readers of server state. Set after the loop, so an abort partway
+        // through leaves it false for the successor binding's drain to satisfy.
+        bootOutboxDrained = true;
       } catch (e) {
         // A binding rotated mid-drain (page-load verification rebind, account
         // switch). Every drain call site is fire-and-forget, so letting this
@@ -1258,6 +1270,12 @@ export function mutativeMiddleware(config: any, opts?: {
     // live socket stranded reaches the server WITHOUT waiting for a reload.
     wrapped._drainOutbox = () => { drainOutbox(false); };
 
+    // Whether the durable outbox has been replayed once since load — see
+    // bootOutboxDrained. Polled by the boot-eager hidden-set crawls, which must
+    // not run their un-hide CLEAR pass against a server that hasn't received the
+    // hides still parked here.
+    wrapped._hasBootOutboxDrained = () => bootOutboxDrained;
+
     // Whether a dispatch fired right now would actually reach the server: a
     // binding exists and its captured authorization is still current. A false
     // here is the only visible symptom of a binding stranded by a
@@ -1290,6 +1308,12 @@ export function mutativeMiddleware(config: any, opts?: {
       outboxEnqueueFn = null;
       outboxRemoveFn = null;
       outboxLoadFn = null;
+      // The drained flag described the OUTGOING principal's outbox. The successor
+      // has its own principal-scoped rows and has replayed none of them, so
+      // carrying the flag across would tell the boot-eager hidden-set crawls the
+      // replay already happened and let them read the server before the new
+      // account's parked hides ship — the exact race the flag exists to prevent.
+      bootOutboxDrained = false;
       // Receipt waiters intentionally survive a runtime/auth rebind. Their
       // random entry ids can resolve only when that exact principal-scoped
       // outbox row drains again; another account cannot present the row. This

--- a/packages/web/store/mutativeMiddleware.ts
+++ b/packages/web/store/mutativeMiddleware.ts
@@ -195,6 +195,21 @@ function generateAutoPending(
 ): Record<string, any> | null {
   let result: Record<string, any> | null = null;
   const now = Date.now();
+  // The hide value is the server acknowledgement identity; `now` below is
+  // merely this middleware pass's freshness stamp and need not equal it.
+  const hideAcks = new Map<string, number>();
+  for (const patch of patches) {
+    const path = patch.path as (string | number)[];
+    if (path.length < 3) continue;
+    const storeKey = String(path[0]);
+    const field = String(path[2]);
+    if (
+      !isProtectedSyncCollection(storeKey) ||
+      (field !== "inbox_dismissed_at" && field !== "inbox_stashed_at") ||
+      typeof patch.value !== "number"
+    ) continue;
+    hideAcks.set(`${storeKey}:${String(path[1])}`, patch.value);
+  }
 
   for (const patch of patches) {
     const path = patch.path as (string | number)[];
@@ -223,6 +238,7 @@ function generateAutoPending(
         type: "field",
         value: patch.value,
         ts: now,
+        ...(hideAcks.has(`${storeKey}:${recordId}`) ? { hideAck: hideAcks.get(`${storeKey}:${recordId}`)! } : {}),
       };
     }
   }
@@ -801,14 +817,25 @@ export function mutativeMiddleware(config: any, opts?: {
 
     let draining = false;
     let drainAgain = false;
-    // Whether a drain pass has loaded the outbox and attempted every entry in it
-    // (delivered, re-queued, or given up on). Consumers that must not act on a
-    // PRE-REPLAY view of server state wait on this — the boot-eager hidden-set
-    // crawls, whose CLEAR pass would otherwise un-hide a dismiss still parked here
-    // (see bootEagerArmed in hooks/reconcileCrawl.ts). Stays false while the
-    // outbox is unwired or a drain aborts on a rotated binding; those consumers
-    // bound their own wait rather than blocking forever.
+    // Consumers that must not act on a PRE-REPLAY view of server state wait for a
+    // verified-empty durable outbox. A failed/re-queued entry is still a pending
+    // server write, so merely attempting it cannot open this gate.
     let bootOutboxDrained = false;
+    let outboxGeneration = 0;
+    let pendingOutboxEnqueues = 0;
+    const markOutboxDirty = () => {
+      bootOutboxDrained = false;
+      outboxGeneration++;
+    };
+    const enqueueOutbox = async (enqueue: OutboxEnqueueFn, entry: OutboxEntry) => {
+      markOutboxDirty();
+      pendingOutboxEnqueues++;
+      try {
+        await enqueue(entry);
+      } finally {
+        pendingOutboxEnqueues--;
+      }
+    };
     async function drainOutbox(countAttempts = true) {
       const captured = dispatchBinding;
       const capturedLoad = outboxLoadFn;
@@ -827,6 +854,7 @@ export function mutativeMiddleware(config: any, opts?: {
       }
       draining = true;
       try {
+        const drainGeneration = outboxGeneration;
         const entries = await capturedLoad();
         assertDispatchCurrent(captured);
         // The outbox exists to survive a reload that lands in the middle of an
@@ -910,7 +938,7 @@ export function mutativeMiddleware(config: any, opts?: {
               if (!countAttempts) continue;
               const disposition = outboxFailureDisposition(entry);
               assertDispatchCurrent(captured);
-              await capturedEnqueue?.(disposition.entry);
+              if (capturedEnqueue) await enqueueOutbox(capturedEnqueue, disposition.entry);
               continue;
             }
             // Legacy non-receipt actions still treat a permanent refusal as
@@ -923,17 +951,22 @@ export function mutativeMiddleware(config: any, opts?: {
             if (!countAttempts) continue;
             const disposition = outboxFailureDisposition(entry);
             assertDispatchCurrent(captured);
-            if (disposition.keep) await capturedEnqueue?.(disposition.entry);
-            else {
+            if (disposition.keep) {
+              if (capturedEnqueue) await enqueueOutbox(capturedEnqueue, disposition.entry);
+            } else {
               rejectReceiptWaiter(entry.id, e);
               await capturedRemove?.(entry.id);
             }
           }
         }
-        // Every parked entry has now been attempted — the replay is no longer
-        // racing readers of server state. Set after the loop, so an abort partway
-        // through leaves it false for the successor binding's drain to satisfy.
-        bootOutboxDrained = true;
+        // Verify the durable queue after every mutation. The initial snapshot is
+        // not sufficient: a failed entry can be re-queued, and a new action can
+        // begin enqueueing while this drain is in flight.
+        const remaining = await capturedLoad();
+        assertDispatchCurrent(captured);
+        bootOutboxDrained = remaining.length === 0 &&
+          pendingOutboxEnqueues === 0 &&
+          drainGeneration === outboxGeneration;
       } catch (e) {
         // A binding rotated mid-drain (page-load verification rebind, account
         // switch). Every drain call site is fire-and-forget, so letting this
@@ -1069,7 +1102,7 @@ export function mutativeMiddleware(config: any, opts?: {
           // the binding while the page stays interactive, and an un-parked
           // action fired in that window would vanish with zero trace.
           const enqueued = outboxEnqueueFn
-            ? Promise.resolve(outboxEnqueueFn(entry)).then(() => {
+            ? enqueueOutbox(outboxEnqueueFn, entry).then(() => {
                 enqueueCompleted = true;
               })
             : null;
@@ -1132,6 +1165,7 @@ export function mutativeMiddleware(config: any, opts?: {
                 // deduplicated command for a later replay.
                 if (completed) {
                   await capturedRemove?.(outboxId);
+                  void drainOutbox(false);
                 }
               }, async (error) => {
                 let current = true;
@@ -1171,13 +1205,17 @@ export function mutativeMiddleware(config: any, opts?: {
             const promise = dispatched.then(async (r) => {
               assertDispatchCurrent(capturedDispatch);
               await capturedRemove?.(outboxId);
+              void drainOutbox(false);
               return r;
             }, async (e) => {
               if (e instanceof StaleDispatchBindingError) throw e;
               assertDispatchCurrent(capturedDispatch);
               // Permanent rejection: the server answered and said no — remove
               // the parked copy so the drain loops don't re-litigate it forever.
-              if (isPermanentDispatchError(e)) await capturedRemove?.(outboxId);
+              if (isPermanentDispatchError(e)) {
+                await capturedRemove?.(outboxId);
+                void drainOutbox(false);
+              }
               throw e;
             });
             if (returnsPromise) return promise;
@@ -1256,7 +1294,10 @@ export function mutativeMiddleware(config: any, opts?: {
         ? { epoch: dispatchEpoch, fn, owner: options?.owner, authorization: options?.authorization }
         : null;
       // Drain any persisted outbox entries from a prior session.
-      if (fn) drainOutbox();
+      if (fn) {
+        markOutboxDirty();
+        void drainOutbox();
+      }
     };
 
     wrapped._clearDispatch = (owner: object) => {
@@ -1299,6 +1340,7 @@ export function mutativeMiddleware(config: any, opts?: {
       outboxEnqueueFn = enqueue;
       outboxRemoveFn = remove;
       outboxLoadFn = load;
+      markOutboxDirty();
     };
 
     wrapped._clearRuntimeBindings = () => {

--- a/packages/web/store/syncProtocol.ts
+++ b/packages/web/store/syncProtocol.ts
@@ -2,7 +2,27 @@ export type PendingEntry = {
   type: "exclude" | "include" | "field";
   value?: any;
   ts?: number;
+  // Exact hidden timestamp expected from a dismiss/stash reconcile. This is
+  // intentionally distinct from `ts`, which is only the local lock freshness
+  // clock and may be sampled a millisecond later by the middleware.
+  hideAck?: number;
 };
+
+// Convex omits optional conversation inbox timestamps when they are clear,
+// while optimistic bridge transitions retain the local `null` spelling.  That
+// is the same server acknowledgement for these three fields only; all other
+// fields keep strict null/undefined semantics.
+const OPTIONAL_INBOX_TIMESTAMPS = new Set([
+  "inbox_dismissed_at",
+  "inbox_stashed_at",
+  "inbox_pinned_at",
+]);
+
+function fieldEchoesPending(field: string, incoming: unknown, pending: unknown): boolean {
+  return incoming === pending || (
+    OPTIONAL_INBOX_TIMESTAMPS.has(field) && incoming == null && pending == null
+  );
+}
 
 /**
  * Local-first sync: pending entries represent local mutations waiting for
@@ -125,7 +145,7 @@ export function applySyncTable<T extends { _id: string }>(
     if (!overrides) return record;
     let merged = record;
     for (const { key, field, entry } of overrides) {
-      if ((record as any)[field] === entry.value) {
+      if (fieldEchoesPending(field, (record as any)[field], entry.value)) {
         delete newPending[key];
       } else {
         if (merged === record) merged = { ...record };
@@ -238,7 +258,7 @@ export function applySyncRecord(
   for (const [key, entry] of Object.entries(newPending)) {
     if (entry.type !== "field" || !key.startsWith(fieldPrefix)) continue;
     const field = key.slice(fieldPrefix.length);
-    if (incoming[field] === entry.value) {
+    if (fieldEchoesPending(field, incoming[field], entry.value)) {
       delete newPending[key];
     } else {
       if (merged === incoming) merged = { ...incoming };

--- a/packages/web/store/undoActions.ts
+++ b/packages/web/store/undoActions.ts
@@ -1,9 +1,11 @@
-import { useInboxStore, type InboxSession, type ConversationMeta } from "./inboxStore";
+import { bridgeUserId, useInboxStore, type InboxSession, type ConversationMeta } from "./inboxStore";
+import { broadcastGesture } from "./gestureBridge";
 import { pushUndo, showUndoToast } from "./undoStack";
 import { declareViewNav } from "./viewNav";
 
 /** Mark a session card to play the enter animation after it appears in the DOM. */
 export function animateSessionEnter(id: string) {
+  if (typeof document === "undefined") return;
   // Use setTimeout with escalating delays to wait for React to commit the render
   const delays = [0, 20, 50, 100, 200];
   const tryApply = (attempt: number) => {
@@ -124,18 +126,33 @@ export function undoableHideSession(id: string, mode: HideSessionMode) {
       animateSessionEnter(id);
       // Push the SNAPSHOT flags, not blanket nulls: undoing a dismiss of a
       // session that was stashed at the time must land it back in Stashed.
+      const restoredFlags = Object.fromEntries(
+        snap.allIds.map((sid) => {
+          const prev = snap.sessions[sid] ?? (snap.conversations[sid] as any);
+          return [sid, {
+            inbox_dismissed_at: prev?.inbox_dismissed_at ?? null,
+            inbox_stashed_at: prev?.inbox_stashed_at ?? null,
+          }];
+        })
+      );
       store.applyUndoPatches({
-        conversations: Object.fromEntries(
-          snap.allIds.map((sid) => {
-            const prev = snap.sessions[sid] ?? (snap.conversations[sid] as any);
-            return [sid, {
-              inbox_dismissed_at: prev?.inbox_dismissed_at ?? null,
-              inbox_stashed_at: prev?.inbox_stashed_at ?? null,
-            }];
-          })
-        ),
+        conversations: restoredFlags,
         client_state: { _: { current_conversation_id: snap.currentSessionId } },
       });
+      // killSession/stashSession announced the hide, so siblings now hold the
+      // HIDDEN row; an un-announced undo leaves it there and that stale row
+      // re-puts the undone hide into shared IDB, resurrecting it. A "fields"
+      // message per id rather than a "restore": the snapshot is not always all
+      // null (undoing a kill of a row that was stashed must land it back in
+      // Stashed), so each id carries its own verbatim values — the same ones
+      // applyUndoPatches dispatches, which is what lets the receiver's field
+      // lock retire on the server echo. ONE timestamp for the whole gesture, so
+      // the sibling's locks all key off the single undo. redo() re-hides
+      // through kill/stashSession, which broadcast on their own.
+      const ts = Date.now();
+      for (const [sid, fields] of Object.entries(restoredFlags)) {
+        broadcastGesture({ kind: "fields", id: sid, fields, ts }, bridgeUserId(store));
+      }
       // Schedules the kill canceled come back with the session: the patch above
       // clears inbox_dismissed_at, and the server's un-hide transition
       // (dispatch.applyPatches) re-arms the stamped tasks authoritatively.
@@ -224,6 +241,17 @@ export function undoablePinSession(id: string) {
       store.applyUndoPatches({
         conversations: { [id]: { inbox_pinned_at: prevPinnedAt } },
       });
+      // pinSession broadcast the flip, so a sibling now holds the PINNED row;
+      // undoing without announcing leaves it there, and that stale row both
+      // re-puts the undone pin into shared IDB and inverts the sibling's next
+      // toggle (`!is_pinned` reads the value we just reverted). Carry the exact
+      // restored inbox_pinned_at — the receiver's pending lock retires only
+      // when the server echo matches it, and applyUndoPatches dispatches this
+      // same value. redo() calls pinSession, which broadcasts on its own.
+      broadcastGesture(
+        { kind: "pin", id, pinned: !!wasPinned, pinnedAt: prevPinnedAt, ts: Date.now() },
+        bridgeUserId(store),
+      );
     },
     redo: () => {
       useInboxStore.getState().pinSession(id);


### PR DESCRIPTION
## Summary

- persist and reconcile inbox dismiss/stash gestures across reloads, accounts, devices, and windows
- make agent launch PATH reliable under launchd and link spawned CLI sessions to their parent transcripts
- make machine selection deterministic and preserve a single stamped/scoped device through roster reconnects

## Validation

- independent integration checker: **RELEASE PASS** on `2ada18bf`
- repo typecheck: pass (CLI, web, Convex)
- web: 1781 pass, 8 skip, 0 fail
- Convex: 1047 pass, 0 fail
- focused release regressions: 539 pass, 0 fail
- production Vite/PWA build and precompression: pass
- CLI focused changed files: 62 pass, 0 fail
- CLI full suite: 1774 pass, 2 skip; two slow environment tests time out (`daemon.inject-clear`, `statusHook`). The tmux failure reproduces on clean `origin/main`; status-hook timeout is a documented pre-existing 5s flake.
- CLI JS bundle and standalone binary build: pass

## Release gate

Draft until the machine picker is smoke-tested in an authenticated browser. Claude-in-Chrome is currently disconnected in the release session.

## Bounded limitation

Native OpenCode task children link through DB `parent_id`. Arbitrary external agents launched from an OpenCode TUI cannot be ancestry-linked because the shared SQLite handle does not identify the active OpenCode session.
