### PR TITLE
Fix session-teardown lifecycle: kills that stick, panes where they belong

### DIFF
--- a/packages/cli/src/daemon.session-teardown.test.ts
+++ b/packages/cli/src/daemon.session-teardown.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, test } from "bun:test";
 import {
+  askUserQuestionStillPending,
+  clearSessionTrackingForKill,
+  conversationForbidsResurrection,
   danglingUserTurnIsReapable,
+  derivedPaneNamesForConversation,
   isConversationRetired,
   parseReapCandidateRow,
   reapSkipBucket,
+  registerManagedStartedSession,
   resumeOwnerVerdict,
+  sessionKillTrackingSnapshot,
   stampedPaneReapEligibility,
   summarizeReapSkips,
+  tmuxSessionIsSinglePane,
   transcriptTailLastRealTimestamp,
 } from "./daemon.js";
+import { isMissingFunctionError, shouldProbeLifecycleQuery } from "./syncService.js";
 import type { ConversationLifecycle } from "./syncService.js";
+
+// Shorthands for the two provenances getConversationLifecycle can return. The
+// distinction is load-bearing: "status-fallback" resolves by session id via
+// `.first()` (the OLDEST twin, ct-36973) and carries no hide state at all.
+const authoritative = (over: Partial<ConversationLifecycle> = {}): ConversationLifecycle =>
+  ({ status: "active", hideStateKnown: true, source: "lifecycle", ...over });
+const degraded = (over: Partial<ConversationLifecycle> = {}): ConversationLifecycle =>
+  ({ status: "active", hideStateKnown: false, source: "status-fallback", ...over });
+const TRUSTING = { trustStatusFallback: true };   // heartbeat reconstitution only
+const STRICT = { trustStatusFallback: false };    // every other resurrection path
 
 // The three lifecycle defects confirmed on 2026-08-03, each reduced to the pure
 // decision the daemon now makes before it acts:
@@ -21,28 +39,68 @@ import type { ConversationLifecycle } from "./syncService.js";
 describe("isConversationRetired", () => {
   test("a killed conversation must never be reconstituted", () => {
     // The exact incident shape: status=completed with inbox_killed_at stamped.
-    expect(isConversationRetired({ status: "completed", inboxKilledAt: 1_700_000_000_000 })).toBe(true);
+    expect(isConversationRetired(authoritative({ status: "completed", inboxKilledAt: 1_700_000_000_000 }), STRICT)).toBe(true);
   });
 
   test("either signal alone is enough", () => {
     // killSession only sets status=completed when mark_completed is passed, so
     // inbox_killed_at can stand alone — and a conversation completed by any other
     // path is equally finished.
-    expect(isConversationRetired({ status: "active", inboxKilledAt: 1 })).toBe(true);
-    expect(isConversationRetired({ status: "completed" })).toBe(true);
+    expect(isConversationRetired(authoritative({ inboxKilledAt: 1 }), STRICT)).toBe(true);
+    expect(isConversationRetired(authoritative({ status: "completed" }), STRICT)).toBe(true);
   });
 
   test("a live conversation still reconstitutes (the crash-recovery case)", () => {
-    expect(isConversationRetired({ status: "active" })).toBe(false);
-    expect(isConversationRetired({ status: "active", inboxKilledAt: null })).toBe(false);
+    expect(isConversationRetired(authoritative(), STRICT)).toBe(false);
+    expect(isConversationRetired(authoritative({ inboxKilledAt: null }), STRICT)).toBe(false);
     // Hidden from the inbox is NOT retired: a stashed/dismissed agent keeps running.
-    expect(isConversationRetired({ status: "active", inboxStashedAt: 1, inboxDismissedAt: 1 })).toBe(false);
+    expect(isConversationRetired(authoritative({ inboxStashedAt: 1, inboxDismissedAt: 1 }), STRICT)).toBe(false);
   });
 
   test("unknown lifecycle fails OPEN — a Convex blip can't strand a live session", () => {
-    expect(isConversationRetired(null)).toBe(false);
-    expect(isConversationRetired(undefined)).toBe(false);
-    expect(isConversationRetired({})).toBe(false);
+    expect(isConversationRetired(null, STRICT)).toBe(false);
+    expect(isConversationRetired(undefined, STRICT)).toBe(false);
+    expect(isConversationRetired(null, TRUSTING)).toBe(false);
+  });
+
+  // The degraded signal resolves by session id through `.first()` — the OLDEST
+  // twin. A wrong "completed" from it would refuse to resume a LIVE session, so
+  // only the caller that can absorb a wrong refusal is allowed to act on it.
+  test("the status-only fallback is ignored by every path but heartbeat reconstitution", () => {
+    const killedLooking = degraded({ status: "completed" });
+    expect(isConversationRetired(killedLooking, STRICT)).toBe(false);   // delivery / warm pool / repair
+    expect(isConversationRetired(killedLooking, TRUSTING)).toBe(true);  // handleDeadSession
+  });
+
+  test("trust does not invent a verdict — a live-looking fallback still allows resume", () => {
+    expect(isConversationRetired(degraded({ status: "active" }), TRUSTING)).toBe(false);
+  });
+});
+
+// The gate as WIRED, not just its pure core: the .catch that must swallow a
+// lookup failure into "not retired". A throwing Convex client here would
+// otherwise take down every resume path at once.
+describe("conversationForbidsResurrection (wired)", () => {
+  test("fails OPEN when the lifecycle lookup throws", async () => {
+    const boom = () => Promise.reject(new Error("connect ECONNREFUSED"));
+    expect(await conversationForbidsResurrection("conv1", "sess1", "TEST", STRICT, boom)).toBe(false);
+    expect(await conversationForbidsResurrection("conv1", "sess1", "TEST", TRUSTING, boom)).toBe(false);
+  });
+
+  test("fails OPEN when the lookup resolves null (unknown row)", async () => {
+    const none = () => Promise.resolve(null);
+    expect(await conversationForbidsResurrection("conv1", "sess1", "TEST", STRICT, none)).toBe(false);
+  });
+
+  test("blocks on an authoritative killed verdict", async () => {
+    const killed = () => Promise.resolve(authoritative({ status: "completed", inboxKilledAt: 5 }));
+    expect(await conversationForbidsResurrection("conv1", "sess1", "TEST", STRICT, killed)).toBe(true);
+  });
+
+  test("a degraded killed verdict blocks ONLY the trusting caller", async () => {
+    const killed = () => Promise.resolve(degraded({ status: "completed" }));
+    expect(await conversationForbidsResurrection("conv1", "sess1", "TEST", STRICT, killed)).toBe(false);
+    expect(await conversationForbidsResurrection("conv1", "sess1", "TEST", TRUSTING, killed)).toBe(true);
   });
 });
 
@@ -147,41 +205,148 @@ describe("parseReapCandidateRow", () => {
     expect(parseReapCandidateRow("")).toBeNull();
   });
 
-  test("a tmux too old to expand #{@opt} yields no stamps, so nothing is misidentified", () => {
-    // Unexpanded format strings come back as the literal, not as a session id —
-    // but the pane is simply uncollected (the resume prefixes still work).
+  test("unset stamps arrive as EMPTY fields, not missing ones (the real tmux output)", () => {
+    // REAP_LIST_FORMAT always emits two tabs; tmux expands an unset user option
+    // to the empty string. Verified against live tmux:
+    //   "cc-resume-7206623b\t7206623b-…\t"   (no conversation stamp)
+    expect(parseReapCandidateRow(row("cc-resume-7206623b", "7206623b-5ba0-4e7c-b91e-f1f1ddeb9b31", "")))
+      .toEqual({ tmux: "cc-resume-7206623b", sessionId: "7206623b-5ba0-4e7c-b91e-f1f1ddeb9b31", convId: null, kind: "resume" });
+    // A foreign pane: both stamps empty, tabs still present.
+    expect(parseReapCandidateRow(row("my-editor", "", ""))).toBeNull();
+  });
+
+  test("a tmux too old to expand #{@opt} emits no tabs at all — still safe", () => {
+    // Degenerate input the format string can't produce on a modern tmux, but an
+    // ancient one yields the bare name: the pane is uncollected unless its NAME
+    // identifies it, which is exactly the conservative outcome we want.
     expect(parseReapCandidateRow("my-editor")).toBeNull();
     expect(parseReapCandidateRow("cc-resume-7206623b")?.kind).toBe("resume");
+    expect(parseReapCandidateRow("cc-claude-6f68a98bqm7z")).toBeNull(); // unidentifiable without stamps
   });
 });
 
 describe("stampedPaneReapEligibility", () => {
-  const lifecycle = (over: ConversationLifecycle): ConversationLifecycle => ({ status: "active", ...over });
-
   test("hidden from the inbox → eligible", () => {
     for (const field of ["inboxKilledAt", "inboxStashedAt", "inboxDismissedAt"] as const) {
-      expect(stampedPaneReapEligibility(lifecycle({ [field]: 1_700_000_000_000 })).eligible).toBe(true);
+      expect(stampedPaneReapEligibility(authoritative({ [field]: 1_700_000_000_000 })).eligible).toBe(true);
     }
   });
 
   test("visible in the inbox → NEVER reaped, however idle", () => {
-    expect(stampedPaneReapEligibility(lifecycle({}))).toEqual({ eligible: false, reason: "inbox-visible" });
+    expect(stampedPaneReapEligibility(authoritative())).toEqual({ eligible: false, reason: "inbox-visible" });
   });
 
   test("a pinned card stays visible even when killed → never reaped", () => {
     // Mirrors shouldShowInInbox: `inbox_killed_at && !inbox_pinned_at` hides it,
     // so a pin keeps the card (and its agent) around.
-    expect(stampedPaneReapEligibility(lifecycle({ inboxKilledAt: 1, inboxPinnedAt: 2 })))
+    expect(stampedPaneReapEligibility(authoritative({ inboxKilledAt: 1, inboxPinnedAt: 2 })))
       .toEqual({ eligible: false, reason: "pinned" });
   });
 
   test("unknown hide state fails CLOSED (opposite of the resurrection gate)", () => {
-    // Can't reach Convex, or the lifecycle query isn't deployed: leave it running.
     expect(stampedPaneReapEligibility(null)).toEqual({ eligible: false, reason: "hide-state-unknown" });
     expect(stampedPaneReapEligibility(undefined).eligible).toBe(false);
-    // A status-only lifecycle (the fallback query's shape) carries no hide flags,
-    // so it reads as visible rather than as permission to kill.
-    expect(stampedPaneReapEligibility({ status: "active" }).eligible).toBe(false);
+  });
+
+  // The lie this used to tell: the status-only fallback carries NO hide fields,
+  // and reading their absence as "not hidden" reported killed conversations as
+  // visible-and-skipped in the audit log while the stamped reaper quietly no-oped
+  // against an undeployed backend. Absence must report as absence.
+  test("a degraded lifecycle reports hide-state-unknown, NOT inbox-visible", () => {
+    expect(stampedPaneReapEligibility(degraded({ status: "active" })))
+      .toEqual({ eligible: false, reason: "hide-state-unknown" });
+    // Even when the degraded row happens to look killed, hide state is still unknown.
+    expect(stampedPaneReapEligibility(degraded({ status: "completed" })).reason).toBe("hide-state-unknown");
+  });
+});
+
+describe("tmuxSessionIsSinglePane", () => {
+  // The reap gates only ever inspect :0.0, but killTmuxSessionAndTree takes the
+  // whole tmux SESSION — so a split or a second window (the user's shell, another
+  // live agent) would die on one idle pane's evidence.
+  test("exactly one pane → safe to treat :0.0 as the whole session", () => {
+    expect(tmuxSessionIsSinglePane("0.0\n")).toBe(true);
+    expect(tmuxSessionIsSinglePane("0.0")).toBe(true);
+  });
+
+  test("a split or a second window → not safe", () => {
+    expect(tmuxSessionIsSinglePane("0.0\n0.1\n")).toBe(false);   // split
+    expect(tmuxSessionIsSinglePane("0.0\n1.0\n")).toBe(false);   // second window
+  });
+
+  test("empty/garbled output → not single (fail closed)", () => {
+    expect(tmuxSessionIsSinglePane("")).toBe(false);
+    expect(tmuxSessionIsSinglePane("   \n  \n")).toBe(false);
+  });
+});
+
+describe("derivedPaneNamesForConversation", () => {
+  const names = derivedPaneNamesForConversation("jx78rf6911tyzst2n8ks6f68a98bqm7z");
+
+  test("covers EVERY launchable agent, not the old hardcoded four", () => {
+    // opencode and pi mint cc-<agent>-* names too, and this sweep is the only
+    // teardown on the owner-defer path — a missing id is an unkillable pane.
+    for (const agent of ["claude", "codex", "cursor", "gemini", "opencode", "pi"]) {
+      expect(names).toContain(`cc-${agent}-6f68a98bqm7z`);
+    }
+  });
+
+  test("keys off the same 12-char conversation suffix start_session uses", () => {
+    expect(names.every((n) => n.endsWith("-6f68a98bqm7z"))).toBe(true);
+  });
+});
+
+// An in-flight resume that passed the gates BEFORE a kill can recreate the pane
+// the sweep just removed. The sweep can't cancel that promise, but it must not
+// leave the map entry behind for the next delivery to join.
+describe("clearSessionTrackingForKill", () => {
+  test("clears every per-session map the kill path owns", () => {
+    const sid = "22222222-3333-4444-8555-666666666666";
+    registerManagedStartedSession("jx7trackedconv0000000000000000000", sid, "cc-claude-trackingtest");
+    expect(sessionKillTrackingSnapshot(sid).pane).toBe(true);
+
+    clearSessionTrackingForKill(sid);
+    expect(sessionKillTrackingSnapshot(sid)).toEqual({
+      pane: false, resumeInFlight: false, resumeInFlightStarted: false, restarting: false, process: false,
+    });
+  });
+
+  test("is a no-op for an unknown or missing session id", () => {
+    expect(() => clearSessionTrackingForKill(undefined)).not.toThrow();
+    expect(() => clearSessionTrackingForKill(null)).not.toThrow();
+    expect(sessionKillTrackingSnapshot("never-seen").pane).toBe(false);
+  });
+});
+
+describe("lifecycle query latch", () => {
+  // A latch that trips on ANY error silently disables the resurrection gate for
+  // the daemon's whole life on one DNS blip. Only a missing function is permanent.
+  test("only a missing-function error latches", () => {
+    expect(isMissingFunctionError(new Error(
+      "Could not find public function for 'conversations:getConversationLifecycle'. Did you forget to run `npx convex deploy`?",
+    ))).toBe(true);
+    expect(isMissingFunctionError(new Error("function not found"))).toBe(true);
+  });
+
+  test("transient failures do NOT latch", () => {
+    for (const msg of [
+      "connect ECONNREFUSED 127.0.0.1:443",
+      "Request timed out after 30000ms",
+      "502 Bad Gateway",
+      "getaddrinfo ENOTFOUND convex.cloud",
+      "Unauthorized",
+    ]) {
+      expect(isMissingFunctionError(new Error(msg))).toBe(false);
+    }
+    expect(isMissingFunctionError(undefined)).toBe(false);
+    expect(isMissingFunctionError("some string")).toBe(false);
+  });
+
+  test("a latched-off query re-probes so a deploy (or a wrong latch) heals", () => {
+    const SIX_H = 6 * 60 * 60 * 1000;
+    expect(shouldProbeLifecycleQuery(0, 1_000)).toBe(true);              // never latched
+    expect(shouldProbeLifecycleQuery(1_000, 1_000 + SIX_H - 1)).toBe(false);
+    expect(shouldProbeLifecycleQuery(1_000, 1_000 + SIX_H)).toBe(true);  // re-probe due
   });
 });
 
@@ -198,6 +363,7 @@ describe("danglingUserTurnIsReapable", () => {
       turn: "active",
       lastRealRole: "user",
       lastRealTimestampMs: NOW - ageHours * HOUR,
+      askSidecarMtimeMs: null,
       paneIdle: true,
       now: NOW,
       ...over,
@@ -216,8 +382,6 @@ describe("danglingUserTurnIsReapable", () => {
   });
 
   test("a pending tool_use is real in-flight work — blocked at ANY age", () => {
-    // classifyTranscriptTail returns "active" for both cases; only the trailing
-    // role separates them. An open AskUserQuestion lives here too.
     expect(dangling(682, { lastRealRole: "assistant" })).toBe(false);
     expect(dangling(10_000, { lastRealRole: "assistant" })).toBe(false);
   });
@@ -235,6 +399,56 @@ describe("danglingUserTurnIsReapable", () => {
     // Never fall back to mtime here: mtime is what lies.
     expect(dangling(682, { lastRealTimestampMs: null })).toBe(false);
     expect(dangling(682, { lastRealRole: null })).toBe(false);
+  });
+
+  // THE REAL AskUserQuestion SHAPE. Claude Code buffers the AUQ tool_use out of
+  // the JSONL until it is answered, so a question-blocked session's tail ends in
+  // a USER turn (the previous, already-resolved tool_result) — indistinguishable
+  // from a dangling turn by role alone. An earlier version of this test asserted
+  // lastRealRole "assistant" for this case, which is the opposite of the on-disk
+  // shape and let the hatch through with only a footer regex protecting it.
+  test("a pending question (user tail + newer sidecar) is NEVER reaped", () => {
+    const lastMsg = NOW - 300 * HOUR;
+    expect(danglingUserTurnIsReapable({
+      turn: "active", lastRealRole: "user", lastRealTimestampMs: lastMsg,
+      askSidecarMtimeMs: lastMsg + 90_000, // question asked after the last message
+      paneIdle: true, now: NOW,
+    })).toBe(false);
+  });
+
+  test("an ANSWERED question (sidecar older than the last message) still reaps", () => {
+    // The sidecar is never deleted, so this is the common case — 3 of the 5 stuck
+    // panes carrying a sidecar here had answered their questions weeks earlier.
+    const lastMsg = NOW - 300 * HOUR;
+    expect(danglingUserTurnIsReapable({
+      turn: "active", lastRealRole: "user", lastRealTimestampMs: lastMsg,
+      askSidecarMtimeMs: lastMsg - 60_000,
+      paneIdle: true, now: NOW,
+    })).toBe(true);
+  });
+});
+
+describe("askUserQuestionStillPending", () => {
+  // Ordering, not existence: ~/.codecast/ask-input/<sid>.json is written when a
+  // question is asked and NEVER removed (123 files here, back to June), so
+  // "a sidecar exists" would permanently retire the escape hatch as sessions each
+  // accumulate one. Answering flushes the buffered turn AND appends the answer,
+  // so the transcript gains a message newer than the sidecar.
+  test("sidecar newer than the last message → still waiting on the user", () => {
+    expect(askUserQuestionStillPending(2_000, 1_000)).toBe(true);
+  });
+
+  test("sidecar older than the last message → answered, transcript moved on", () => {
+    expect(askUserQuestionStillPending(1_000, 2_000)).toBe(false);
+    expect(askUserQuestionStillPending(1_000, 1_000)).toBe(false); // not strictly newer
+  });
+
+  test("no sidecar → this session never asked a question", () => {
+    expect(askUserQuestionStillPending(null, 2_000)).toBe(false);
+  });
+
+  test("sidecar but no message clock → can't order them → assume pending", () => {
+    expect(askUserQuestionStillPending(2_000, null)).toBe(true);
   });
 });
 
@@ -281,6 +495,14 @@ describe("reaper pass summary", () => {
       "no-transcript", "pane=busy", "no-transcript", "active-12min",
       "no-transcript", "pane=busy", "active-300min", "inbox-visible",
     ])).toBe("no-transcript×3, active×2, pane=busy×2, inbox-visible×1");
+  });
+
+  test("the new skip reasons are distinguishable in the tally", () => {
+    // Each names a different root cause, and conflating them is what made the
+    // reaper look inert: an undeployed query, an attached split, and a live
+    // question are three very different reasons to do nothing.
+    expect(summarizeReapSkips(["hide-state-unknown", "multi-pane", "pending-question", "transcript=active"]))
+      .toBe("hide-state-unknown×1, multi-pane×1, pending-question×1, transcript=active×1");
   });
 
   test("a clean pass says so", () => {

--- a/packages/cli/src/daemon.session-teardown.test.ts
+++ b/packages/cli/src/daemon.session-teardown.test.ts
@@ -6,6 +6,7 @@ import {
   danglingUserTurnIsReapable,
   derivedPaneNamesForConversation,
   isConversationRetired,
+  killLocalPanesForConversation,
   parseReapCandidateRow,
   reapSkipBucket,
   registerManagedStartedSession,
@@ -315,6 +316,27 @@ describe("clearSessionTrackingForKill", () => {
     expect(() => clearSessionTrackingForKill(undefined)).not.toThrow();
     expect(() => clearSessionTrackingForKill(null)).not.toThrow();
     expect(sessionKillTrackingSnapshot("never-seen").pane).toBe(false);
+  });
+
+  // THE race the sweep exists for, and the one the first version of it missed:
+  // the kill lands after a resume passed the gates but BEFORE its pane exists.
+  // Clearing state only next to a found pane means finding none clears nothing,
+  // and the in-flight resume completes into a killed conversation.
+  // (clearConversationDeliveryAndResumeState does not cover these maps — it
+  // touches resumeFatalReasons/deliveryFailures/repairAttempts, never resumeInFlight.)
+  test("a sweep that finds ZERO panes still clears the in-flight maps", async () => {
+    const sid = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";
+    // A conversation id whose derived cc-<agent>-* names cannot exist, and a
+    // session id no live pane is stamped with — so the sweep matches nothing.
+    const convId = "jx7nosuchconversation000000000000";
+    registerManagedStartedSession(convId, sid, "cc-claude-zeropanetest");
+    expect(sessionKillTrackingSnapshot(sid).pane).toBe(true);
+
+    const killed = await killLocalPanesForConversation(convId, sid, "TEST");
+    expect(killed).toBe(0);
+    // Proof the unconditional clear ran: clearSessionTrackingForKill empties every
+    // map in one body (covered above), so the pane bit flipping is the whole set.
+    expect(sessionKillTrackingSnapshot(sid).pane).toBe(false);
   });
 });
 

--- a/packages/cli/src/daemon.session-teardown.test.ts
+++ b/packages/cli/src/daemon.session-teardown.test.ts
@@ -16,7 +16,7 @@ import {
   tmuxSessionIsSinglePane,
   transcriptTailLastRealTimestamp,
 } from "./daemon.js";
-import { isMissingFunctionError, shouldProbeLifecycleQuery } from "./syncService.js";
+import { SyncService, isMissingFunctionError, resetLifecycleQueryLatch, shouldProbeLifecycleQuery } from "./syncService.js";
 import type { ConversationLifecycle } from "./syncService.js";
 
 // Shorthands for the two provenances getConversationLifecycle can return. The
@@ -507,5 +507,89 @@ describe("reaper pass summary", () => {
 
   test("a clean pass says so", () => {
     expect(summarizeReapSkips([])).toBe("none");
+  });
+});
+
+// Route selection inside getConversationLifecycle. The ghost case is the whole
+// reason a fallback exists: the conversation id we were handed no longer
+// resolves, but the session is alive under a twin. Routing that to the devices
+// query would take the OLDEST twin AND lose every hide field; the lifecycle
+// query's session route takes the NEWEST and keeps them.
+describe("getConversationLifecycle routing", () => {
+  const LIFECYCLE = "conversations:getConversationLifecycle";
+  const DEVICES = "devices:resolveConversationBySession";
+  const liveRow = {
+    status: "active", inbox_killed_at: null, inbox_stashed_at: 1_700_000_000_000,
+    inbox_dismissed_at: null, inbox_pinned_at: null,
+  };
+
+  // Stubs the Convex client and records which (name, selector) pairs were called.
+  function serviceWith(handler: (name: string, args: any) => unknown) {
+    resetLifecycleQueryLatch();
+    const calls: Array<{ name: string; selector: string }> = [];
+    const svc = new SyncService(
+      { convexUrl: "http://localhost:0", userId: "u", authToken: "t" },
+      { nextTranscriptSourceRevision: () => 1 },
+    );
+    (svc as any).client = {
+      query: async (name: string, args: any) => {
+        calls.push({ name, selector: args.conversation_id ? "conversation_id" : "session_id" });
+        return handler(name, args);
+      },
+    };
+    return { svc, calls };
+  }
+
+  test("an existing row resolves by conversation id and stops there", async () => {
+    const { svc, calls } = serviceWith((name) => (name === LIFECYCLE ? liveRow : null));
+    const got = await svc.getConversationLifecycle("conv-live", "sess-1");
+    expect(got).toMatchObject({ hideStateKnown: true, source: "lifecycle", inboxStashedAt: 1_700_000_000_000 });
+    expect(calls).toEqual([{ name: LIFECYCLE, selector: "conversation_id" }]);
+  });
+
+  test("a GHOST id falls through to the session route and keeps full hide state", async () => {
+    // Route A misses (deleted/remapped row); route B finds the live twin.
+    const { svc, calls } = serviceWith((name, args) =>
+      name === LIFECYCLE && args.session_id ? liveRow : null);
+    const got = await svc.getConversationLifecycle("conv-ghost", "sess-1");
+    expect(got).toMatchObject({ hideStateKnown: true, source: "lifecycle", inboxStashedAt: 1_700_000_000_000 });
+    expect(calls).toEqual([
+      { name: LIFECYCLE, selector: "conversation_id" },
+      { name: LIFECYCLE, selector: "session_id" },
+    ]);
+    // The oldest-twin, status-only query must not be consulted at all.
+    expect(calls.some((c) => c.name === DEVICES)).toBe(false);
+  });
+
+  test("both routes answering 'no such conversation' returns null, not a devices miss", async () => {
+    const { svc, calls } = serviceWith(() => null);
+    expect(await svc.getConversationLifecycle("conv-gone", "sess-1")).toBeNull();
+    expect(calls.map((c) => c.name)).toEqual([LIFECYCLE, LIFECYCLE]); // no devices call
+  });
+
+  test("an UNDEPLOYED query (both routes missing) still uses the devices fallback", async () => {
+    const { svc, calls } = serviceWith((name) => {
+      if (name === LIFECYCLE) throw new Error("Could not find public function for 'conversations:getConversationLifecycle'");
+      return { status: "completed" };
+    });
+    const got = await svc.getConversationLifecycle("conv-1", "sess-1");
+    expect(got).toEqual({ status: "completed", hideStateKnown: false, source: "status-fallback" });
+    expect(calls[calls.length - 1].name).toBe(DEVICES);
+  });
+
+  test("a transient error does not latch, and still degrades to devices for this call", async () => {
+    const { svc } = serviceWith((name) => {
+      if (name === LIFECYCLE) throw new Error("connect ECONNREFUSED 127.0.0.1:443");
+      return { status: "active" };
+    });
+    expect(await svc.getConversationLifecycle("conv-1", "sess-1")).toMatchObject({ source: "status-fallback" });
+    // Latch untouched: the next call probes the real query again.
+    expect(shouldProbeLifecycleQuery(0, Date.now())).toBe(true);
+  });
+
+  test("no session id means no ghost route and no fallback", async () => {
+    const { svc, calls } = serviceWith(() => null);
+    expect(await svc.getConversationLifecycle("conv-gone")).toBeNull();
+    expect(calls).toEqual([{ name: LIFECYCLE, selector: "conversation_id" }]);
   });
 });

--- a/packages/cli/src/daemon.session-teardown.test.ts
+++ b/packages/cli/src/daemon.session-teardown.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+import {
+  danglingUserTurnIsReapable,
+  isConversationRetired,
+  parseReapCandidateRow,
+  reapSkipBucket,
+  resumeOwnerVerdict,
+  stampedPaneReapEligibility,
+  summarizeReapSkips,
+  transcriptTailLastRealTimestamp,
+} from "./daemon.js";
+import type { ConversationLifecycle } from "./syncService.js";
+
+// The three lifecycle defects confirmed on 2026-08-03, each reduced to the pure
+// decision the daemon now makes before it acts:
+//   D1 — the health sweep reconstituted killed conversations (isConversationRetired)
+//   D3 — resume ignored ownership on local devices (resumeOwnerVerdict)
+//   D4 — only cc-resume-* panes were reap candidates (parseReapCandidateRow +
+//        stampedPaneReapEligibility)
+
+describe("isConversationRetired", () => {
+  test("a killed conversation must never be reconstituted", () => {
+    // The exact incident shape: status=completed with inbox_killed_at stamped.
+    expect(isConversationRetired({ status: "completed", inboxKilledAt: 1_700_000_000_000 })).toBe(true);
+  });
+
+  test("either signal alone is enough", () => {
+    // killSession only sets status=completed when mark_completed is passed, so
+    // inbox_killed_at can stand alone — and a conversation completed by any other
+    // path is equally finished.
+    expect(isConversationRetired({ status: "active", inboxKilledAt: 1 })).toBe(true);
+    expect(isConversationRetired({ status: "completed" })).toBe(true);
+  });
+
+  test("a live conversation still reconstitutes (the crash-recovery case)", () => {
+    expect(isConversationRetired({ status: "active" })).toBe(false);
+    expect(isConversationRetired({ status: "active", inboxKilledAt: null })).toBe(false);
+    // Hidden from the inbox is NOT retired: a stashed/dismissed agent keeps running.
+    expect(isConversationRetired({ status: "active", inboxStashedAt: 1, inboxDismissedAt: 1 })).toBe(false);
+  });
+
+  test("unknown lifecycle fails OPEN — a Convex blip can't strand a live session", () => {
+    expect(isConversationRetired(null)).toBe(false);
+    expect(isConversationRetired(undefined)).toBe(false);
+    expect(isConversationRetired({})).toBe(false);
+  });
+});
+
+const LOCAL = "device-local-aaaaaaaa";
+const PEER = "device-peer-bbbbbbbb";
+
+describe("resumeOwnerVerdict", () => {
+  test("a conversation owned by a LIVE peer is never resumed here (the D3 hole)", () => {
+    // Pre-fix this rule existed only for remote daemons, so a session owned by a
+    // live peer got resumed on both machines at once.
+    expect(resumeOwnerVerdict({
+      conversationId: "conv1",
+      localDeviceId: LOCAL,
+      isRemote: false,
+      owner: { ownerDeviceId: PEER, ownerIsRemote: false, ownerOnline: true },
+    })).toBe("owned_by_live_device");
+  });
+
+  test("a DEAD owner still fails over to this device (deliberate)", () => {
+    expect(resumeOwnerVerdict({
+      conversationId: "conv1",
+      localDeviceId: LOCAL,
+      isRemote: false,
+      owner: { ownerDeviceId: PEER, ownerIsRemote: false, ownerOnline: false },
+    })).toBe("proceed");
+  });
+
+  test("an unowned conversation is adopted by a local daemon", () => {
+    expect(resumeOwnerVerdict({ conversationId: "conv1", localDeviceId: LOCAL, isRemote: false, owner: null })).toBe("proceed");
+    expect(resumeOwnerVerdict({ conversationId: undefined, localDeviceId: LOCAL, isRemote: false, owner: null })).toBe("proceed");
+  });
+
+  test("this device owning it always proceeds, live or not", () => {
+    for (const online of [true, false]) {
+      expect(resumeOwnerVerdict({
+        conversationId: "conv1",
+        localDeviceId: LOCAL,
+        isRemote: false,
+        owner: { ownerDeviceId: LOCAL, ownerIsRemote: false, ownerOnline: online },
+      })).toBe("proceed");
+    }
+  });
+
+  test("a remote daemon manages ONLY what it owns (unchanged)", () => {
+    expect(resumeOwnerVerdict({ conversationId: "conv1", localDeviceId: LOCAL, isRemote: true, owner: null })).toBe("remote_unowned");
+    expect(resumeOwnerVerdict({
+      conversationId: "conv1",
+      localDeviceId: LOCAL,
+      isRemote: true,
+      owner: { ownerDeviceId: PEER, ownerIsRemote: false, ownerOnline: false },
+    })).toBe("remote_unowned");
+    expect(resumeOwnerVerdict({
+      conversationId: "conv1",
+      localDeviceId: LOCAL,
+      isRemote: true,
+      owner: { ownerDeviceId: LOCAL, ownerIsRemote: true, ownerOnline: true },
+    })).toBe("proceed");
+  });
+
+  test("a remote daemon with no conversation id can't verify ownership → refuse", () => {
+    expect(resumeOwnerVerdict({ conversationId: undefined, localDeviceId: LOCAL, isRemote: true, owner: null }))
+      .toBe("remote_no_conversation");
+  });
+
+  test("the live-owner rule outranks the remote rule (same skip, clearer log)", () => {
+    expect(resumeOwnerVerdict({
+      conversationId: "conv1",
+      localDeviceId: LOCAL,
+      isRemote: true,
+      owner: { ownerDeviceId: PEER, ownerIsRemote: false, ownerOnline: true },
+    })).toBe("owned_by_live_device");
+  });
+});
+
+describe("parseReapCandidateRow", () => {
+  const row = (name: string, session = "", conv = "") => [name, session, conv].join("\t");
+
+  test("resume shells are candidates with or without stamps", () => {
+    expect(parseReapCandidateRow(row("cc-resume-7206623b", "7206623b-5ba0-4e7c-b91e-f1f1ddeb9b31")))
+      .toEqual({ tmux: "cc-resume-7206623b", sessionId: "7206623b-5ba0-4e7c-b91e-f1f1ddeb9b31", convId: null, kind: "resume" });
+    expect(parseReapCandidateRow(row("cx-resume-019fc268"))?.kind).toBe("resume");
+  });
+
+  test("a codecast-stamped primary terminal is now a candidate (the D4 gap)", () => {
+    // cc-<agent>-<convSuffix> panes were invisible to the reaper, so a stashed or
+    // killed session's own terminal leaked forever.
+    expect(parseReapCandidateRow(row("cc-claude-6f68a98bqm7z", "2a466fef-c989-4285-b754-ece01f6cdc92", "jx78rf6911tyzst2n8ks6f68a98bqm7z")))
+      .toEqual({
+        tmux: "cc-claude-6f68a98bqm7z",
+        sessionId: "2a466fef-c989-4285-b754-ece01f6cdc92",
+        convId: "jx78rf6911tyzst2n8ks6f68a98bqm7z",
+        kind: "stamped",
+      });
+    // Either stamp alone identifies it.
+    expect(parseReapCandidateRow(row("cc-codex-abc", "", "jx7conv"))?.kind).toBe("stamped");
+  });
+
+  test("an unstamped foreign pane is never a candidate", () => {
+    // The user's own tmux sessions must stay out of the reaper entirely.
+    expect(parseReapCandidateRow(row("my-editor"))).toBeNull();
+    expect(parseReapCandidateRow(row("work", "  ", " "))).toBeNull();
+    expect(parseReapCandidateRow("")).toBeNull();
+  });
+
+  test("a tmux too old to expand #{@opt} yields no stamps, so nothing is misidentified", () => {
+    // Unexpanded format strings come back as the literal, not as a session id —
+    // but the pane is simply uncollected (the resume prefixes still work).
+    expect(parseReapCandidateRow("my-editor")).toBeNull();
+    expect(parseReapCandidateRow("cc-resume-7206623b")?.kind).toBe("resume");
+  });
+});
+
+describe("stampedPaneReapEligibility", () => {
+  const lifecycle = (over: ConversationLifecycle): ConversationLifecycle => ({ status: "active", ...over });
+
+  test("hidden from the inbox → eligible", () => {
+    for (const field of ["inboxKilledAt", "inboxStashedAt", "inboxDismissedAt"] as const) {
+      expect(stampedPaneReapEligibility(lifecycle({ [field]: 1_700_000_000_000 })).eligible).toBe(true);
+    }
+  });
+
+  test("visible in the inbox → NEVER reaped, however idle", () => {
+    expect(stampedPaneReapEligibility(lifecycle({}))).toEqual({ eligible: false, reason: "inbox-visible" });
+  });
+
+  test("a pinned card stays visible even when killed → never reaped", () => {
+    // Mirrors shouldShowInInbox: `inbox_killed_at && !inbox_pinned_at` hides it,
+    // so a pin keeps the card (and its agent) around.
+    expect(stampedPaneReapEligibility(lifecycle({ inboxKilledAt: 1, inboxPinnedAt: 2 })))
+      .toEqual({ eligible: false, reason: "pinned" });
+  });
+
+  test("unknown hide state fails CLOSED (opposite of the resurrection gate)", () => {
+    // Can't reach Convex, or the lifecycle query isn't deployed: leave it running.
+    expect(stampedPaneReapEligibility(null)).toEqual({ eligible: false, reason: "hide-state-unknown" });
+    expect(stampedPaneReapEligibility(undefined).eligible).toBe(false);
+    // A status-only lifecycle (the fallback query's shape) carries no hide flags,
+    // so it reads as visible rather than as permission to kill.
+    expect(stampedPaneReapEligibility({ status: "active" }).eligible).toBe(false);
+  });
+});
+
+// The permanent `transcript=active` block — the actual reason panes accumulate.
+// An agent that died mid-turn leaves the user's unanswered prompt last, which
+// classifyTranscriptTail reads as "the agent's move" forever. On this machine 25
+// of 267 idle Claude transcripts are stuck that way, the oldest 682h.
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+describe("danglingUserTurnIsReapable", () => {
+  const dangling = (ageHours: number, over: Partial<Parameters<typeof danglingUserTurnIsReapable>[0]> = {}) =>
+    danglingUserTurnIsReapable({
+      turn: "active",
+      lastRealRole: "user",
+      lastRealTimestampMs: NOW - ageHours * HOUR,
+      paneIdle: true,
+      now: NOW,
+      ...over,
+    });
+
+  test("dangling user turn + >24h + idle pane → reapable", () => {
+    expect(dangling(25)).toBe(true);
+    expect(dangling(325)).toBe(true); // the real fc9eed88 shape
+    expect(dangling(24)).toBe(true);  // exactly at the bar
+  });
+
+  test("dangling user turn under 24h → still blocked", () => {
+    // Past the 5h mtime gate but not the raised bar: the agent may yet answer.
+    expect(dangling(23)).toBe(false);
+    expect(dangling(6)).toBe(false);
+  });
+
+  test("a pending tool_use is real in-flight work — blocked at ANY age", () => {
+    // classifyTranscriptTail returns "active" for both cases; only the trailing
+    // role separates them. An open AskUserQuestion lives here too.
+    expect(dangling(682, { lastRealRole: "assistant" })).toBe(false);
+    expect(dangling(10_000, { lastRealRole: "assistant" })).toBe(false);
+  });
+
+  test("only rescues the 'active' verdict, never invents one", () => {
+    expect(dangling(500, { turn: "idle" })).toBe(false);
+    expect(dangling(500, { turn: "unknown" })).toBe(false);
+  });
+
+  test("a busy pane vetoes it however old the turn is", () => {
+    expect(dangling(682, { paneIdle: false })).toBe(false);
+  });
+
+  test("no parseable timestamp → no honest clock → keep blocking", () => {
+    // Never fall back to mtime here: mtime is what lies.
+    expect(dangling(682, { lastRealTimestampMs: null })).toBe(false);
+    expect(dangling(682, { lastRealRole: null })).toBe(false);
+  });
+});
+
+describe("transcriptTailLastRealTimestamp", () => {
+  const msg = (role: string, timestamp?: string) =>
+    JSON.stringify({ type: role, timestamp, message: { role, content: [{ type: "text", text: "hi" }] } });
+  const meta = () => JSON.stringify({ type: "mode", mode: "default", sessionId: "x" });
+
+  test("reads the last real turn's timestamp, skipping meta lines", () => {
+    // Real shape: Claude writes `mode` / `permission-mode` lines after the turn,
+    // and those carry no timestamp — reading them would yield null every time.
+    expect(transcriptTailLastRealTimestamp([
+      msg("user", "2026-07-20T10:00:00.000Z"),
+      meta(),
+      meta(),
+    ].join("\n"))).toBe(Date.parse("2026-07-20T10:00:00.000Z"));
+  });
+
+  test("skips a partial/corrupt final line (mid-write tail)", () => {
+    expect(transcriptTailLastRealTimestamp([
+      msg("assistant", "2026-07-20T10:00:00.000Z"),
+      '{"type":"assist',
+    ].join("\n"))).toBe(Date.parse("2026-07-20T10:00:00.000Z"));
+  });
+
+  test("a real turn with no/unparseable timestamp → null, never a guess", () => {
+    expect(transcriptTailLastRealTimestamp(msg("user"))).toBeNull();
+    expect(transcriptTailLastRealTimestamp(msg("user", "not a date"))).toBeNull();
+    expect(transcriptTailLastRealTimestamp([meta(), meta()].join("\n"))).toBeNull();
+    expect(transcriptTailLastRealTimestamp("")).toBeNull();
+  });
+});
+
+describe("reaper pass summary", () => {
+  test("collapses the idle-age detail so one bucket per reason", () => {
+    expect(reapSkipBucket("active-37min")).toBe("active");
+    expect(reapSkipBucket("active-303min")).toBe("active");
+    expect(reapSkipBucket("pane=busy")).toBe("pane=busy");
+    expect(reapSkipBucket("no-transcript")).toBe("no-transcript");
+  });
+
+  test("commonest reason first — the line answers 'why did nothing get reaped'", () => {
+    expect(summarizeReapSkips([
+      "no-transcript", "pane=busy", "no-transcript", "active-12min",
+      "no-transcript", "pane=busy", "active-300min", "inbox-visible",
+    ])).toBe("no-transcript×3, active×2, pane=busy×2, inbox-visible×1");
+  });
+
+  test("a clean pass says so", () => {
+    expect(summarizeReapSkips([])).toBe("none");
+  });
+});

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2348,6 +2348,13 @@ export function derivedPaneNamesForConversation(conversationId: string): string[
 // the next health check or reaper pass.)
 export function clearSessionTrackingForKill(sessionId: string | null | undefined): void {
   if (!sessionId) return;
+  // NOTE on restartingSessionIds: killConversationBackends never cleared it, and
+  // this does. Harmless today because Restart enqueues kill and resume as two
+  // separate daemon commands, so the guard is not yet set when the kill runs. It
+  // stops being harmless if those ever land together or in-process: the guard is
+  // what tells the watchdog "a restart is in progress, don't mark this
+  // completed", so clearing it mid-restart would make Restart complete the
+  // session instead of restarting it. If you couple them, drop this line.
   stopManagedSessionHeartbeat(sessionId);
   stopCodexPermissionPoller(sessionId);
   resumeSessionCache.delete(sessionId);
@@ -2384,7 +2391,7 @@ export function sessionKillTrackingSnapshot(sessionId: string): Record<string, b
  * Each stops tracking BEFORE the kill, or heartbeatHealthCheck sees the vanished
  * tmux and RECONSTITUTES the agent. Returns how many panes were killed.
  */
-async function killLocalPanesForConversation(
+export async function killLocalPanesForConversation(
   conversationId: string,
   sessionIdHint: string | undefined,
   context: string,
@@ -2393,6 +2400,13 @@ async function killLocalPanesForConversation(
   const stopTracking = (id: string | null | undefined) => clearSessionTrackingForKill(id);
 
   const sessionId = sessionIdHint ?? buildReverseConversationCache(readConversationCache())[conversationId];
+  // UNCONDITIONALLY, before any pane lookup — finding no pane is not the same as
+  // having nothing to clear, and is in fact THE race this exists for: a resume
+  // that passed the gates is mid-flight and its pane does not exist YET, so a
+  // sweep that only cleared state next to a kill would leave resumeInFlight set
+  // and let that resume complete into a killed conversation. (The loops below
+  // still call it for the id stamped on a pane, which can differ from this one.)
+  clearSessionTrackingForKill(sessionId);
   if (sessionId) {
     try {
       const { stdout: tmuxList } = await tmuxExec(["list-sessions", "-F", "#{session_name}"]);
@@ -12008,6 +12022,18 @@ export function danglingUserTurnIsReapable(input: {
  * sidecar. A sidecar newer than the last real message therefore means the
  * question was asked and nothing has happened since — still pending. On the same
  * 23 panes this correctly protects exactly 2, both genuinely abandoned mid-question.
+ *
+ * KNOWN INERT SHAPES — strictly better than the pane regex alone, but not total:
+ *   - a stale sidecar from an ANSWERED earlier question masks a LATER pending one
+ *     whose own write never happened: codecast-status.sh skips the write when the
+ *     tool_input carries an empty `questions` array (statusHook.ts), and the hook
+ *     can also lose it to its own timeout. The mask reads as "pending" — the SAFE
+ *     direction (we decline to reap), so it costs a leaked pane, not a killed
+ *     question.
+ *   - a session running WITHOUT the codecast status hook writes no sidecar at all,
+ *     so it has no protection here beyond the pane classifier.
+ * Closing either needs a signal the agent emits unconditionally while blocked;
+ * the sidecar is the best one that exists today.
  */
 export function askUserQuestionStillPending(
   sidecarMtimeMs: number | null,
@@ -12067,8 +12093,14 @@ async function resolveReapSessionId(tmux: string): Promise<string | null> {
 // file falls back to the full walk. Reaper-local on purpose — findSessionFile has
 // many other callers whose freshness assumptions we're not touching.
 const reapTranscriptCache = new Map<string, SessionFileInfo>();
+// Misses need caching more than hits do: "no-transcript" is the DOMINANT skip
+// bucket, and each one paid the full walk every pass forever. TTL'd rather than
+// permanent so a transcript that shows up later (a resume materializing one) is
+// still found within half an hour.
+const reapTranscriptMisses = new Map<string, number>();
+const REAP_TRANSCRIPT_MISS_TTL_MS = 30 * 60 * 1000;
 
-function findReapTranscript(sessionId: string): SessionFileInfo | null {
+function findReapTranscript(sessionId: string, now: number = Date.now()): SessionFileInfo | null {
   const cached = reapTranscriptCache.get(sessionId);
   if (cached) {
     try {
@@ -12078,8 +12110,15 @@ function findReapTranscript(sessionId: string): SessionFileInfo | null {
       reapTranscriptCache.delete(sessionId);
     }
   }
+  const missedAt = reapTranscriptMisses.get(sessionId);
+  if (missedAt !== undefined && now - missedAt < REAP_TRANSCRIPT_MISS_TTL_MS) return null;
   const found = findSessionFile(sessionId);
-  if (found) reapTranscriptCache.set(sessionId, found);
+  if (found) {
+    reapTranscriptCache.set(sessionId, found);
+    reapTranscriptMisses.delete(sessionId);
+  } else {
+    reapTranscriptMisses.set(sessionId, now);
+  }
   return found;
 }
 
@@ -12110,7 +12149,7 @@ export function tmuxSessionIsSinglePane(listPanesStdout: string): boolean {
 async function reapBlockReason(
   sessionId: string, tmux: string, now: number,
 ): Promise<{ reason: string } | { reason: null; idleHours: number }> {
-  const file = findReapTranscript(sessionId);
+  const file = findReapTranscript(sessionId, now);
   if (!file) return { reason: "no-transcript" };
   const classifyTail = classifyTranscriptTailFor(file.agentType);
   if (!classifyTail) return { reason: `agent=${file.agentType}` };

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -78,7 +78,7 @@ import { getPosition, setPosition } from "./positionTracker.js";
 import { encryptToken, decryptToken, isEncryptedToken, TokenDecryptError } from "./tokenEncryption.js";
 import { getMachineKey } from "./machineKey.js";
 import { markSynced, updateSyncRecord, getSyncRecord, findUnsyncedFiles, type SyncRecord } from "./syncLedger.js";
-import { SyncService, AuthExpiredError, type CreateConversationParams } from "./syncService.js";
+import { SyncService, AuthExpiredError, type ConversationLifecycle, type CreateConversationParams } from "./syncService.js";
 import { redactSecrets, maskToken } from "./redact.js";
 import { RetryQueue, type RetryOperation } from "./retryQueue.js";
 import { InvalidateSync, type InvalidateSyncOptions } from "./invalidateSync.js";
@@ -2291,6 +2291,108 @@ function ownedByAnotherLiveDevice(
   return !!info?.ownerDeviceId && info.ownerDeviceId !== deviceId() && !!info.ownerOnline;
 }
 
+// Every resume driven by a resume_session / fork_session command — i.e. a human
+// pressing Restart/Resume/Fork. See ResumeOptions.userInitiated.
+const USER_RESUME = { userInitiated: true } as const;
+
+export type OwnerInfo = { ownerDeviceId?: string | null; ownerIsRemote?: boolean; ownerOnline?: boolean } | null | undefined;
+
+export type ResumeOwnerVerdict = "proceed" | "owned_by_live_device" | "remote_unowned" | "remote_no_conversation";
+
+/**
+ * Whether THIS daemon may resume a conversation, given who owns it. Two rules,
+ * one owner lookup:
+ *   - EVERY device: never resume a conversation owned by a DIFFERENT device that
+ *     is currently live — that daemon is the one running it. The command queue
+ *     has always enforced this (see the ownedByAnotherLiveDevice skip in
+ *     executeRemoteCommand), but resume itself only gated remotes, so a
+ *     conversation owned by a live peer got resumed on both machines at once.
+ *   - REMOTE devices only: a remote daemon (the cloud Mac) manages ONLY sessions
+ *     explicitly OWNED by it. Unlike the primary local daemon it must not adopt
+ *     unowned sessions — doing so reconstitutes the user's real sessions from
+ *     Convex and double-manages them (cross-device stomp).
+ * A DEAD/unresponsive owner, or an unowned conversation, proceeds on a local
+ * daemon: that failover (adopt and keep serving) is deliberate.
+ */
+export function resumeOwnerVerdict(input: {
+  conversationId: string | undefined;
+  localDeviceId: string;
+  isRemote: boolean;
+  owner: OwnerInfo;
+}): ResumeOwnerVerdict {
+  if (!!input.owner?.ownerDeviceId && input.owner.ownerDeviceId !== input.localDeviceId && !!input.owner.ownerOnline) {
+    return "owned_by_live_device";
+  }
+  if (!input.isRemote) return "proceed";
+  if (!input.conversationId) return "remote_no_conversation";
+  if (input.owner?.ownerDeviceId !== input.localDeviceId) return "remote_unowned";
+  return "proceed";
+}
+
+/**
+ * Kill every tmux pane for a conversation that is PHYSICALLY on this machine,
+ * regardless of who the conversation records as its owner. A pane in this
+ * daemon's own tmux server is always safe to tear down, and an owner-mismatched
+ * one is otherwise unkillable from anywhere: the owner device has no pane to
+ * kill and this device refuses the command (2026-08-03 — pane on the laptop,
+ * owner_device_id=nose, both daemons declined, the agent ran on untouched).
+ *
+ * Two ownership-independent sweeps, both keyed off ids alone (no lookup tables,
+ * so they reach a pane that outlived every in-memory map — e.g. across a daemon
+ * restart):
+ *   1. any pane stamped with this session id (@codecast_session_id)
+ *   2. the deterministic cc-<agent>-<convId.slice(-12)> name start_session mints
+ * Each stops tracking BEFORE the kill, or heartbeatHealthCheck sees the vanished
+ * tmux and RECONSTITUTES the agent. Returns how many panes were killed.
+ */
+async function killLocalPanesForConversation(
+  conversationId: string,
+  sessionIdHint: string | undefined,
+  context: string,
+): Promise<number> {
+  let killed = 0;
+  const stopTracking = (id: string | null | undefined) => {
+    if (!id) return;
+    stopManagedSessionHeartbeat(id);
+    stopCodexPermissionPoller(id);
+    resumeSessionCache.delete(id);
+  };
+
+  const sessionId = sessionIdHint ?? buildReverseConversationCache(readConversationCache())[conversationId];
+  if (sessionId) {
+    try {
+      const { stdout: tmuxList } = await tmuxExec(["list-sessions", "-F", "#{session_name}"]);
+      for (const tmuxName of tmuxList.trim().split("\n")) {
+        if (!tmuxName || !(await tmuxSessionMatchesFullSessionId(tmuxName, sessionId))) continue;
+        if (!validateTmuxTarget(tmuxName)) continue;
+        stopTracking(sessionId);
+        await killTmuxSessionAndTree(tmuxName);
+        log(`[${context}] Killed local tmux ${tmuxName} (+process tree) for session ${sessionId.slice(0, 8)}`);
+        killed++;
+      }
+    } catch {}
+  }
+
+  // agentType isn't in the kill args, so try every prefix; has-session guards
+  // each (cheap, idempotent). The session id lives on the tmux itself, so we can
+  // stop the right heartbeat even when no lookup table maps this conversation.
+  const convSuffix = conversationId.slice(-12);
+  for (const derivedName of ["claude", "codex", "cursor", "gemini"].map((a) => `cc-${a}-${convSuffix}`)) {
+    if (!validateTmuxTarget(derivedName)) continue;
+    try {
+      await tmuxExec(["has-session", "-t", derivedName], { timeout: 3000 });
+    } catch {
+      continue; // no such session
+    }
+    const derivedSessionId = (await getTmuxSessionOption(derivedName, "@codecast_session_id"))?.trim() || null;
+    stopTracking(derivedSessionId);
+    await killTmuxSessionAndTree(derivedName);
+    log(`[${context}] Killed tmux ${derivedName} by derived name (session ${derivedSessionId?.slice(0, 8) ?? "?"}) for conversation ${conversationId.slice(0, 12)}`);
+    killed++;
+  }
+  return killed;
+}
+
 // Tear down every backend bound to a conversation (app-server thread and/or
 // tmux pane + process tree), stopping heartbeats BEFORE each kill (or
 // heartbeatHealthCheck sees the vanished tmux and RECONSTITUTES the agent),
@@ -2364,53 +2466,16 @@ async function killConversationBackends(
     sessionProcessCache.delete(sessionId);
     resumeInFlight.delete(sessionId);
     resumeInFlightStarted.delete(sessionId);
-
-    try {
-      const { stdout: tmuxList } = await tmuxExec(["list-sessions", "-F", "#{session_name}"]);
-      for (const tmuxName of tmuxList.trim().split("\n")) {
-        if (!tmuxName || !(await tmuxSessionMatchesFullSessionId(tmuxName, sessionId))) continue;
-        if (!validateTmuxTarget(tmuxName)) continue;
-        const alive = await isTmuxAgentAlive(tmuxName);
-        if (!alive) {
-          await killTmuxSessionAndTree(tmuxName);
-          log(`[REMOTE] Killed zombie tmux session ${tmuxName} (+process tree) for session ${sessionId}`);
-          if (!result) result = "killed_zombie";
-        }
-      }
-    } catch {}
   }
 
-  // Deterministic last-resort kill. The tmux session name is keyed by
-  // conversation_id (cc-<agent>-<convId.slice(-12)>, see start_session), so a
-  // session is killable from the id ALONE — no lookup tables. This catches an
-  // idle pre-warmed agent that outlived the daemon's in-memory startedSessionTmux
-  // map (e.g. across a daemon restart) and has no live process for findSessionProcess
-  // to match: the lookups above all miss it, yet its tmux is right there under the
-  // derived name. Without this, reaping a dismissed empty pre-warm can't reach such
-  // an agent and it leaks forever (idle, still heartbeating). agentType isn't in the
-  // kill args, so try every prefix; has-session guards each (cheap, idempotent).
-  const convSuffix = conversationId.slice(-12);
-  for (const derivedName of ["claude", "codex", "cursor", "gemini"].map((a) => `cc-${a}-${convSuffix}`)) {
-    if (!validateTmuxTarget(derivedName)) continue;
-    try {
-      await tmuxExec(["has-session", "-t", derivedName], { timeout: 3000 });
-    } catch {
-      continue; // no such session
-    }
-    // CRITICAL: stop tracking the session BEFORE the kill, or heartbeatHealthCheck
-    // sees the vanished tmux and RECONSTITUTES the agent (the daemon keeps managed
-    // sessions warm). The session id lives on the tmux itself (@codecast_session_id),
-    // so we can stop the right heartbeat even when no lookup table maps this
-    // conversation. Mirrors reapOneTerminal's stop-then-kill ordering.
-    const derivedSessionId = (await getTmuxSessionOption(derivedName, "@codecast_session_id"))?.trim() || null;
-    if (derivedSessionId) {
-      stopManagedSessionHeartbeat(derivedSessionId);
-      stopCodexPermissionPoller(derivedSessionId);
-      resumeSessionCache.delete(derivedSessionId);
-    }
-    await killTmuxSessionAndTree(derivedName);
-    log(`[REMOTE] Killed tmux ${derivedName} by derived name (session ${derivedSessionId?.slice(0, 8) ?? "?"}) for conversation ${conversationId.slice(0, 12)}`);
-    if (!result) result = "killed_tmux";
+  // Last-resort sweep of anything still standing locally: a second pane for this
+  // session, or an idle pre-warmed agent that outlived the in-memory
+  // startedSessionTmux map (e.g. across a daemon restart) and has no live process
+  // for findSessionProcess to match — the lookups above all miss it, yet its tmux
+  // is right there under the derived name. Ownership-independent, so it is also
+  // what the owner-skip path in executeRemoteCommand runs on its own.
+  if (await killLocalPanesForConversation(conversationId, sessionId, "REMOTE") > 0 && !result) {
+    result = "killed_tmux";
   }
 
   // A kill is a clean slate. Wipe per-session/per-conversation caches that
@@ -2444,12 +2509,27 @@ async function executeRemoteCommand(
   const SESSION_COMMANDS = new Set(["resume_session", "fork_session", "kill_session", "send_keys", "escape", "rewind", "set_model"]);
   if (SESSION_COMMANDS.has(command) && commandArgs && syncServiceRef) {
     try {
-      const convId = JSON.parse(commandArgs)?.conversation_id;
+      const parsedArgs = JSON.parse(commandArgs);
+      const convId = parsedArgs?.conversation_id;
       if (convId) {
         const info = await syncServiceRef.getConversationOwnerInfo(convId);
         if (ownedByAnotherLiveDevice(info)) {
           log(`[OWNER] skipping ${command} for ${String(convId).slice(0, 12)} — owned by live device ${info?.ownerDeviceId.slice(0, 8)}${info?.ownerIsRemote ? " (remote)" : ""} (not ${deviceId().slice(0, 8)})`);
-          return; // leave the command for the owner device
+          // …except a kill, which ALWAYS sweeps this machine's own panes first.
+          // Routing the command to the owner is still right (it holds the rest of
+          // the backends), but a pane physically here is only reachable from here:
+          // deferring to the owner left owner-mismatched panes unkillable from
+          // every device. The sweep is safe to run twice — it is has-session
+          // guarded and idempotent — and the owner==local case never reaches it.
+          if (command === "kill_session") {
+            const swept = await killLocalPanesForConversation(
+              convId,
+              typeof parsedArgs?.session_id === "string" && parsedArgs.session_id ? parsedArgs.session_id : undefined,
+              "OWNER",
+            );
+            if (swept > 0) log(`[OWNER] kill_session for ${String(convId).slice(0, 12)} swept ${swept} local pane(s) before deferring to the owner`);
+          }
+          return; // leave the rest of the command for the owner device
         }
       }
     } catch { /* on any error, fall through and execute (fail-open) */ }
@@ -3559,7 +3639,7 @@ async function executeRemoteCommand(
 
           if (realForkId) {
             restartingSessionIds.set(realForkId, Date.now());
-            const resumed = await autoResumeSession(realForkId, "", readTitleCache(), projectPath, conversationId, "opencode");
+            const resumed = await autoResumeSession(realForkId, "", readTitleCache(), projectPath, conversationId, "opencode", USER_RESUME);
             restartingSessionIds.delete(realForkId);
             if (resumed) {
               syncServiceRef?.markSessionActive(conversationId).catch(logConvexFailure);
@@ -3636,13 +3716,13 @@ async function executeRemoteCommand(
         let resumed = false;
         if (forceReconstitute) {
           log(`[REMOTE] Force-reconstituting session ${sessionId.slice(0, 8)} from DB${projectPath ? ` in ${projectPath}` : ""}`);
-          resumed = await repairAndResumeSession(sessionId, "", readTitleCache(), projectPath, conversationId, resumeAgentType);
+          resumed = await repairAndResumeSession(sessionId, "", readTitleCache(), projectPath, conversationId, resumeAgentType, USER_RESUME);
         } else {
           log(`[REMOTE] Force-resuming session ${sessionId.slice(0, 8)}${projectPath ? ` in ${projectPath}` : ""}`);
-          resumed = await autoResumeSession(sessionId, "", readTitleCache(), projectPath, conversationId, resumeAgentType);
+          resumed = await autoResumeSession(sessionId, "", readTitleCache(), projectPath, conversationId, resumeAgentType, USER_RESUME);
           if (!resumed) {
             log(`[REMOTE] Auto-resume failed for ${sessionId.slice(0, 8)}, attempting repair...`);
-            resumed = await repairAndResumeSession(sessionId, "", readTitleCache(), projectPath, conversationId, resumeAgentType);
+            resumed = await repairAndResumeSession(sessionId, "", readTitleCache(), projectPath, conversationId, resumeAgentType, USER_RESUME);
           }
         }
         if (resumed) {
@@ -3710,7 +3790,7 @@ async function executeRemoteCommand(
                 setPosition(reconFilePath, fs.statSync(reconFilePath).size);
                 log(`[REMOTE] Reconstituted ${reconAgent} JSONL for ${sessionId.slice(0, 8)} (${exportData.messages.length} msgs)`);
 
-                const reconResumed = await autoResumeSession(newSessionId, "", readTitleCache(), cwd, conversationId, resumeAgentType);
+                const reconResumed = await autoResumeSession(newSessionId, "", readTitleCache(), cwd, conversationId, resumeAgentType, USER_RESUME);
                 if (reconResumed) {
                   const cache = readConversationCache();
                   cache[newSessionId] = conversationId;
@@ -9226,6 +9306,35 @@ export function transcriptTailLastRealRole(tailContent: string): "user" | "assis
   return null;
 }
 
+// The wall-clock timestamp of the most recent *real* message in a Claude JSONL
+// tail (epoch ms), or null when none parses or carries one. Same scan as
+// transcriptTailLastRealRole, reading the `timestamp` field real turns carry and
+// meta lines don't.
+//
+// This is the honest "when did anything actually happen" clock, and file mtime is
+// NOT: metadata touches rewrite mtime with no new content (2026-08-03 — two
+// transcripts whose last real message was 13 days old carried an mtime from that
+// morning). Any gate measured in days must use this, not fs.statSync.
+export function transcriptTailLastRealTimestamp(tailContent: string): number | null {
+  const lines = tailContent.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    let d: { type?: string; timestamp?: unknown; message?: { role?: string } };
+    try {
+      d = JSON.parse(line);
+    } catch {
+      continue; // partial/corrupt line (mid-write tail) -> skip
+    }
+    const role = d.message?.role ?? (d.type === "user" || d.type === "assistant" ? d.type : undefined);
+    if (role !== "user" && role !== "assistant") continue; // system/meta -> keep scanning
+    if (typeof d.timestamp !== "string") return null;
+    const ms = Date.parse(d.timestamp);
+    return Number.isFinite(ms) ? ms : null;
+  }
+  return null;
+}
+
 // permission_blocked is a latch with no other recovery path: the daemon doesn't
 // drive AskUserQuestion resolution, reconciledStatus deliberately skips it, and the
 // pane reconcile can't tell an answered poll from a pending one. So a lost resume
@@ -11689,8 +11798,18 @@ async function sweepGitPlaneFleet(sessionIds: string[]): Promise<void> {
 // ─── Orphan terminal reaper ────────────────────────────────────────────────
 // The daemon keeps a warm tmux terminal per managed session and (deliberately)
 // never auto-kills idle ones, so every conversation ever resumed leaves a
-// cc-resume-* / cx-resume-* terminal behind. They accumulate without bound and,
-// once re-adopted on a restart, re-float a stale "working" into the inbox.
+// cc-resume-* / cx-resume-* terminal behind, and every started one a
+// cc-<agent>-<conv> pane. They accumulate without bound and, once re-adopted on
+// a restart, re-float a stale "working" into the inbox.
+//
+// Two candidate classes, differing ONLY in the extra hide-state gate:
+//   - cc-resume-* / cx-resume-*: a warm re-resume shell. Reaped on the idle
+//     signals alone — clicking the session cold-resumes it, so nothing is lost.
+//   - any other codecast-stamped pane (@codecast_session_id /
+//     @codecast_conversation_id): the session's PRIMARY terminal. Reaped only
+//     when its conversation is already out of the inbox — stashed, dismissed or
+//     killed. A conversation VISIBLE in the inbox is never auto-reaped, however
+//     long it has been idle, because the user is still holding it.
 //
 // This reaps a terminal ONLY when multiple independent ground-truth signals agree
 // it is finished, and writes every kill to a dedicated reaper.log so the action is
@@ -11706,16 +11825,138 @@ async function sweepGitPlaneFleet(sessionIds: string[]): Promise<void> {
 // so it cold-resumes on click. The kill first removes the session from the
 // heartbeat / pane-tracking sets so heartbeatHealthCheck can't reconstitute it.
 const REAPER_LOG_FILE = path.join(CONFIG_DIR, "reaper.log");
+const REAPER_LOG_MAX_BYTES = 1_000_000;
 const REAP_IDLE_MS = 5 * 60 * 60 * 1000;    // 5h of no transcript activity
+// The higher bar a DANGLING USER TURN must clear (measured from the last real
+// message, never mtime). See danglingUserTurnIsReapable.
+const REAP_DANGLING_TURN_IDLE_MS = 24 * 60 * 60 * 1000;
 const REAP_MAX_PER_PASS = 3;                 // gentle drain; first kills stay observable
 const REAP_EVERY_N_FLUSHES = 10;             // ~5 min between passes (flush = 30s)
 const REAP_TMUX_PREFIXES = ["cc-resume-", "cx-resume-"];
+// Name + both codecast stamps in ONE tmux call, so identifying every candidate
+// costs one exec per pass instead of one show-options per pane.
+const REAP_LIST_FORMAT = "#{session_name}\t#{@codecast_session_id}\t#{@codecast_conversation_id}";
 
-function reaperLog(message: string): void {
+function reaperLog(message: string, mirror = true): void {
   const line = `[${new Date().toISOString()}] ${message}\n`;
+  try {
+    // Nothing rotates this file, and the per-pass summary appends every ~5 min
+    // forever — keep the tail, drop the oldest half once it gets large.
+    if (fs.statSync(REAPER_LOG_FILE).size > REAPER_LOG_MAX_BYTES) {
+      const kept = fs.readFileSync(REAPER_LOG_FILE, "utf8").slice(-REAPER_LOG_MAX_BYTES / 2);
+      fs.writeFileSync(REAPER_LOG_FILE, kept.slice(kept.indexOf("\n") + 1));
+    }
+  } catch {}
   try { fs.appendFileSync(REAPER_LOG_FILE, line); } catch {}
   // Mirror to daemon.log (and the server log feed) at warn — a kill is notable.
-  log(`[REAPER] ${message}`, "warn");
+  // The per-pass summary passes mirror=false: it fires every ~5 min and would
+  // swamp the feed, but belongs in reaper.log where the kills are.
+  if (mirror) log(`[REAPER] ${message}`, "warn");
+}
+
+export type ReapCandidate = {
+  tmux: string;
+  /** From @codecast_session_id, when the pane carries it. */
+  sessionId: string | null;
+  /** From @codecast_conversation_id, when the pane carries it. */
+  convId: string | null;
+  /** "resume" panes reap on idle alone; "stamped" panes also need a hide state. */
+  kind: "resume" | "stamped";
+};
+
+// One `tmux list-sessions` row: name + the two codecast stamps, tab-separated
+// (see REAP_LIST_FORMAT). Returns null for a pane this daemon has no business
+// touching — neither a resume shell nor codecast-stamped. Unset user options
+// expand to the empty string, and an ancient tmux that doesn't expand `#{@opt}`
+// at all just yields no stamps, so a pane goes uncollected rather than
+// misidentified.
+export function parseReapCandidateRow(row: string): ReapCandidate | null {
+  const [name, sessionId, convId] = row.split("\t");
+  const tmux = (name ?? "").trim();
+  if (!tmux) return null;
+  const stampedSession = (sessionId ?? "").trim() || null;
+  const stampedConv = (convId ?? "").trim() || null;
+  if (REAP_TMUX_PREFIXES.some((p) => tmux.startsWith(p))) {
+    return { tmux, sessionId: stampedSession, convId: stampedConv, kind: "resume" };
+  }
+  if (stampedSession || stampedConv) {
+    return { tmux, sessionId: stampedSession, convId: stampedConv, kind: "stamped" };
+  }
+  return null;
+}
+
+// Whether a stamped (primary-terminal) pane's conversation is hidden enough to
+// reap. Killed, stashed and dismissed all mean the user has taken the card out
+// of their inbox; anything still visible there is off limits regardless of idle
+// time, and a PINNED card is visible even when killed (see shouldShowInInbox).
+// Unknown lifecycle fails CLOSED — the opposite of the resurrection gate,
+// because here the cautious move is to leave the agent running.
+export function stampedPaneReapEligibility(
+  lifecycle: ConversationLifecycle | null | undefined,
+): { eligible: boolean; reason: string | null } {
+  if (!lifecycle) return { eligible: false, reason: "hide-state-unknown" };
+  if (lifecycle.inboxPinnedAt) return { eligible: false, reason: "pinned" };
+  const hidden = !!(lifecycle.inboxKilledAt || lifecycle.inboxStashedAt || lifecycle.inboxDismissedAt);
+  if (!hidden) return { eligible: false, reason: "inbox-visible" };
+  return { eligible: true, reason: null };
+}
+
+/**
+ * Rescues the ONE case where `transcript=active` blocks a reap forever.
+ *
+ * classifyTranscriptTail reads a trailing user turn as "active" — it is the
+ * agent's move — with no staleness dimension. When an agent dies or wedges
+ * mid-turn, the transcript is frozen with the user's unanswered prompt last, so
+ * the tail reads "active" for all eternity and the pane is permanently
+ * un-reapable. That is the unbounded accumulator: 25 of this machine's 267 idle
+ * Claude transcripts (~9%) are stuck exactly this way, some 682h old.
+ *
+ * A dead agent is not mid-turn. So a DANGLING user turn reaps once every
+ * independent signal agrees it is abandoned: the live pane already reads idle
+ * (guaranteed by reapBlockReason's ordering, passed explicitly so this decision
+ * is complete on its own), and the last real message is older than the raised
+ * REAP_DANGLING_TURN_IDLE_MS bar — measured from the MESSAGE timestamp, because
+ * mtime lies (see transcriptTailLastRealTimestamp).
+ *
+ * A pending tool_use still blocks at any age: that is real in-flight work, and
+ * an open AskUserQuestion lives there too. No timestamp → no honest clock → keep
+ * blocking. The fix lives here rather than in classifyTranscriptTail because the
+ * status-reconcile path depends on the classifier's current semantics.
+ */
+export function danglingUserTurnIsReapable(input: {
+  turn: TranscriptTurnState;
+  lastRealRole: "user" | "assistant" | null;
+  lastRealTimestampMs: number | null;
+  paneIdle: boolean;
+  now: number;
+}): boolean {
+  if (input.turn !== "active") return false;
+  if (input.lastRealRole !== "user") return false;
+  if (!input.paneIdle) return false;
+  if (input.lastRealTimestampMs === null) return false;
+  return input.now - input.lastRealTimestampMs >= REAP_DANGLING_TURN_IDLE_MS;
+}
+
+// Collapse a skip reason into a stable bucket for the per-pass summary — the raw
+// reasons embed the exact idle age ("active-37min"), which would give every pane
+// its own tally line.
+export function reapSkipBucket(reason: string): string {
+  return reason.startsWith("active-") ? "active" : reason;
+}
+
+// "pane=busy×3, no-transcript×8" — commonest first, so the reason the reaper is
+// doing nothing is the first thing on the line.
+export function summarizeReapSkips(reasons: string[]): string {
+  if (reasons.length === 0) return "none";
+  const counts = new Map<string, number>();
+  for (const r of reasons) {
+    const bucket = reapSkipBucket(r);
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([bucket, n]) => `${bucket}×${n}`)
+    .join(", ");
 }
 
 // Resolve the full session id for a cc-resume-* terminal. The tmux name carries
@@ -11760,8 +12001,23 @@ async function reapBlockReason(
   let tail: string;
   try { tail = readFileTailSync(file.path); } catch { return { reason: "tail-read-failed" }; }
   const turn = classifyTail(tail);
-  if (turn !== "idle") return { reason: `transcript=${turn}` };
-  return { reason: null, idleHours: Math.round(idleMs / 3600000) };
+  let idleHours = Math.round(idleMs / 3600000);
+  if (turn !== "idle") {
+    const lastRealTimestampMs = transcriptTailLastRealTimestamp(tail);
+    const reapable = danglingUserTurnIsReapable({
+      turn,
+      lastRealRole: transcriptTailLastRealRole(tail),
+      lastRealTimestampMs,
+      paneIdle: true, // established above — we only reach here when live === "idle"
+      now,
+    });
+    if (!reapable) return { reason: `transcript=${turn}` };
+    // Report the age the DECISION used. mtime can be far younger than the content
+    // (metadata touches), and logging "idle=16h" for a 325h-dead turn would make
+    // the reap look reckless in the audit log.
+    idleHours = Math.max(idleHours, Math.round((now - lastRealTimestampMs!) / 3600000));
+  }
+  return { reason: null, idleHours };
 }
 
 async function reapOneTerminal(sessionId: string, tmux: string, convId: string | undefined, idleHours: number): Promise<void> {
@@ -11789,25 +12045,41 @@ async function reapOneTerminal(sessionId: string, tmux: string, convId: string |
 
 async function reapIdleOrphanTerminals(): Promise<void> {
   const now = Date.now();
-  let names: string[];
+  let candidates: ReapCandidate[];
   try {
-    const { stdout } = await tmuxExec(["list-sessions", "-F", "#{session_name}"], { timeout: 5000 });
-    names = stdout.split("\n").map((s) => s.trim()).filter((s) => REAP_TMUX_PREFIXES.some((p) => s.startsWith(p)));
+    const { stdout } = await tmuxExec(["list-sessions", "-F", REAP_LIST_FORMAT], { timeout: 5000 });
+    candidates = stdout.split("\n")
+      .map(parseReapCandidateRow)
+      .filter((c): c is ReapCandidate => c !== null);
   } catch { return; }
-  if (names.length === 0) return;
+  if (candidates.length === 0) return;
 
   const convCache = readConversationCache();
+  const skips: string[] = [];
   let reaped = 0;
-  for (const tmux of names) {
-    if (reaped >= REAP_MAX_PER_PASS) break;
-    const sessionId = await resolveReapSessionId(tmux);
-    if (!sessionId) continue; // unidentifiable → never kill
-    const verdict = await reapBlockReason(sessionId, tmux, now);
-    if (verdict.reason !== null) continue; // ineligible (don't spam the log with skips)
-    await reapOneTerminal(sessionId, tmux, convCache[sessionId], verdict.idleHours);
+  for (const cand of candidates) {
+    if (reaped >= REAP_MAX_PER_PASS) { skips.push("pass-cap"); continue; }
+    const sessionId = cand.sessionId ?? await resolveReapSessionId(cand.tmux);
+    if (!sessionId) { skips.push("unidentified"); continue; } // never kill what we can't name
+    const verdict = await reapBlockReason(sessionId, cand.tmux, now);
+    if (verdict.reason !== null) { skips.push(verdict.reason); continue; }
+    const convId = cand.convId ?? convCache[sessionId];
+    // Only now — past the cheap idle/pane/tail gates, so at most a handful of
+    // panes per pass — pay the hide-state lookup for a primary terminal.
+    if (cand.kind === "stamped") {
+      const lifecycle = convId && syncServiceRef
+        ? await syncServiceRef.getConversationLifecycle(convId, sessionId).catch(() => null)
+        : null;
+      const eligibility = stampedPaneReapEligibility(lifecycle);
+      if (!eligibility.eligible) { skips.push(eligibility.reason!); continue; }
+    }
+    await reapOneTerminal(sessionId, cand.tmux, convId, verdict.idleHours);
     reaped++;
   }
-  if (reaped > 0) reaperLog(`pass complete: reaped ${reaped} terminal(s) (cap ${REAP_MAX_PER_PASS}, idle≥${REAP_IDLE_MS / 3600000}h)`);
+  // Every pass leaves a line: without it the skip reasons were invisible and a
+  // reaper that had quietly stopped reaping looked identical to one with nothing
+  // to do. File-only (mirror=false) — this fires every ~5 min.
+  reaperLog(`pass: ${candidates.length} candidates, reaped ${reaped}, skipped: ${summarizeReapSkips(skips)}`, false);
 }
 
 // Reads the last ~64KB of a file as UTF-8 without loading the whole thing --
@@ -11944,6 +12216,49 @@ async function heartbeatHealthCheck(sessionId: string): Promise<void> {
   }
 }
 
+// ─── Kill-state gate for resurrection ──────────────────────────────────────
+// The daemon keeps managed sessions warm and reconstitutes any whose tmux
+// vanished, which is right for a crash and wrong for a KILL — a kill tears the
+// pane down, the health sweep sees the vanished tmux, and the agent the user
+// just retired comes straight back (2026-08-03: five conversations, all
+// status=completed with inbox_killed_at stamped, resurrected on every pass).
+// The verdict is this pure function; "killed" and "completed" are equivalent
+// here, since killSession stamps both and a completed conversation is finished
+// either way.
+export function isConversationRetired(lifecycle: ConversationLifecycle | null | undefined): boolean {
+  // Unknown lifecycle fails OPEN: a Convex blip must not strand a genuinely
+  // crashed live session that the user still wants running.
+  if (!lifecycle) return false;
+  return !!lifecycle.inboxKilledAt || lifecycle.status === "completed";
+}
+
+export type ResumeOptions = {
+  /**
+   * This resume is an explicit human gesture (the resume_session / fork_session
+   * command), not the daemon reviving something on its own — so it bypasses the
+   * retired-conversation gate. It has to: restartSession leaves an existing row's
+   * status/inbox_killed_at untouched when it enqueues the kill→resume pair, so a
+   * "Restart" on a killed card reaches the daemon still looking killed, and
+   * refusing it would break the one gesture that is meant to bring a session back.
+   * Only the gate reads this; nothing downstream does.
+   */
+  userInitiated?: boolean;
+};
+
+// Convex side of the gate. Runs only on resurrection paths (rare), never per
+// heartbeat, and swallows lookup failures into "not retired" (fail open).
+async function conversationForbidsResurrection(
+  conversationId: string,
+  sessionId: string,
+  context: string,
+): Promise<boolean> {
+  if (!syncServiceRef) return false;
+  const lifecycle = await syncServiceRef.getConversationLifecycle(conversationId, sessionId).catch(() => null);
+  if (!isConversationRetired(lifecycle)) return false;
+  log(`[${context}] not reconstituting ${sessionId.slice(0, 8)} — conversation killed (conv=${conversationId.slice(0, 12)} status=${lifecycle?.status ?? "?"}${lifecycle?.inboxKilledAt ? " killed_at=set" : ""})`);
+  return true;
+}
+
 async function handleDeadSession(sessionId: string, tmuxSession: string): Promise<void> {
   try { await tmuxExec(["kill-session", "-t", tmuxSession]); } catch {}
   resumeSessionCache.delete(sessionId);
@@ -11952,6 +12267,18 @@ async function handleDeadSession(sessionId: string, tmuxSession: string): Promis
 
   const cache = readConversationCache();
   const conversationId = cache[sessionId];
+
+  // A retired conversation is not a crash. Tracking is already fully torn down
+  // above (the same set reapOneTerminal clears), so stamp the tidy "idle" and
+  // stop — before the transcript regeneration inside repairAndResumeSession and
+  // before the "Session crashed" banner, neither of which belongs on a session
+  // the user deliberately killed. autoResumeSession gates on this too (it is the
+  // chokepoint for every other resume path); this earlier check is what keeps
+  // the crash-recovery side effects from running at all.
+  if (conversationId && await conversationForbidsResurrection(conversationId, sessionId, "HEARTBEAT-HEALTH")) {
+    if (syncServiceRef) await syncServiceRef.updateSessionAgentStatus(conversationId, "idle").catch(() => {});
+    return;
+  }
 
   // Crash recovery shares the kill_session lifecycle contract: the tmux pane has
   // been torn down, any "injected" messages on Convex were lost with it, and the
@@ -12608,22 +12935,34 @@ async function resolveLiveTmuxTarget(
   return { tmuxTarget: null, source: null, proc: null, cachedStillValid };
 }
 
-async function autoResumeSession(sessionId: string, content: string, titleCache: TitleCache, cwdOverride?: string, conversationId?: string, agentTypeHint?: AgentClientId): Promise<boolean> {
-  // Remote-device safety gate: a remote daemon (the cloud Mac) ONLY manages
-  // sessions explicitly OWNED by it. Unlike the primary local daemon, it must
-  // NOT adopt/reconstitute/resume unowned sessions — doing so reconstitutes the
-  // user's real sessions from Convex and double-manages them (cross-device
-  // stomp). The local primary daemon keeps its legacy adopt-unowned behavior.
-  if (isRemoteDevice()) {
-    if (!conversationId) {
-      log(`[OWNER] remote daemon skipping resume of ${sessionId.slice(0, 8)} — no conversation id to verify ownership`);
-      return false;
-    }
-    const owner = syncServiceRef ? await syncServiceRef.getConversationOwner(conversationId) : null;
-    if (owner !== deviceId()) {
-      log(`[OWNER] remote daemon skipping resume of ${sessionId.slice(0, 8)} — owner=${owner ? owner.slice(0, 8) : "unowned"} (this device ${deviceId().slice(0, 8)})`);
-      return false;
-    }
+async function autoResumeSession(sessionId: string, content: string, titleCache: TitleCache, cwdOverride?: string, conversationId?: string, agentTypeHint?: AgentClientId, opts?: ResumeOptions): Promise<boolean> {
+  // Lifecycle gate: a killed/completed conversation must never come back on its
+  // own. This is the chokepoint every AUTOMATIC resurrection path funnels through
+  // (the health check's reconstitution, message-delivery resume, the warm pool,
+  // repairAndResumeSession), so the check lives here rather than at each caller.
+  // Fails OPEN on a lookup error.
+  if (!opts?.userInitiated && conversationId && await conversationForbidsResurrection(conversationId, sessionId, "RESUME")) {
+    return false;
+  }
+
+  // Single-owner resume gate — see resumeOwnerVerdict for the two rules it folds
+  // together. One owner lookup serves both.
+  const ownerInfo = conversationId && syncServiceRef
+    ? await syncServiceRef.getConversationOwnerInfo(conversationId)
+    : null;
+  const verdict = resumeOwnerVerdict({ conversationId, localDeviceId: deviceId(), isRemote: isRemoteDevice(), owner: ownerInfo });
+  if (verdict === "owned_by_live_device") {
+    log(`[OWNER] skipping resume of ${sessionId.slice(0, 8)} — owned by live device ${ownerInfo!.ownerDeviceId.slice(0, 8)}${ownerInfo!.ownerIsRemote ? " (remote)" : ""} (not ${deviceId().slice(0, 8)})`);
+    return false;
+  }
+  if (verdict === "remote_no_conversation") {
+    log(`[OWNER] remote daemon skipping resume of ${sessionId.slice(0, 8)} — no conversation id to verify ownership`);
+    return false;
+  }
+  if (verdict === "remote_unowned") {
+    const owner = ownerInfo?.ownerDeviceId;
+    log(`[OWNER] remote daemon skipping resume of ${sessionId.slice(0, 8)} — owner=${owner ? owner.slice(0, 8) : "unowned"} (this device ${deviceId().slice(0, 8)})`);
+    return false;
   }
   // Deduplicate concurrent resume attempts on the same session
   const existing = resumeInFlight.get(sessionId);
@@ -13099,7 +13438,8 @@ async function repairAndResumeSession(
   titleCache: TitleCache,
   cwdOverride?: string,
   conversationId?: string,
-  agentTypeHint?: AgentClientId
+  agentTypeHint?: AgentClientId,
+  opts?: ResumeOptions
 ): Promise<boolean> {
   const existing = repairInFlight.get(sessionId);
   if (existing) return existing;
@@ -13121,7 +13461,7 @@ async function repairAndResumeSession(
   const repairType = agentTypeHint ?? findSessionFile(sessionId)?.agentType ?? "claude";
   if (clientOwnsSessionStore(repairType)) {
     log(`Repairing ${repairType} session ${sessionId.slice(0, 8)} = re-resume (${repairType} owns its session store; no Claude/Codex JSONL to regenerate)`);
-    return autoResumeSession(sessionId, content, titleCache, cwdOverride, conversationId, repairType);
+    return autoResumeSession(sessionId, content, titleCache, cwdOverride, conversationId, repairType, opts);
   }
 
   const promise = (async (): Promise<boolean> => {
@@ -13190,7 +13530,7 @@ async function repairAndResumeSession(
           }
           log(`Materialized fresh Claude session ${targetSessionId.slice(0, 8)} from stale ${sessionId.slice(0, 8)} (${exportData.messages.length} messages, tail=${tailMessages})`);
 
-          const resumed = await autoResumeSession(targetSessionId, content, titleCache, cwdOverride || projectPath, convId, agentTypeHint);
+          const resumed = await autoResumeSession(targetSessionId, content, titleCache, cwdOverride || projectPath, convId, agentTypeHint, opts);
           if (resumed) {
             log(`Repair + resume succeeded for ${sessionId.slice(0, 8)} via fresh session ${targetSessionId.slice(0, 8)}`);
             success = true;
@@ -13216,7 +13556,7 @@ async function repairAndResumeSession(
           log(`Wrote new session file for ${sessionId.slice(0, 8)}`);
         }
 
-        const resumed = await autoResumeSession(sessionId, content, titleCache, cwdOverride || projectPath, convId, agentTypeHint);
+        const resumed = await autoResumeSession(sessionId, content, titleCache, cwdOverride || projectPath, convId, agentTypeHint, opts);
         if (resumed) {
           log(`Repair + resume succeeded for ${sessionId.slice(0, 8)}`);
           success = true;
@@ -13263,7 +13603,7 @@ async function repairAndResumeSession(
           fs.writeFileSync(sessionFile.path, cleanLines.join("\n") + "\n");
           log(`Surgical cleanup: removed ${removed} corrupt entries from ${sessionId.slice(0, 8)}`);
 
-          const resumed = await autoResumeSession(sessionId, content, titleCache, cwdOverride, convId, agentTypeHint);
+          const resumed = await autoResumeSession(sessionId, content, titleCache, cwdOverride, convId, agentTypeHint, opts);
           if (resumed) {
             log(`Surgical repair + resume succeeded for ${sessionId.slice(0, 8)}`);
             success = true;

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2329,6 +2329,45 @@ export function resumeOwnerVerdict(input: {
   return "proceed";
 }
 
+// Every tmux name start_session could have minted for a conversation
+// (cc-<agent>-<convId.slice(-12)>), for EVERY launchable agent — sourced from the
+// shared registry, because the old hardcoded ["claude","codex","cursor","gemini"]
+// silently leaked opencode and pi panes, and this sweep is the ONLY teardown on
+// the owner-defer path: a missing id there means a permanently unkillable pane.
+export function derivedPaneNamesForConversation(conversationId: string): string[] {
+  const convSuffix = conversationId.slice(-12);
+  return Object.keys(AGENT_CLIENTS).map((agent) => `cc-${agent}-${convSuffix}`);
+}
+
+// Everything killConversationBackends clears per session, in one place so the
+// owner-defer sweep can't drift from it. resumeInFlight matters most: a resume
+// that passed the lifecycle/owner gates BEFORE the kill is still holding a
+// promise, and leaving its entry behind lets the next delivery join that stale
+// promise and adopt the pane it recreates. (This narrows the window; it cannot
+// cancel a resume already in flight — one that lands after the sweep is caught by
+// the next health check or reaper pass.)
+export function clearSessionTrackingForKill(sessionId: string | null | undefined): void {
+  if (!sessionId) return;
+  stopManagedSessionHeartbeat(sessionId);
+  stopCodexPermissionPoller(sessionId);
+  resumeSessionCache.delete(sessionId);
+  sessionProcessCache.delete(sessionId);
+  resumeInFlight.delete(sessionId);
+  resumeInFlightStarted.delete(sessionId);
+  restartingSessionIds.delete(sessionId);
+}
+
+// Test/inspection seam: which per-session kill-teardown maps still hold an entry.
+export function sessionKillTrackingSnapshot(sessionId: string): Record<string, boolean> {
+  return {
+    pane: resumeSessionCache.has(sessionId),
+    resumeInFlight: resumeInFlight.has(sessionId),
+    resumeInFlightStarted: resumeInFlightStarted.has(sessionId),
+    restarting: restartingSessionIds.has(sessionId),
+    process: sessionProcessCache.has(sessionId),
+  };
+}
+
 /**
  * Kill every tmux pane for a conversation that is PHYSICALLY on this machine,
  * regardless of who the conversation records as its owner. A pane in this
@@ -2351,12 +2390,7 @@ async function killLocalPanesForConversation(
   context: string,
 ): Promise<number> {
   let killed = 0;
-  const stopTracking = (id: string | null | undefined) => {
-    if (!id) return;
-    stopManagedSessionHeartbeat(id);
-    stopCodexPermissionPoller(id);
-    resumeSessionCache.delete(id);
-  };
+  const stopTracking = (id: string | null | undefined) => clearSessionTrackingForKill(id);
 
   const sessionId = sessionIdHint ?? buildReverseConversationCache(readConversationCache())[conversationId];
   if (sessionId) {
@@ -2376,8 +2410,7 @@ async function killLocalPanesForConversation(
   // agentType isn't in the kill args, so try every prefix; has-session guards
   // each (cheap, idempotent). The session id lives on the tmux itself, so we can
   // stop the right heartbeat even when no lookup table maps this conversation.
-  const convSuffix = conversationId.slice(-12);
-  for (const derivedName of ["claude", "codex", "cursor", "gemini"].map((a) => `cc-${a}-${convSuffix}`)) {
+  for (const derivedName of derivedPaneNamesForConversation(conversationId)) {
     if (!validateTmuxTarget(derivedName)) continue;
     try {
       await tmuxExec(["has-session", "-t", derivedName], { timeout: 3000 });
@@ -2522,12 +2555,17 @@ async function executeRemoteCommand(
           // every device. The sweep is safe to run twice — it is has-session
           // guarded and idempotent — and the owner==local case never reaches it.
           if (command === "kill_session") {
-            const swept = await killLocalPanesForConversation(
-              convId,
-              typeof parsedArgs?.session_id === "string" && parsedArgs.session_id ? parsedArgs.session_id : undefined,
-              "OWNER",
-            );
-            if (swept > 0) log(`[OWNER] kill_session for ${String(convId).slice(0, 12)} swept ${swept} local pane(s) before deferring to the owner`);
+            const sessionIdHint = typeof parsedArgs?.session_id === "string" && parsedArgs.session_id ? parsedArgs.session_id : undefined;
+            const swept = await killLocalPanesForConversation(convId, sessionIdHint, "OWNER");
+            // The owner runs the real teardown, but the local delivery/resume
+            // caches are OURS and would otherwise survive the kill and suppress
+            // (or resurrect) the next message. Always clear them — and always say
+            // so: a silent swept-0 is indistinguishable from the command never
+            // arriving, which is how this path stayed invisible.
+            await clearConversationDeliveryAndResumeState(convId, sessionIdHint, "OWNER");
+            log(swept > 0
+              ? `[OWNER] kill_session for ${String(convId).slice(0, 12)} swept ${swept} local pane(s) and cleared in-flight resume state before deferring to the owner`
+              : `[OWNER] kill_session for ${String(convId).slice(0, 12)} — no local panes; cleared in-flight resume state`);
           }
           return; // leave the rest of the command for the owner device
         }
@@ -11894,7 +11932,12 @@ export function parseReapCandidateRow(row: string): ReapCandidate | null {
 export function stampedPaneReapEligibility(
   lifecycle: ConversationLifecycle | null | undefined,
 ): { eligible: boolean; reason: string | null } {
-  if (!lifecycle) return { eligible: false, reason: "hide-state-unknown" };
+  // "Absent hide fields" is NOT "not hidden". The status-only fallback carries no
+  // hide state at all, and reading its silence as "inbox-visible" would put a lie
+  // in the audit log (killed conversations reported as visible-and-skipped) while
+  // the stamped reaper silently no-ops against an undeployed backend. Demand that
+  // the state was actually fetched.
+  if (!lifecycle || !lifecycle.hideStateKnown) return { eligible: false, reason: "hide-state-unknown" };
   if (lifecycle.inboxPinnedAt) return { eligible: false, reason: "pinned" };
   const hidden = !!(lifecycle.inboxKilledAt || lifecycle.inboxStashedAt || lifecycle.inboxDismissedAt);
   if (!hidden) return { eligible: false, reason: "inbox-visible" };
@@ -11918,15 +11961,26 @@ export function stampedPaneReapEligibility(
  * REAP_DANGLING_TURN_IDLE_MS bar — measured from the MESSAGE timestamp, because
  * mtime lies (see transcriptTailLastRealTimestamp).
  *
- * A pending tool_use still blocks at any age: that is real in-flight work, and
- * an open AskUserQuestion lives there too. No timestamp → no honest clock → keep
- * blocking. The fix lives here rather than in classifyTranscriptTail because the
- * status-reconcile path depends on the classifier's current semantics.
+ * A pending tool_use still blocks at any age: that is real in-flight work. No
+ * timestamp → no honest clock → keep blocking. The fix lives here rather than in
+ * classifyTranscriptTail because the status-reconcile path depends on the
+ * classifier's current semantics.
+ *
+ * A PENDING AskUserQuestion looks EXACTLY like a dangling user turn and must be
+ * excluded separately. Claude Code buffers the AUQ tool_use out of the JSONL
+ * until it is answered (see extractPendingToolUseFromTail), so while a question
+ * waits, the newest message physically in the transcript is the previous,
+ * already-resolved tool_result — a `user` turn. lastRealRole cannot see the
+ * question, and the pane classifier's modal detection is regex on footer copy,
+ * one release away from letting a live question-blocked session be killed. So we
+ * consult the ask-input sidecar directly — see askUserQuestionStillPending.
  */
 export function danglingUserTurnIsReapable(input: {
   turn: TranscriptTurnState;
   lastRealRole: "user" | "assistant" | null;
   lastRealTimestampMs: number | null;
+  /** mtime of ~/.codecast/ask-input/<session>.json, or null when absent. */
+  askSidecarMtimeMs: number | null;
   paneIdle: boolean;
   now: number;
 }): boolean {
@@ -11934,7 +11988,34 @@ export function danglingUserTurnIsReapable(input: {
   if (input.lastRealRole !== "user") return false;
   if (!input.paneIdle) return false;
   if (input.lastRealTimestampMs === null) return false;
+  if (askUserQuestionStillPending(input.askSidecarMtimeMs, input.lastRealTimestampMs)) return false;
   return input.now - input.lastRealTimestampMs >= REAP_DANGLING_TURN_IDLE_MS;
+}
+
+/**
+ * Whether an AskUserQuestion is still waiting on the user, judged by ORDERING
+ * rather than existence.
+ *
+ * The sidecar is written when the question is asked and is NEVER deleted —
+ * readAskUserQuestionInput copes via a 5-minute mtime window, and this machine
+ * has 123 of them going back to June. So "a sidecar exists" is nearly meaningless
+ * (it blocked 5 of 23 stuck panes here, 3 of whose questions were answered weeks
+ * ago) and gets monotonically worse as sessions accumulate one each — it would
+ * quietly retire this escape hatch altogether.
+ *
+ * Ordering is the honest signal: answering a question flushes the buffered turn
+ * AND appends the user's answer, so the transcript gains a message NEWER than the
+ * sidecar. A sidecar newer than the last real message therefore means the
+ * question was asked and nothing has happened since — still pending. On the same
+ * 23 panes this correctly protects exactly 2, both genuinely abandoned mid-question.
+ */
+export function askUserQuestionStillPending(
+  sidecarMtimeMs: number | null,
+  lastRealTimestampMs: number | null,
+): boolean {
+  if (sidecarMtimeMs === null) return false;
+  if (lastRealTimestampMs === null) return true; // can't order them → assume pending
+  return sidecarMtimeMs > lastRealTimestampMs;
 }
 
 // Collapse a skip reason into a stable bucket for the per-pass summary — the raw
@@ -11980,13 +12061,56 @@ async function resolveReapSessionId(tmux: string): Promise<string | null> {
   return null;
 }
 
+// findSessionFile walks every ~/.claude/projects dir with sync readdir (~4.5ms on
+// a miss) and the reaper now calls it per candidate per pass. Cache the resolved
+// transcript across passes, revalidated with a single statSync; a moved/deleted
+// file falls back to the full walk. Reaper-local on purpose — findSessionFile has
+// many other callers whose freshness assumptions we're not touching.
+const reapTranscriptCache = new Map<string, SessionFileInfo>();
+
+function findReapTranscript(sessionId: string): SessionFileInfo | null {
+  const cached = reapTranscriptCache.get(sessionId);
+  if (cached) {
+    try {
+      fs.statSync(cached.path);
+      return cached;
+    } catch {
+      reapTranscriptCache.delete(sessionId);
+    }
+  }
+  const found = findSessionFile(sessionId);
+  if (found) reapTranscriptCache.set(sessionId, found);
+  return found;
+}
+
+// mtime of the pending-AskUserQuestion sidecar, or null when the session never
+// asked one. See askUserQuestionStillPending for why mtime and not existence.
+function askInputSidecarMtimeMs(sessionId: string): number | null {
+  try {
+    return fs.statSync(path.join(ASK_INPUT_DIR, `${sessionId}.json`)).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+// `tmux list-panes -s -t <sess>` emits one line per pane across ALL windows.
+// killTmuxSessionAndTree takes the whole tmux SESSION, while every reap gate only
+// inspects :0.0 — so a second window or a split (the user's own shell, or another
+// live agent) would die on the strength of one idle pane's evidence. Exactly one
+// pane means what we inspected is all there is. Unparseable output → not single
+// (fail closed).
+export function tmuxSessionIsSinglePane(listPanesStdout: string): boolean {
+  const panes = listPanesStdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  return panes.length === 1;
+}
+
 // The reason a terminal is NOT safe to reap, or null if it passed every gate.
 // On success returns the resolved transcript path + idle age so the caller need
 // not re-scan. Cheapest gates first (idle-age before the pane/tail reads).
 async function reapBlockReason(
   sessionId: string, tmux: string, now: number,
 ): Promise<{ reason: string } | { reason: null; idleHours: number }> {
-  const file = findSessionFile(sessionId);
+  const file = findReapTranscript(sessionId);
   if (!file) return { reason: "no-transcript" };
   const classifyTail = classifyTranscriptTailFor(file.agentType);
   if (!classifyTail) return { reason: `agent=${file.agentType}` };
@@ -12004,14 +12128,22 @@ async function reapBlockReason(
   let idleHours = Math.round(idleMs / 3600000);
   if (turn !== "idle") {
     const lastRealTimestampMs = transcriptTailLastRealTimestamp(tail);
+    const askSidecarMtimeMs = askInputSidecarMtimeMs(sessionId);
     const reapable = danglingUserTurnIsReapable({
       turn,
       lastRealRole: transcriptTailLastRealRole(tail),
       lastRealTimestampMs,
+      askSidecarMtimeMs,
       paneIdle: true, // established above — we only reach here when live === "idle"
       now,
     });
-    if (!reapable) return { reason: `transcript=${turn}` };
+    if (!reapable) {
+      // Name the AUQ case separately: "transcript=active" on a session that is
+      // actually waiting on a question is the misleading log line that hid this.
+      return askUserQuestionStillPending(askSidecarMtimeMs, lastRealTimestampMs)
+        ? { reason: "pending-question" }
+        : { reason: `transcript=${turn}` };
+    }
     // Report the age the DECISION used. mtime can be far younger than the content
     // (metadata touches), and logging "idle=16h" for a 325h-dead turn would make
     // the reap look reckless in the audit log.
@@ -12064,9 +12196,15 @@ async function reapIdleOrphanTerminals(): Promise<void> {
     const verdict = await reapBlockReason(sessionId, cand.tmux, now);
     if (verdict.reason !== null) { skips.push(verdict.reason); continue; }
     const convId = cand.convId ?? convCache[sessionId];
-    // Only now — past the cheap idle/pane/tail gates, so at most a handful of
-    // panes per pass — pay the hide-state lookup for a primary terminal.
+    // A stamped pane is the session's PRIMARY terminal — the one a human may be
+    // attached to. Two extra gates, cheapest first: the whole tmux session must
+    // be the single pane we actually inspected, and its conversation must already
+    // be out of the inbox. (cc-resume-* shells skip both: nobody attaches to them.)
     if (cand.kind === "stamped") {
+      let panes: string;
+      try { ({ stdout: panes } = await tmuxExec(["list-panes", "-s", "-t", cand.tmux, "-F", "#{window_index}.#{pane_index}"], { timeout: 4000 })); }
+      catch { skips.push("pane-list-failed"); continue; }
+      if (!tmuxSessionIsSinglePane(panes)) { skips.push("multi-pane"); continue; }
       const lifecycle = convId && syncServiceRef
         ? await syncServiceRef.getConversationLifecycle(convId, sessionId).catch(() => null)
         : null;
@@ -12225,10 +12363,22 @@ async function heartbeatHealthCheck(sessionId: string): Promise<void> {
 // The verdict is this pure function; "killed" and "completed" are equivalent
 // here, since killSession stamps both and a completed conversation is finished
 // either way.
-export function isConversationRetired(lifecycle: ConversationLifecycle | null | undefined): boolean {
+export function isConversationRetired(
+  lifecycle: ConversationLifecycle | null | undefined,
+  opts: { trustStatusFallback: boolean },
+): boolean {
   // Unknown lifecycle fails OPEN: a Convex blip must not strand a genuinely
   // crashed live session that the user still wants running.
   if (!lifecycle) return false;
+  // The status-only fallback resolves by session id via `.first()` — the OLDEST
+  // twin (ct-36973). With twins it can report the wrong row's status in EITHER
+  // direction, and a false "completed" here refuses to resume a LIVE session,
+  // silently stranding it. So only the caller that can absorb a wrong refusal may
+  // act on it: heartbeat reconstitution, where the worst case is a crashed
+  // session staying down — the pre-fix status quo, recoverable with Restart.
+  // Every other path (delivery, warm pool, resume repair) requires the real
+  // conversation-id-resolved query and otherwise proceeds.
+  if (!lifecycle.hideStateKnown && !opts.trustStatusFallback) return false;
   return !!lifecycle.inboxKilledAt || lifecycle.status === "completed";
 }
 
@@ -12247,15 +12397,19 @@ export type ResumeOptions = {
 
 // Convex side of the gate. Runs only on resurrection paths (rare), never per
 // heartbeat, and swallows lookup failures into "not retired" (fail open).
-async function conversationForbidsResurrection(
+export async function conversationForbidsResurrection(
   conversationId: string,
   sessionId: string,
   context: string,
+  opts: { trustStatusFallback: boolean },
+  // Injectable so the wired gate — including its fail-open on a throwing lookup —
+  // is testable without a live Convex client. Production always uses the default.
+  fetchLifecycle: (c: string, s: string) => Promise<ConversationLifecycle | null> = (c, sid) =>
+    syncServiceRef ? syncServiceRef.getConversationLifecycle(c, sid) : Promise.resolve(null),
 ): Promise<boolean> {
-  if (!syncServiceRef) return false;
-  const lifecycle = await syncServiceRef.getConversationLifecycle(conversationId, sessionId).catch(() => null);
-  if (!isConversationRetired(lifecycle)) return false;
-  log(`[${context}] not reconstituting ${sessionId.slice(0, 8)} — conversation killed (conv=${conversationId.slice(0, 12)} status=${lifecycle?.status ?? "?"}${lifecycle?.inboxKilledAt ? " killed_at=set" : ""})`);
+  const lifecycle = await fetchLifecycle(conversationId, sessionId).catch(() => null);
+  if (!isConversationRetired(lifecycle, opts)) return false;
+  log(`[${context}] not reconstituting ${sessionId.slice(0, 8)} — conversation killed (conv=${conversationId.slice(0, 12)} status=${lifecycle?.status ?? "?"}${lifecycle?.inboxKilledAt ? " killed_at=set" : ""} via=${lifecycle?.source})`);
   return true;
 }
 
@@ -12275,7 +12429,7 @@ async function handleDeadSession(sessionId: string, tmuxSession: string): Promis
   // the user deliberately killed. autoResumeSession gates on this too (it is the
   // chokepoint for every other resume path); this earlier check is what keeps
   // the crash-recovery side effects from running at all.
-  if (conversationId && await conversationForbidsResurrection(conversationId, sessionId, "HEARTBEAT-HEALTH")) {
+  if (conversationId && await conversationForbidsResurrection(conversationId, sessionId, "HEARTBEAT-HEALTH", { trustStatusFallback: true })) {
     if (syncServiceRef) await syncServiceRef.updateSessionAgentStatus(conversationId, "idle").catch(() => {});
     return;
   }
@@ -12941,7 +13095,7 @@ async function autoResumeSession(sessionId: string, content: string, titleCache:
   // (the health check's reconstitution, message-delivery resume, the warm pool,
   // repairAndResumeSession), so the check lives here rather than at each caller.
   // Fails OPEN on a lookup error.
-  if (!opts?.userInitiated && conversationId && await conversationForbidsResurrection(conversationId, sessionId, "RESUME")) {
+  if (!opts?.userInitiated && conversationId && await conversationForbidsResurrection(conversationId, sessionId, "RESUME", { trustStatusFallback: false })) {
     return false;
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5879,6 +5879,7 @@ program
         id: c.id, session_id: c.session_id, title: c.title, project_path: c.project_path,
         updated_at: c.updated_at, message_count: c.message_count, agent_type: c.agent_type,
         agent_status: c.agent_status, work_state: c.work_state || "idle", is_pinned: !!c.is_pinned,
+        is_killed: !!c.is_killed,
         is_live: !!c.is_live, is_unresponsive: false, awaiting_input: false,
         idle_summary: null, last_user_message: null, active_plan: null, active_task: null,
       }));
@@ -5986,6 +5987,14 @@ program
       const cur: typeof prevRows = {};
       for (const s of sessions) {
         if (!matchesId(s)) continue;
+        // A KILL is a DEPARTURE, not a transition. A retired row keeps showing
+        // up in the query (team scope lists it; a pinned solo row survives
+        // shouldShowInInbox), so leaving it in the watched set made every kill
+        // emit transition→idle — and a bulk kill emit a storm of them — into
+        // what fleet orchestration uses as its wake signal. Dropping it here
+        // leaves the "gone" pass below to announce it exactly once, with the
+        // state it left from.
+        if (s.is_killed) continue;
         cur[s.id] = { state: s.work_state, title: s.title ?? null, session_id: s.session_id ?? null };
         if (firstFrame) continue;
         const prev = prevRows[s.id];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3316,20 +3316,27 @@ program
   .argument("<session>", "Session short ID (e.g. jx7c6zk)")
   .action(async (session: string) => {
     const result = await cliPost("/cli/sessions/kill", { session });
-    if (result.outcome === "none") {
-      console.log(`${c.dim}${result.short_id} was already dismissed — nothing to tear down${c.reset}`);
-      return;
-    }
     const canceled = result.canceled_schedules
       ? `, canceled ${result.canceled_schedules} trigger${result.canceled_schedules === 1 ? "" : "s"}`
       : "";
     const grouped = result.cascaded_children
       ? ` with ${result.cascaded_children} nested worker${result.cascaded_children === 1 ? "" : "s"}`
       : "";
+    // Queued messages die with the session (they would otherwise land later and
+    // revive it), so say so — that's the user's content being dropped.
+    const dropped = result.canceled_messages
+      ? `, canceled ${result.canceled_messages} queued message${result.canceled_messages === 1 ? "" : "s"}`
+      : "";
+    // Kill is a desired state, not an event: an already-killed session gets its
+    // teardown re-enqueued (the server forces past the hide-flag transition), so
+    // say what happened instead of the old "nothing to tear down" dead end.
     const note = result.outcome === "reap"
       ? ` ${c.dim}(empty session — cleaned up entirely)${c.reset}`
-      : ` ${c.dim}— agent torn down${grouped}${canceled} (cast undismiss ${result.short_id} to resurface)${c.reset}`;
-    console.log(`${c.green}ok${c.reset} killed ${c.cyan}${result.short_id}${c.reset}${note}`);
+      : result.was_hidden
+        ? ` ${c.dim}— ${result.teardown_enqueued ? "teardown re-enqueued" : "teardown already queued for the daemon"}${grouped}${canceled}${dropped}${c.reset}`
+        : ` ${c.dim}— agent torn down${grouped}${canceled}${dropped} (cast undismiss ${result.short_id} to resurface)${c.reset}`;
+    const verb = result.was_hidden && result.outcome !== "reap" ? "re-killed" : "killed";
+    console.log(`${c.green}ok${c.reset} ${verb} ${c.cyan}${result.short_id}${c.reset}${note}`);
   });
 
 // ── cast keys ─────────────────────────────────────────────────────────────────

--- a/packages/cli/src/syncService.ts
+++ b/packages/cli/src/syncService.ts
@@ -244,6 +244,25 @@ export type ExecutionControlMutationName =
 
 export type ExecutionControlQueryName = "getExecutionAuthority" | "listExecutionWork";
 
+/**
+ * A conversation's own lifecycle + inbox visibility, as far as the daemon can
+ * see it. Every field is optional: an undefined field means "not known", never
+ * "not set" — see SyncService.getConversationLifecycle for which source
+ * populates what.
+ */
+export interface ConversationLifecycle {
+  status?: string | null;
+  inboxKilledAt?: number | null;
+  inboxStashedAt?: number | null;
+  inboxDismissedAt?: number | null;
+  inboxPinnedAt?: number | null;
+}
+
+// Flipped off for the process the first time conversations:getConversationLifecycle
+// comes back missing, so an undeployed query costs one round trip, not one per
+// resurrection/reap. A daemon restart re-probes.
+let lifecycleQueryAvailable = true;
+
 export interface GitInfo {
   commitHash?: string;
   branch?: string;
@@ -1291,6 +1310,58 @@ export class SyncService {
         ownerIsRemote: !!(res as any).owner_is_remote,
         ownerOnline: !!(res as any).owner_online,
       };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Lifecycle + inbox-visibility state of a conversation — the daemon's gate for
+   * "may I bring this session back?" and "may I reap its pane?". A killed or
+   * hidden conversation is exactly the one no automation may resurrect.
+   *
+   * The hide flags need a server query that does not exist yet
+   * (conversations:getConversationLifecycle — api_token authed, conversation_id
+   * in, {status, inbox_killed_at, inbox_stashed_at, inbox_dismissed_at,
+   * inbox_pinned_at} out). Until it ships this falls back to the existing
+   * api_token-authed devices:resolveConversationBySession, which carries
+   * `status` — enough to catch the completed/killed conversations the health
+   * check was resurrecting, but not the hide flags, which stay undefined so
+   * every caller that needs them fails closed. Returns null when nothing
+   * resolves, which callers read as "unknown".
+   */
+  async getConversationLifecycle(
+    conversationId: string,
+    sessionId?: string,
+  ): Promise<ConversationLifecycle | null> {
+    if (lifecycleQueryAvailable) {
+      try {
+        const res: any = await this.client.query("conversations:getConversationLifecycle" as any, {
+          api_token: this.apiToken,
+          conversation_id: conversationId,
+        });
+        if (res) {
+          return {
+            status: res.status ?? null,
+            inboxKilledAt: res.inbox_killed_at ?? null,
+            inboxStashedAt: res.inbox_stashed_at ?? null,
+            inboxDismissedAt: res.inbox_dismissed_at ?? null,
+            inboxPinnedAt: res.inbox_pinned_at ?? null,
+          };
+        }
+      } catch {
+        // Undeployed query: stop paying the round trip (and the server-side
+        // error log) for the rest of this daemon's life.
+        lifecycleQueryAvailable = false;
+      }
+    }
+    if (!sessionId) return null;
+    try {
+      const res: any = await this.client.query("devices:resolveConversationBySession" as any, {
+        api_token: this.apiToken,
+        session_id: sessionId,
+      });
+      return res ? { status: res.status ?? null } : null;
     } catch {
       return null;
     }

--- a/packages/cli/src/syncService.ts
+++ b/packages/cli/src/syncService.ts
@@ -246,9 +246,18 @@ export type ExecutionControlQueryName = "getExecutionAuthority" | "listExecution
 
 /**
  * A conversation's own lifecycle + inbox visibility, as far as the daemon can
- * see it. Every field is optional: an undefined field means "not known", never
- * "not set" — see SyncService.getConversationLifecycle for which source
- * populates what.
+ * see it. `source` is load-bearing, not decoration — the two sources are NOT
+ * interchangeable, and a caller that treats them as such gets a wrong answer:
+ *
+ *  - "lifecycle": the real query, resolved by CONVERSATION ID (an exact
+ *    ctx.db.get), carrying every field. `hideStateKnown` is true.
+ *  - "status-fallback": devices:resolveConversationBySession, which resolves by
+ *    SESSION ID with `.first()` — the OLDEST twin (this repo's ct-36973
+ *    foot-gun). It carries `status` only, so `hideStateKnown` is false, and with
+ *    twins the status may belong to the wrong row in either direction.
+ *
+ * An absent hide field means "not known", never "not set" — read `hideStateKnown`
+ * before believing any of them.
  */
 export interface ConversationLifecycle {
   status?: string | null;
@@ -256,12 +265,40 @@ export interface ConversationLifecycle {
   inboxStashedAt?: number | null;
   inboxDismissedAt?: number | null;
   inboxPinnedAt?: number | null;
+  /** True only when the hide fields were actually fetched (source === "lifecycle"). */
+  hideStateKnown: boolean;
+  source: "lifecycle" | "status-fallback";
 }
 
-// Flipped off for the process the first time conversations:getConversationLifecycle
-// comes back missing, so an undeployed query costs one round trip, not one per
-// resurrection/reap. A daemon restart re-probes.
-let lifecycleQueryAvailable = true;
+// An undeployed Convex function is a PERMANENT condition; a DNS blip, a 502 or a
+// sleep-killed socket is not. Latching the query off on the latter silently
+// degrades the resurrection gate and makes the reap hide-gate misclassify for the
+// rest of the daemon's life, so we match the missing-function shape narrowly and
+// treat everything else as transient.
+export function isMissingFunctionError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /could not find (public )?function|function not found|no such function/i.test(msg);
+}
+
+// 0 = believed available. Set to the failure time when the function is missing;
+// a re-probe past LIFECYCLE_REPROBE_MS heals a latch that was wrong (or that a
+// deploy has since fixed) without waiting for a daemon restart.
+let lifecycleQueryMissingSince = 0;
+const LIFECYCLE_REPROBE_MS = 6 * 60 * 60 * 1000;
+
+export function shouldProbeLifecycleQuery(
+  missingSince: number,
+  now: number,
+  reprobeMs: number = LIFECYCLE_REPROBE_MS,
+): boolean {
+  if (missingSince === 0) return true;
+  return now - missingSince >= reprobeMs;
+}
+
+/** Test seam: forget the latch so each case starts from a known state. */
+export function resetLifecycleQueryLatch(): void {
+  lifecycleQueryMissingSince = 0;
+}
 
 export interface GitInfo {
   commitHash?: string;
@@ -1334,12 +1371,13 @@ export class SyncService {
     conversationId: string,
     sessionId?: string,
   ): Promise<ConversationLifecycle | null> {
-    if (lifecycleQueryAvailable) {
+    if (shouldProbeLifecycleQuery(lifecycleQueryMissingSince, Date.now())) {
       try {
         const res: any = await this.client.query("conversations:getConversationLifecycle" as any, {
           api_token: this.apiToken,
           conversation_id: conversationId,
         });
+        lifecycleQueryMissingSince = 0; // the probe answered — clear any stale latch
         if (res) {
           return {
             status: res.status ?? null,
@@ -1347,21 +1385,29 @@ export class SyncService {
             inboxStashedAt: res.inbox_stashed_at ?? null,
             inboxDismissedAt: res.inbox_dismissed_at ?? null,
             inboxPinnedAt: res.inbox_pinned_at ?? null,
+            hideStateKnown: true,
+            source: "lifecycle",
           };
         }
-      } catch {
-        // Undeployed query: stop paying the round trip (and the server-side
-        // error log) for the rest of this daemon's life.
-        lifecycleQueryAvailable = false;
+        // Reached the query and it found nothing (deleted row / not ours). That
+        // is an answer, not an outage — don't paper over it with the fallback.
+        return null;
+      } catch (err) {
+        // ONLY an undeployed function latches. Anything else (network, 5xx,
+        // timeout) is transient: leave the latch alone and let the caller's own
+        // fail-open/fail-closed policy handle this one call.
+        if (isMissingFunctionError(err)) lifecycleQueryMissingSince = Date.now();
       }
     }
+    // Degraded path: status only, resolved by session id (oldest twin). Marked
+    // as such so callers can decide whether that is good enough for them.
     if (!sessionId) return null;
     try {
       const res: any = await this.client.query("devices:resolveConversationBySession" as any, {
         api_token: this.apiToken,
         session_id: sessionId,
       });
-      return res ? { status: res.status ?? null } : null;
+      return res ? { status: res.status ?? null, hideStateKnown: false, source: "status-fallback" } : null;
     } catch {
       return null;
     }

--- a/packages/cli/src/syncService.ts
+++ b/packages/cli/src/syncService.ts
@@ -1357,15 +1357,15 @@ export class SyncService {
    * "may I bring this session back?" and "may I reap its pane?". A killed or
    * hidden conversation is exactly the one no automation may resurrect.
    *
-   * The hide flags need a server query that does not exist yet
-   * (conversations:getConversationLifecycle — api_token authed, conversation_id
-   * in, {status, inbox_killed_at, inbox_stashed_at, inbox_dismissed_at,
-   * inbox_pinned_at} out). Until it ships this falls back to the existing
-   * api_token-authed devices:resolveConversationBySession, which carries
-   * `status` — enough to catch the completed/killed conversations the health
-   * check was resurrecting, but not the hide flags, which stay undefined so
-   * every caller that needs them fails closed. Returns null when nothing
-   * resolves, which callers read as "unknown".
+   * Three routes, best first — see the body for why each exists:
+   *   A. conversations:getConversationLifecycle by conversation_id (exact row)
+   *   B. the same query by session_id (NEWEST twin) when the id is a ghost
+   *   C. devices:resolveConversationBySession — status only, OLDEST twin — only
+   *      when the query itself is unavailable (undeployed backend / transient
+   *      error), never when it answered "no such conversation"
+   * A and B return `hideStateKnown: true`; C is marked degraded so callers can
+   * refuse to act on it. Returns null when nothing resolves, which callers read
+   * as "unknown" and handle per their own fail-open/fail-closed policy.
    */
   async getConversationLifecycle(
     conversationId: string,
@@ -1373,10 +1373,27 @@ export class SyncService {
   ): Promise<ConversationLifecycle | null> {
     if (shouldProbeLifecycleQuery(lifecycleQueryMissingSince, Date.now())) {
       try {
-        const res: any = await this.client.query("conversations:getConversationLifecycle" as any, {
+        // The query takes EXACTLY ONE selector (it returns null when both or
+        // neither are set), so the two routes are separate calls.
+        //
+        // Route A — the conversation id, an exact ctx.db.get. Always tried first:
+        // when the row exists this is unambiguous, with no twin reduction at all.
+        let res: any = await this.client.query("conversations:getConversationLifecycle" as any, {
           api_token: this.apiToken,
           conversation_id: conversationId,
         });
+        // Route B — the GHOST case, which is the whole reason a fallback exists:
+        // the id we were handed no longer resolves (deleted/remapped row, a
+        // client's cached copy), but the session is alive under a twin. The
+        // query's session route picks the NEWEST twin by updated_at, so it beats
+        // devices:resolveConversationBySession on both counts — right row, and
+        // full hide state instead of status only.
+        if (!res && sessionId) {
+          res = await this.client.query("conversations:getConversationLifecycle" as any, {
+            api_token: this.apiToken,
+            session_id: sessionId,
+          });
+        }
         lifecycleQueryMissingSince = 0; // the probe answered — clear any stale latch
         if (res) {
           return {
@@ -1389,8 +1406,10 @@ export class SyncService {
             source: "lifecycle",
           };
         }
-        // Reached the query and it found nothing (deleted row / not ours). That
-        // is an answer, not an outage — don't paper over it with the fallback.
+        // Both routes reached the query and it found nothing. That is an answer,
+        // not an outage — and the devices fallback reads the same by_session_id
+        // index under the same user filter, so it cannot do better. Don't paper
+        // over a real "no such conversation" with a second miss.
         return null;
       } catch (err) {
         // ONLY an undeployed function latches. Anything else (network, 5xx,
@@ -1399,8 +1418,10 @@ export class SyncService {
         if (isMissingFunctionError(err)) lifecycleQueryMissingSince = Date.now();
       }
     }
-    // Degraded path: status only, resolved by session id (oldest twin). Marked
-    // as such so callers can decide whether that is good enough for them.
+    // Legacy-backend path only — reached when the query above is undeployed or
+    // errored, never when it simply found nothing. Status only, resolved by
+    // session id through `.first()` (the OLDEST twin), so it is marked degraded
+    // and most callers refuse to act on it.
     if (!sessionId) return null;
     try {
       const res: any = await this.client.query("devices:resolveConversationBySession" as any, {

--- a/packages/convex/convex/cleanup.test.ts
+++ b/packages/convex/convex/cleanup.test.ts
@@ -8,6 +8,7 @@ import {
   cascadeHideToNestedChildren,
   applyHideTransition,
 } from "./cleanup";
+import { enqueuePendingMessage } from "./pendingMessages";
 
 // Minimal in-memory ctx.db honoring the .withIndex(name, q => q.eq(field,val))
 // chains the cleanup helpers use, so the reap logic is testable without the full
@@ -269,6 +270,28 @@ describe("cascadeHideToNestedChildren", () => {
     expect(row("conv_fork").inbox_dismissed_at).toBeUndefined();
   });
 
+  // A FORCED kill takes the group down again: the lead's teardown is only as
+  // good as its children's, and a resurrected teammate is exactly the bug
+  // forcing exists to fix. Their hide stamps stay put — only teardown re-runs.
+  test("a FORCED kill re-tears-down already-hidden children (group comes down as one unit)", async () => {
+    const tables = mkTables();
+    const db = makeFakeDb(tables);
+    const lead = tables.conversations[0];
+    const kills = () => db._inserted.filter((i: any) => i.table === "daemon_commands");
+
+    await cascadeHideToNestedChildren({ db }, lead, { inbox_dismissed_at: 111 });
+    expect(kills()).toHaveLength(2);
+    // The daemon executed those kills; a resurrection bug brought the workers
+    // back. Executed commands leave nothing pending, so the re-kill enqueues.
+    for (const cmd of tables.daemon_commands) cmd.executed_at = 1;
+
+    const again = await cascadeHideToNestedChildren({ db }, lead, { inbox_dismissed_at: 222 }, { forceKill: true });
+    expect(again).toBe(2);
+    expect(kills()).toHaveLength(4);
+    // Already-hidden children keep their original stamp — no timestamp churn.
+    expect(tables.conversations.find((r: any) => r._id === "conv_sub")!.inbox_dismissed_at).toBe(111);
+  });
+
   test("already-hidden children are skipped — a re-asserted hide never re-kills", async () => {
     const tables = mkTables();
     const db = makeFakeDb(tables);
@@ -337,5 +360,206 @@ describe("cascadeHideToNestedChildren", () => {
     const { cascaded } = await applyHideTransition({ db }, lead, patch, { cascade: false });
     expect(cascaded).toBe(0);
     expect(tables.conversations.find((r: any) => r._id === "conv_sub")!.inbox_dismissed_at).toBeUndefined();
+  });
+});
+
+// Kill is a DESIRED STATE, not an event. classifyHideTransition gates on the
+// hide flag's transition, which is right for a quiet re-assert (the web's
+// optimistic re-patch, a stub-rekey flush) and wrong for a deliberate re-kill:
+// a killed session whose worker a daemon bug revived was still flagged, so
+// `cast kill` classified "none" and never enqueued teardown — the worker was
+// unkillable through the supported path. forceKill is how an EXPLICIT kill
+// gesture says "make it so" regardless of the flags.
+describe("applyHideTransition — explicit kill forces teardown", () => {
+  const CONV = "conv_killed";
+  // Already killed (dismissed + completed), with real work so the empty-reap
+  // path can't fire — the resurrection case. `extra` overrides the row (e.g.
+  // back to a live, never-killed session for the fresh-kill cases).
+  const mkTables = (extra: Record<string, any> = {}): Record<string, any[]> => ({
+    conversations: [{
+      _id: CONV, user_id: "u1", session_id: "s-1", message_count: 12,
+      inbox_dismissed_at: 111, inbox_killed_at: 111, status: "completed", ...extra,
+    }],
+    daemon_commands: [],
+    messages: [],
+    pending_messages: [],
+    managed_sessions: [],
+    client_state: [],
+    agent_tasks: [],
+  });
+  const prePatch = (tables: Record<string, any[]>) => ({ ...tables.conversations[0] });
+  const kills = (db: any) => db._inserted.filter((i: any) => i.table === "daemon_commands");
+
+  test("a re-asserted EXPLICIT kill enqueues teardown again", async () => {
+    const tables = mkTables();
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    const { action, teardownEnqueued } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(action).toBe("kill");
+    expect(teardownEnqueued).toBe(true);
+    expect(kills(db)).toHaveLength(1);
+    expect(kills(db)[0].doc.command).toBe("kill_session");
+    expect(JSON.parse(kills(db)[0].doc.args)).toMatchObject({ conversation_id: CONV, session_id: "s-1" });
+    expect(tables.conversations[0].inbox_killed_at).toBeGreaterThan(111);
+  });
+
+  test("a re-asserted quiet DISMISS still does not re-kill", async () => {
+    const tables = mkTables();
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    const { action, teardownEnqueued } = await applyHideTransition({ db }, doc, patch);
+    expect(action).toBe("none");
+    expect(teardownEnqueued).toBe(false);
+    expect(kills(db)).toHaveLength(0);
+  });
+
+  test("forceKill never turns a STASH into a kill", async () => {
+    const tables = mkTables({ inbox_dismissed_at: undefined, inbox_killed_at: undefined, status: "active" });
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_stashed_at: 333 };
+    await db.patch(CONV, patch);
+
+    const { action } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(action).toBe("none");
+    expect(kills(db)).toHaveLength(0);
+    expect(tables.conversations[0].status).toBe("active");
+  });
+
+  test("a kill still queued for the daemon reports no new command, but the state holds", async () => {
+    const tables = mkTables();
+    // An UNEXECUTED kill_session for this conversation is already on the queue.
+    tables.daemon_commands.push({
+      _id: "cmdPending", user_id: "u1", command: "kill_session",
+      args: JSON.stringify({ conversation_id: CONV }), created_at: 111,
+    });
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    const { action, teardownEnqueued } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(action).toBe("kill");
+    expect(teardownEnqueued).toBe(false);
+    expect(kills(db)).toHaveLength(0);
+  });
+
+  // A persistent anchor goes dormant on a kill, it is never retired — only
+  // decommissionAnchor clears `persistent`. Forcing must not change that.
+  test("a forced kill on a persistent anchor keeps anchor semantics", async () => {
+    const tables = mkTables({ persistent: true, status: "active" });
+    tables.agent_tasks.push({
+      _id: "t1", user_id: "u1", status: "scheduled", originating_conversation_id: CONV,
+    });
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    const { action, canceledSchedules, teardownEnqueued } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(action).toBe("kill");
+    expect(teardownEnqueued).toBe(true);
+    expect(canceledSchedules).toBe(0);
+    expect(tables.agent_tasks[0].status).toBe("scheduled");
+    expect(tables.conversations[0].status).toBe("active");
+    expect(tables.conversations[0].inbox_killed_at).toBeGreaterThan(111);
+  });
+
+  // Kill is TERMINAL for messages already queued. Retained ones kept retrying:
+  // one could land later and revive a session still stamped inbox_killed_at
+  // (observed live — 193 messages after the kill), and an exhausted one left the
+  // row completed + has_pending_messages forever.
+  test("a kill cancels the messages already queued and clears has_pending_messages", async () => {
+    const tables = mkTables({
+      inbox_dismissed_at: undefined, inbox_killed_at: undefined,
+      status: "active", has_pending_messages: true,
+    });
+    tables.pending_messages.push(
+      { _id: "pm_pending", conversation_id: CONV, status: "pending", retry_count: 0 },
+      { _id: "pm_undeliverable", conversation_id: CONV, status: "undeliverable", retry_count: 9 },
+      { _id: "pm_delivered", conversation_id: CONV, status: "delivered", retry_count: 1 },
+    );
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    // A FRESH kill (no force needed) — the flag transitions here.
+    const { action, canceledMessages } = await applyHideTransition({ db }, doc, patch);
+    expect(action).toBe("kill");
+    expect(canceledMessages).toBe(2);
+    const msg = (id: string) => tables.pending_messages.find((r: any) => r._id === id)!;
+    expect(msg("pm_pending").status).toBe("cancelled");
+    expect(msg("pm_undeliverable").status).toBe("cancelled");
+    expect(msg("pm_delivered").status).toBe("delivered"); // terminal, untouched
+    expect(tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  test("a forced re-kill cancels what was queued since the first kill", async () => {
+    const tables = mkTables({ has_pending_messages: true });
+    tables.pending_messages.push(
+      { _id: "pm_since", conversation_id: CONV, status: "pending", retry_count: 0 },
+    );
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    const { canceledMessages } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(canceledMessages).toBe(1);
+    expect(tables.pending_messages[0].status).toBe("cancelled");
+    expect(tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  // The other half of the contract: only the PRE-kill queue dies. A human send
+  // afterwards re-enqueues and resurfaces the session — enqueuePendingMessage's
+  // wake-up rules clear the dismissed/killed flags and flip completed → active.
+  test("a later send still revives the killed session; the pre-kill queue stays dead", async () => {
+    const tables = mkTables({ has_pending_messages: true });
+    tables.pending_messages.push(
+      { _id: "pm_before", conversation_id: CONV, status: "pending", retry_count: 0 },
+    );
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+    await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(tables.pending_messages[0].status).toBe("cancelled");
+
+    const conv = await db.get(CONV);
+    const newId = await enqueuePendingMessage({ db }, conv, "u1" as any, { content: "back to work" });
+
+    expect(tables.pending_messages.find((r: any) => r._id === newId)!.status).toBe("pending");
+    expect(conv.inbox_dismissed_at).toBeUndefined();
+    expect(conv.inbox_killed_at).toBeUndefined();
+    expect(conv.status).toBe("active");
+    expect(conv.has_pending_messages).toBe(true);
+    // The message queued before the kill is terminal — it must not ride along.
+    expect(tables.pending_messages.find((r: any) => r._id === "pm_before")!.status).toBe("cancelled");
+  });
+
+  // Re-running the schedule sweep is safe: it only touches
+  // scheduled/running/paused tasks, so already-canceled ones stay put — and a
+  // trigger re-armed since the first kill dies again with the session.
+  test("a forced kill re-cancels a schedule re-armed since the first kill", async () => {
+    const tables = mkTables();
+    tables.agent_tasks.push({
+      _id: "t1", user_id: "u1", status: "scheduled", originating_conversation_id: CONV,
+    });
+    const db = makeFakeDb(tables);
+    const doc = prePatch(tables);
+    const patch = { inbox_dismissed_at: 222 };
+    await db.patch(CONV, patch);
+
+    const { canceledSchedules } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expect(canceledSchedules).toBe(1);
+    expect(tables.agent_tasks[0].status).toBe("completed");
+    expect(tables.agent_tasks[0].canceled_on_kill_at).toBeGreaterThan(0);
   });
 });

--- a/packages/convex/convex/cleanup.test.ts
+++ b/packages/convex/convex/cleanup.test.ts
@@ -285,11 +285,14 @@ describe("cascadeHideToNestedChildren", () => {
     // back. Executed commands leave nothing pending, so the re-kill enqueues.
     for (const cmd of tables.daemon_commands) cmd.executed_at = 1;
 
+    const firstKilledAt = tables.conversations.find((r: any) => r._id === "conv_sub")!.inbox_killed_at;
     const again = await cascadeHideToNestedChildren({ db }, lead, { inbox_dismissed_at: 222 }, { forceKill: true });
     expect(again).toBe(2);
     expect(kills()).toHaveLength(4);
-    // Already-hidden children keep their original stamp — no timestamp churn.
+    // Already-hidden children keep their original stamps — no timestamp churn,
+    // on the hide flag OR on the record of when they were first killed.
     expect(tables.conversations.find((r: any) => r._id === "conv_sub")!.inbox_dismissed_at).toBe(111);
+    expect(tables.conversations.find((r: any) => r._id === "conv_sub")!.inbox_killed_at).toBe(firstKilledAt);
   });
 
   test("already-hidden children are skipped — a re-asserted hide never re-kills", async () => {
@@ -403,7 +406,9 @@ describe("applyHideTransition — explicit kill forces teardown", () => {
     expect(kills(db)).toHaveLength(1);
     expect(kills(db)[0].doc.command).toBe("kill_session");
     expect(JSON.parse(kills(db)[0].doc.args)).toMatchObject({ conversation_id: CONV, session_id: "s-1" });
-    expect(tables.conversations[0].inbox_killed_at).toBeGreaterThan(111);
+    // inbox_killed_at is FIRST-kill time: the re-kill re-runs teardown, it does
+    // not rewrite when the user retired the session.
+    expect(tables.conversations[0].inbox_killed_at).toBe(111);
   });
 
   test("a re-asserted quiet DISMISS still does not re-kill", async () => {
@@ -452,23 +457,35 @@ describe("applyHideTransition — explicit kill forces teardown", () => {
 
   // A persistent anchor goes dormant on a kill, it is never retired — only
   // decommissionAnchor clears `persistent`. Forcing must not change that.
-  test("a forced kill on a persistent anchor keeps anchor semantics", async () => {
-    const tables = mkTables({ persistent: true, status: "active" });
+  // Killing an anchor means DORMANCY, not death — so it keeps BOTH halves of
+  // what a retirement would take: its schedules stay armed, and so does the
+  // queue the human left for it. Cancelling the queue while keeping the
+  // schedules is the worst of both: the anchor wakes on its next trigger and
+  // runs without the messages the human queued, silently.
+  test("a forced kill on a persistent anchor keeps anchor semantics: schedules AND queued messages", async () => {
+    const tables = mkTables({ persistent: true, status: "active", has_pending_messages: true });
     tables.agent_tasks.push({
       _id: "t1", user_id: "u1", status: "scheduled", originating_conversation_id: CONV,
     });
+    tables.pending_messages.push(
+      { _id: "pm_queued", conversation_id: CONV, status: "pending", retry_count: 0 },
+    );
     const db = makeFakeDb(tables);
     const doc = prePatch(tables);
     const patch = { inbox_dismissed_at: 222 };
     await db.patch(CONV, patch);
 
-    const { action, canceledSchedules, teardownEnqueued } = await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    const { action, canceledSchedules, canceledMessages, teardownEnqueued } =
+      await applyHideTransition({ db }, doc, patch, { forceKill: true });
     expect(action).toBe("kill");
-    expect(teardownEnqueued).toBe(true);
+    expect(teardownEnqueued).toBe(true); // the agent still comes down
     expect(canceledSchedules).toBe(0);
+    expect(canceledMessages).toBe(0);
     expect(tables.agent_tasks[0].status).toBe("scheduled");
-    expect(tables.conversations[0].status).toBe("active");
-    expect(tables.conversations[0].inbox_killed_at).toBeGreaterThan(111);
+    expect(tables.pending_messages[0].status).toBe("pending");
+    expect(tables.conversations[0].has_pending_messages).toBe(true);
+    expect(tables.conversations[0].status).toBe("active"); // never auto-completes
+    expect(tables.conversations[0].inbox_killed_at).toBe(111); // first-kill time preserved
   });
 
   // Kill is TERMINAL for messages already queued. Retained ones kept retrying:

--- a/packages/convex/convex/cleanup.ts
+++ b/packages/convex/convex/cleanup.ts
@@ -331,30 +331,39 @@ export async function applyHideTransition(
     teardownEnqueued = await enqueueKillSessionCommand(ctx, doc);
     // A persistent anchor never auto-completes on a dismiss/kill — it goes
     // dormant, not retired (only decommissionAnchor clears `persistent`).
-    const killPatch: Record<string, any> = { inbox_killed_at: Date.now() };
+    // inbox_killed_at records when the session was FIRST killed: a forced
+    // re-kill re-runs the teardown but must not rewrite that history, or the
+    // row's honest "killed at" jumps forward every time a resurrection is
+    // stamped out (and the cascade below claims exactly this for its children).
+    const killPatch: Record<string, any> = {};
+    if (!doc?.inbox_killed_at) killPatch.inbox_killed_at = Date.now();
     if (!doc?.persistent) killPatch.status = "completed";
-    await ctx.db.patch(doc._id, killPatch);
+    if (Object.keys(killPatch).length > 0) await ctx.db.patch(doc._id, killPatch);
     // Dismiss retires the session — a standing schedule that injects
     // into it must die with it, or its next fire would silently
     // resurrect a session the user just retired. User gestures only:
     // bulk cleanup sweeps patch inbox_dismissed_at directly (not via
-    // dispatch) and deliberately leave standing schedules armed. An
-    // anchor going dormant keeps its schedules too. Task owner = the
-    // conversation's runner (a second-party owner may be triaging). Safe to
-    // re-run on a forced re-kill: it only touches scheduled/running/paused
-    // tasks, so a second pass over already-canceled ones is a no-op — and a
-    // schedule re-armed since the first kill SHOULD die again with it.
-    if (!doc?.persistent) {
-      canceledSchedules = await cancelTasksBoundToConversation(ctx, doc.user_id, doc._id);
-    }
+    // dispatch) and deliberately leave standing schedules armed. Task
+    // owner = the conversation's runner (a second-party owner may be
+    // triaging).
+    //
     // Kill is terminal for messages ALREADY queued, or the retry loop delivers
     // one later and revives a session carrying kill metadata (and an exhausted
-    // one strands the row as completed + has_pending forever). Applies to
-    // anchors too: `persistent` governs RETIREMENT (no auto-complete, schedules
-    // kept), not delivery of work queued before the user pulled the plug — a
-    // later send re-enqueues and wakes it normally. Re-runs safely on a forced
-    // re-kill, taking anything queued since the first kill with it.
-    canceledMessages = await cancelQueuedMessagesOnKill(ctx, doc._id);
+    // one strands the row as completed + has_pending forever). Re-runs safely on
+    // a forced re-kill, taking anything queued since the first kill with it.
+    //
+    // Both of these are RETIREMENT effects, so a persistent anchor is exempt
+    // from both: killing an anchor means dormancy, not death. Its schedules stay
+    // armed on purpose — and so its queue must stay too, or the anchor wakes on
+    // its next trigger and runs WITHOUT the messages the human queued for it,
+    // silently. (The schedule sweep is safe to re-run: it only touches
+    // scheduled/running/paused tasks, so a second pass over already-canceled
+    // ones is a no-op — and a schedule re-armed since the first kill SHOULD die
+    // again with it.)
+    if (!doc?.persistent) {
+      canceledSchedules = await cancelTasksBoundToConversation(ctx, doc.user_id, doc._id);
+      canceledMessages = await cancelQueuedMessagesOnKill(ctx, doc._id);
+    }
   }
   // The nested group (Task subagents + agent-team teammates) always comes down
   // with the card, no matter which surface asked — the group is one unit. Runs

--- a/packages/convex/convex/cleanup.ts
+++ b/packages/convex/convex/cleanup.ts
@@ -2,6 +2,7 @@ import { internalMutation, mutation } from "./functions";
 import { v } from "convex/values";
 import { hasRecentPendingDaemonCommand } from "./daemonCommandUtils";
 import { cancelTasksBoundToConversation } from "./agentTasks";
+import { cancelQueuedMessagesOnKill } from "./pendingMessages";
 import { nestParentIdOf } from "./ccAccountsShared";
 
 // ---------------------------------------------------------------------------
@@ -270,6 +271,9 @@ export async function reapEmptyConversation(
 //           undo (dismissed → null) never reaches here. Stays resumable.
 //  "none" — a stash of a session with real work (the whole point of stash), or
 //           a re-asserted dismiss.
+//
+// This is the decision for a PATCH; an explicit kill gesture is a desired state
+// and overrides a "none" here — see applyHideTransition's forceKill.
 export function classifyHideTransition(
   patch: { inbox_dismissed_at?: any; inbox_stashed_at?: any },
   doc: { inbox_dismissed_at?: number | null },
@@ -286,18 +290,45 @@ export function classifyHideTransition(
 // every hide path — the web dispatch layer and the CLI visibility mutation
 // (cast dismiss/kill) — so a hide always gets the same teardown no matter which
 // surface asked for it.
+//
+// `forceKill` marks the caller as an EXPLICIT kill gesture (cast kill, the web's
+// killSession/killSessions actions) rather than a patch that merely happens to
+// carry the flag.
 export async function applyHideTransition(
   ctx: { db: any },
   doc: any,
   patch: { inbox_dismissed_at?: any; inbox_stashed_at?: any },
-  opts?: { cascade?: boolean },
-): Promise<{ action: "reap" | "kill" | "none"; canceledSchedules: number; cascaded: number }> {
-  const action = classifyHideTransition(patch, doc, await conversationHasNoWork(ctx, doc));
+  opts?: { cascade?: boolean; forceKill?: boolean },
+): Promise<{
+  action: "reap" | "kill" | "none";
+  canceledSchedules: number;
+  canceledMessages: number;
+  cascaded: number;
+  teardownEnqueued: boolean;
+}> {
+  const classified = classifyHideTransition(patch, doc, await conversationHasNoWork(ctx, doc));
+  // Kill is a DESIRED STATE, not an event. classifyHideTransition gates on the
+  // FLAG's transition, so a quiet re-assert of an already-set inbox_dismissed_at
+  // (the web's optimistic re-patch, a stub-rekey field flush) classifies "none"
+  // and skips teardown — right for a re-assert, wrong for a deliberate one. A
+  // killed session whose worker came back (daemon resurrection) still carried
+  // the flag, so `cast kill` reported "already dismissed", never enqueued
+  // teardown, and the worker was unkillable through the supported path. An
+  // EXPLICIT kill therefore runs the kill branch whatever the flags already
+  // say; teardown is idempotent daemon-side (killing a dead pane no-ops).
+  const action = classified === "none" && opts?.forceKill && patch.inbox_dismissed_at ? "kill" : classified;
   let canceledSchedules = 0;
+  let canceledMessages = 0;
+  let teardownEnqueued = false;
   if (action === "reap") {
-    await reapEmptyConversation(ctx, doc);
+    teardownEnqueued = (await reapEmptyConversation(ctx, doc)) === "kill_enqueued";
   } else if (action === "kill") {
-    await enqueueKillSessionCommand(ctx, doc);
+    // false = an unexecuted kill_session for this conversation is ALREADY on the
+    // daemon's queue (enqueueKillSessionCommand's 1h dedupe). The desired state
+    // holds either way, so callers report which it was instead of piling on a
+    // duplicate command. A kill the daemon already executed leaves no pending
+    // row, so the re-kill that matters — the resurrection case — always inserts.
+    teardownEnqueued = await enqueueKillSessionCommand(ctx, doc);
     // A persistent anchor never auto-completes on a dismiss/kill — it goes
     // dormant, not retired (only decommissionAnchor clears `persistent`).
     const killPatch: Record<string, any> = { inbox_killed_at: Date.now() };
@@ -309,10 +340,21 @@ export async function applyHideTransition(
     // bulk cleanup sweeps patch inbox_dismissed_at directly (not via
     // dispatch) and deliberately leave standing schedules armed. An
     // anchor going dormant keeps its schedules too. Task owner = the
-    // conversation's runner (a second-party owner may be triaging).
+    // conversation's runner (a second-party owner may be triaging). Safe to
+    // re-run on a forced re-kill: it only touches scheduled/running/paused
+    // tasks, so a second pass over already-canceled ones is a no-op — and a
+    // schedule re-armed since the first kill SHOULD die again with it.
     if (!doc?.persistent) {
       canceledSchedules = await cancelTasksBoundToConversation(ctx, doc.user_id, doc._id);
     }
+    // Kill is terminal for messages ALREADY queued, or the retry loop delivers
+    // one later and revives a session carrying kill metadata (and an exhausted
+    // one strands the row as completed + has_pending forever). Applies to
+    // anchors too: `persistent` governs RETIREMENT (no auto-complete, schedules
+    // kept), not delivery of work queued before the user pulled the plug — a
+    // later send re-enqueues and wakes it normally. Re-runs safely on a forced
+    // re-kill, taking anything queued since the first kill with it.
+    canceledMessages = await cancelQueuedMessagesOnKill(ctx, doc._id);
   }
   // The nested group (Task subagents + agent-team teammates) always comes down
   // with the card, no matter which surface asked — the group is one unit. Runs
@@ -322,9 +364,9 @@ export async function applyHideTransition(
   // per-child transition call opts out to stay single-level.
   let cascaded = 0;
   if (opts?.cascade !== false && (patch.inbox_dismissed_at || patch.inbox_stashed_at)) {
-    cascaded = await cascadeHideToNestedChildren(ctx, doc, patch);
+    cascaded = await cascadeHideToNestedChildren(ctx, doc, patch, { forceKill: action === "kill" && opts?.forceKill });
   }
-  return { action, canceledSchedules, cascaded };
+  return { action, canceledSchedules, canceledMessages, cascaded, teardownEnqueued };
 }
 
 // A hide gesture on a session takes its NESTED group with it — the same set
@@ -343,10 +385,18 @@ export async function applyHideTransition(
 // second sees no transition and never re-kills. cast-spawn lineage
 // (spawned_by WITHOUT a team name) and forks stay first-class — the per-child
 // nestParentIdOf gate is the same one the renderer uses.
+//
+// `forceKill` overrides that skip: an EXPLICIT kill of the lead re-tears-down
+// already-flagged children too, because the group comes down as ONE unit and a
+// resurrected child is exactly the bug forcing exists to fix — a lead whose
+// teammate's pane survived is as unkillable as one whose own did. Their hide
+// STAMP is left alone (they are already hidden; only teardown re-runs), and the
+// per-child `{ cascade: false }` still keeps the sweep single-level.
 export async function cascadeHideToNestedChildren(
   ctx: { db: any },
   lead: any,
   patch: { inbox_dismissed_at?: number; inbox_stashed_at?: number },
+  opts?: { forceKill?: boolean },
 ): Promise<number> {
   const field = patch.inbox_dismissed_at ? ("inbox_dismissed_at" as const) : ("inbox_stashed_at" as const);
   const stamp = patch[field];
@@ -369,10 +419,11 @@ export async function cascadeHideToNestedChildren(
     if (idStr === leadId || seen.has(idStr)) continue;
     seen.add(idStr);
     if (nestParentIdOf(child) !== leadId) continue;
-    if (child[field]) continue; // already hidden — never re-kill
-    const childPatch = { [field]: stamp };
-    await ctx.db.patch(child._id, childPatch);
-    await applyHideTransition(ctx, child, childPatch, { cascade: false });
+    const alreadyHidden = !!child[field];
+    if (alreadyHidden && !opts?.forceKill) continue; // quiet re-assert — never re-kill
+    const childPatch = { [field]: alreadyHidden ? child[field] : stamp };
+    if (!alreadyHidden) await ctx.db.patch(child._id, childPatch);
+    await applyHideTransition(ctx, child, childPatch, { cascade: false, forceKill: opts?.forceKill });
     cascaded++;
   }
   return cascaded;

--- a/packages/convex/convex/conversations.restartRecovery.test.ts
+++ b/packages/convex/convex/conversations.restartRecovery.test.ts
@@ -26,6 +26,38 @@ describe("resolveRestartTarget", () => {
     expect(ctx.db._patched.length).toBe(0);
   });
 
+  // Restart is the sanctioned revival, so it wakes the row in the SAME
+  // transaction that enqueues the resume — otherwise the daemon gets "restart
+  // me" for a conversation that still reads as killed and its hide gate refuses
+  // to bring it back. Mirrors the send path's wake-up rules.
+  test("restarting a KILLED conversation clears the kill/hide stamps and re-activates it", async () => {
+    const ctx = ctxWith({
+      conversations: [{
+        _id: "conversations_1", user_id: USER, session_id: "s1", updated_at: 5,
+        status: "completed", inbox_killed_at: 222, inbox_dismissed_at: 222, inbox_stashed_at: 111,
+      }],
+    });
+    const { conv, restored } = await resolveRestartTarget(ctx, USER, "conversations_1" as any, {});
+    expect(restored).toBe(false); // the row survived — this is not ghost recovery
+    // The returned doc is re-read, so callers act on the woken row.
+    expect(conv.status).toBe("active");
+    expect(conv.inbox_killed_at).toBeUndefined();
+    expect(conv.inbox_dismissed_at).toBeUndefined();
+    expect(conv.inbox_stashed_at).toBeUndefined();
+    expect(ctx.db._tables.conversations[0].inbox_killed_at).toBeUndefined();
+  });
+
+  test("restart wakes a merely STASHED session without touching its status", async () => {
+    const ctx = ctxWith({
+      conversations: [{
+        _id: "conversations_1", user_id: USER, session_id: "s1", status: "active", inbox_stashed_at: 111,
+      }],
+    });
+    const { conv } = await resolveRestartTarget(ctx, USER, "conversations_1" as any, {});
+    expect(conv.inbox_stashed_at).toBeUndefined();
+    expect(conv.status).toBe("active");
+  });
+
   test("live conversation owned by someone else throws", async () => {
     const ctx = ctxWith({
       conversations: [{ _id: "conversations_1", user_id: OTHER, session_id: "s1" }],

--- a/packages/convex/convex/conversations.restartRecovery.test.ts
+++ b/packages/convex/convex/conversations.restartRecovery.test.ts
@@ -47,6 +47,29 @@ describe("resolveRestartTarget", () => {
     expect(ctx.db._tables.conversations[0].inbox_killed_at).toBeUndefined();
   });
 
+  // A revival is a revival: undismiss re-arms the schedules the kill canceled,
+  // so Restart must too — otherwise the more common gesture silently leaves the
+  // session's standing loops dead forever.
+  test("restarting a killed session re-arms the triggers its kill canceled", async () => {
+    const ctx = ctxWith({
+      conversations: [{
+        _id: "conversations_1", user_id: USER, session_id: "s1",
+        status: "completed", inbox_dismissed_at: 222, inbox_killed_at: 222,
+      }],
+      agent_tasks: [
+        { _id: "t_killed", user_id: USER, status: "completed", canceled_on_kill_at: 222, originating_conversation_id: "conversations_1", schedule_type: "recurring", interval_ms: 3600000 },
+        // A schedule that finished on its own stays finished — only the kill's
+        // own casualties come back.
+        { _id: "t_natural", user_id: USER, status: "completed", originating_conversation_id: "conversations_1" },
+      ],
+    });
+    await resolveRestartTarget(ctx, USER, "conversations_1" as any, {});
+    const task = (id: string) => ctx.db._tables.agent_tasks.find((t: any) => t._id === id)!;
+    expect(task("t_killed").status).not.toBe("completed");
+    expect(task("t_killed").canceled_on_kill_at).toBeUndefined();
+    expect(task("t_natural").status).toBe("completed");
+  });
+
   test("restart wakes a merely STASHED session without touching its status", async () => {
     const ctx = ctxWith({
       conversations: [{

--- a/packages/convex/convex/conversations.sessionCommands.test.ts
+++ b/packages/convex/convex/conversations.sessionCommands.test.ts
@@ -112,4 +112,57 @@ describe("getConversationLifecycle", () => {
     expect(await call({ conversations: [killedRow] }, null, { conversation_id: CONV })).toBeNull();
     expect(await call({ conversations: [] }, RUNNER, { conversation_id: CONV })).toBeNull();
   });
+
+  test("exactly one selector — neither or both is null, never a guess", async () => {
+    const tables = { conversations: [killedRow] };
+    expect(await call(tables, RUNNER, {})).toBeNull();
+    expect(await call(tables, RUNNER, { conversation_id: CONV, session_id: "s1" })).toBeNull();
+  });
+
+  // The session route resolves the NEWEST twin. .first() is creation order —
+  // the OLDEST row bound to the session_id (the ct-36973 foot-gun) — which for
+  // this query means handing the daemon a dead twin's stamps for a live session.
+  describe("by session_id", () => {
+    const twins = (extra: Record<string, any> = {}) => [
+      { _id: "conversations_old", user_id: RUNNER, session_id: "s1", updated_at: 10, status: "completed", inbox_killed_at: 999 },
+      { _id: "conversations_new", user_id: RUNNER, session_id: "s1", updated_at: 50, status: "active", ...extra },
+    ];
+
+    test("the newest twin wins — a dead older twin cannot speak for a live session", async () => {
+      expect(await call({ conversations: twins() }, RUNNER, { session_id: "s1" })).toEqual({
+        status: "active",
+        inbox_killed_at: null,
+        inbox_dismissed_at: null,
+        inbox_stashed_at: null,
+        inbox_pinned_at: null,
+      });
+    });
+
+    test("newest-wins holds whatever order the rows come back in", async () => {
+      const reversed = twins().reverse();
+      expect((await call({ conversations: reversed }, RUNNER, { session_id: "s1" }))!.status).toBe("active");
+    });
+
+    test("the newest twin's own hide state is reported faithfully", async () => {
+      const stashed = twins({ inbox_stashed_at: 777 });
+      expect(await call({ conversations: stashed }, RUNNER, { session_id: "s1" })).toMatchObject({
+        status: "active",
+        inbox_stashed_at: 777,
+        inbox_killed_at: null,
+      });
+    });
+
+    test("a foreign twin on the same session_id is neither selected nor leaked", async () => {
+      const mixed = [
+        { _id: "conversations_mine", user_id: RUNNER, session_id: "s1", updated_at: 10, status: "active" },
+        { _id: "conversations_theirs", user_id: STRANGER, session_id: "s1", updated_at: 99, status: "completed", inbox_killed_at: 5 },
+      ];
+      expect((await call({ conversations: mixed }, RUNNER, { session_id: "s1" }))!.status).toBe("active");
+      expect(await call({ conversations: mixed }, "users_nobody", { session_id: "s1" })).toBeNull();
+    });
+
+    test("an unknown session is null", async () => {
+      expect(await call({ conversations: twins() }, RUNNER, { session_id: "s-unknown" })).toBeNull();
+    });
+  });
 });

--- a/packages/convex/convex/conversations.sessionCommands.test.ts
+++ b/packages/convex/convex/conversations.sessionCommands.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { requireSessionCommandTarget, getConversationLifecycle } from "./conversations";
+import { requireSessionCommandTarget, getConversationLifecycle, killSession, cliSetSessionVisibility } from "./conversations";
+import { applyHideTransition } from "./cleanup";
+import { shouldShowInInbox } from "./inboxFilters";
 import { makeFakeDb } from "./testDb";
 
 // Session commands (send keys/escape, rewind, model switch, project/agent
@@ -164,5 +166,87 @@ describe("getConversationLifecycle", () => {
     test("an unknown session is null", async () => {
       expect(await call({ conversations: twins() }, RUNNER, { session_id: "s-unknown" })).toBeNull();
     });
+  });
+});
+
+// A persistent anchor going dormant keeps BOTH the schedules and the queue the
+// human left for it. The two kill surfaces must agree about that: applyHideTransition
+// (cast kill / the web inbox gesture) and the killSession mutation (the panel and
+// /sessions buttons) hit the same session, so a guard on only one of them leaves
+// the anchor in a different state depending on which button was pressed.
+describe("killSession vs applyHideTransition: one anchor, one answer", () => {
+  const ANCHOR = "conversations_anchor";
+  const anchorTables = () => ({
+    conversations: [{
+      _id: ANCHOR, user_id: RUNNER, session_id: "s-anchor", persistent: true,
+      status: "active", message_count: 20, has_pending_messages: true,
+    }],
+    agent_tasks: [{ _id: "t1", user_id: RUNNER, status: "scheduled", originating_conversation_id: ANCHOR }],
+    pending_messages: [{ _id: "pm1", conversation_id: ANCHOR, status: "pending", retry_count: 0 }],
+    daemon_commands: [], messages: [], managed_sessions: [], client_state: [], session_owners: [],
+  });
+
+  const expectAnchorIntact = (tables: any) => {
+    expect(tables.agent_tasks[0].status).toBe("scheduled");
+    expect(tables.pending_messages[0].status).toBe("pending");
+    expect(tables.conversations[0].status).toBe("active");
+    expect(tables.conversations[0].has_pending_messages).toBe(true);
+    // …but it IS retired from the inbox and its agent IS torn down.
+    expect(tables.conversations[0].inbox_killed_at).toBeGreaterThan(0);
+    expect(tables.daemon_commands.some((c: any) => c.command === "kill_session")).toBe(true);
+  };
+
+  test("the killSession mutation leaves an anchor's schedules and queue alone", async () => {
+    const tables = anchorTables();
+    const db = makeFakeDb(tables);
+    await (killSession as any)._handler(
+      { db, auth: { getUserIdentity: async () => ({ subject: `${RUNNER}|session` }) } },
+      { conversation_id: ANCHOR, mark_completed: true },
+    );
+    expectAnchorIntact(tables);
+  });
+
+  test("applyHideTransition agrees, given the same anchor", async () => {
+    const tables = anchorTables();
+    const db = makeFakeDb(tables);
+    const doc = { ...tables.conversations[0] };
+    const patch = { inbox_dismissed_at: Date.now() };
+    await db.patch(ANCHOR, patch);
+    await applyHideTransition({ db }, doc, patch, { forceKill: true });
+    expectAnchorIntact(tables);
+  });
+});
+
+// `cast kill` tells the user "cast undismiss <id> to resurface" — undismiss has
+// to actually deliver that. shouldShowInInbox hides a row on inbox_killed_at
+// ALONE, so clearing only the two hide stamps left the card invisible.
+describe("undismiss un-kills", () => {
+  const CONV = "conversations_killed";
+  const killedTables = () => ({
+    conversations: [{
+      _id: CONV, user_id: RUNNER, short_id: "abc1234", session_id: "s1", message_count: 9,
+      status: "completed", inbox_dismissed_at: 111, inbox_killed_at: 111,
+    }],
+    agent_tasks: [], daemon_commands: [], messages: [], pending_messages: [],
+    managed_sessions: [], client_state: [], session_owners: [],
+  });
+
+  test("cast undismiss clears the kill stamp, so the card comes back", async () => {
+    const tables = killedTables();
+    const db = makeFakeDb(tables);
+    // Pre-check: the killed row is invisible to the inbox on the kill stamp alone.
+    expect(shouldShowInInbox(tables.conversations[0] as any)).toBe(false);
+
+    const res = await (cliSetSessionVisibility as any)._handler(
+      { db, auth: { getUserIdentity: async () => ({ subject: `${RUNNER}|session` }) } },
+      { session: "abc1234", action: "undismiss" },
+    );
+    expect(res.was_hidden).toBe(true);
+    const row = tables.conversations[0] as any;
+    expect(row.inbox_killed_at).toBeUndefined();
+    expect(row.inbox_dismissed_at).toBeUndefined();
+    expect(shouldShowInInbox(row)).toBe(true); // visible with no pin required
+    // Undismiss resurfaces the CARD; restarting the agent is Restart's job.
+    expect(row.status).toBe("completed");
   });
 });

--- a/packages/convex/convex/conversations.sessionCommands.test.ts
+++ b/packages/convex/convex/conversations.sessionCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { requireSessionCommandTarget } from "./conversations";
+import { requireSessionCommandTarget, getConversationLifecycle } from "./conversations";
 import { makeFakeDb } from "./testDb";
 
 // Session commands (send keys/escape, rewind, model switch, project/agent
@@ -53,5 +53,63 @@ describe("requireSessionCommandTarget", () => {
   test("a deleted/ghost conversation is refused (kill/restart keep their own recovery)", async () => {
     const ctx = ctxWith({ conversations: [] });
     await expect(requireSessionCommandTarget(ctx, RUNNER, "conversations_gone" as any)).rejects.toThrow("Not authorized");
+  });
+});
+
+// The daemon's LIFECYCLE read (api_token auth — no session cookie on a CLI/daemon
+// caller). It gates the daemon's reap on the user's intent: a session the human
+// killed or stashed must not be resurrected by a recovery path. No other
+// daemon-facing query exposes the hide stamps, so this is the whole contract:
+// five fields, or null when the caller doesn't run the conversation.
+describe("getConversationLifecycle", () => {
+  const CONV = "conversations_1";
+  const call = (tables: Record<string, any[]>, subjectUser: string | null, args: any) =>
+    (getConversationLifecycle as any)._handler(
+      {
+        db: makeFakeDb(tables),
+        auth: { getUserIdentity: async () => (subjectUser ? { subject: `${subjectUser}|session` } : null) },
+      },
+      args,
+    );
+
+  const killedRow = {
+    _id: CONV,
+    user_id: RUNNER,
+    session_id: "s1",
+    status: "completed",
+    inbox_killed_at: 222,
+    inbox_dismissed_at: 222,
+    inbox_stashed_at: 111,
+    inbox_pinned_at: undefined,
+  };
+
+  test("returns the five lifecycle fields for a conversation the caller runs", async () => {
+    expect(await call({ conversations: [killedRow] }, RUNNER, { conversation_id: CONV })).toEqual({
+      status: "completed",
+      inbox_killed_at: 222,
+      inbox_dismissed_at: 222,
+      inbox_stashed_at: 111,
+      inbox_pinned_at: null, // absent stamps normalize to null, never undefined
+    });
+  });
+
+  test("a live, never-hidden session reports every stamp as null", async () => {
+    const tables = { conversations: [{ _id: CONV, user_id: RUNNER, status: "active" }] };
+    expect(await call(tables, RUNNER, { conversation_id: CONV })).toEqual({
+      status: "active",
+      inbox_killed_at: null,
+      inbox_dismissed_at: null,
+      inbox_stashed_at: null,
+      inbox_pinned_at: null,
+    });
+  });
+
+  test("someone else's conversation is null, not a leak", async () => {
+    expect(await call({ conversations: [killedRow] }, STRANGER, { conversation_id: CONV })).toBeNull();
+  });
+
+  test("unauthenticated and missing conversations are null too", async () => {
+    expect(await call({ conversations: [killedRow] }, null, { conversation_id: CONV })).toBeNull();
+    expect(await call({ conversations: [] }, RUNNER, { conversation_id: CONV })).toBeNull();
   });
 });

--- a/packages/convex/convex/conversations.ts
+++ b/packages/convex/convex/conversations.ts
@@ -6462,6 +6462,9 @@ export const feedForCLI = query({
         agent_type: conv.agent_type,
         ...(convIsLive ? { is_live: true, agent_status: coercedStatusMap.get(conv._id.toString()) || undefined } : {}),
         work_state: workStateMap.get(conv._id.toString()) || "idle",
+        // A retired row. `cast sessions -w` reads this to emit a kill as a
+        // DEPARTURE from the watched set rather than a work-state transition.
+        ...(conv.inbox_killed_at ? { is_killed: true } : {}),
         is_pinned: !!conv.inbox_pinned_at,
         user: !isOwnConv && owner ? { name: owner.name || null, email: owner.email || null } : undefined,
         ...(sessionOwner ? { owner: sessionOwner } : {}),
@@ -8351,6 +8354,7 @@ export const inboxForCLI = query({
       agent_type?: string;
       agent_status?: string;
       work_state: WorkState;
+      is_killed: boolean;
       is_pinned: boolean;
       is_live: boolean;
       is_unresponsive: boolean;
@@ -8406,6 +8410,9 @@ export const inboxForCLI = query({
         agent_type: s.agent_type,
         agent_status: s.agent_status,
         work_state,
+        // A retired row (still listed while pinned, or under --all). The watch
+        // stream reads it to emit a kill as a departure, not a transition.
+        is_killed: !!s.inbox_killed_at,
         is_pinned: !!s.is_pinned,
         is_live,
         is_unresponsive: !!s.is_unresponsive,
@@ -8799,15 +8806,44 @@ export const markSessionActive = mutation({
 // Returns null for a missing conversation or one the caller doesn't run —
 // same silent-null convention as its siblings, and the daemon treats null (or
 // an undeployed query) as "no lifecycle opinion" and falls back.
+//
+// Addressable by conversation_id OR session_id (exactly one), because the daemon
+// often knows only the session it is about to reap or resurrect — and the
+// session route MUST resolve the newest twin, not the oldest (see below).
 export const getConversationLifecycle = query({
   args: {
     api_token: v.optional(v.string()),
-    conversation_id: v.id("conversations"),
+    conversation_id: v.optional(v.id("conversations")),
+    session_id: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const userId = await getAuthenticatedUserId(ctx, args.api_token);
     if (!userId) return null;
-    const conv = await ctx.db.get(args.conversation_id);
+    // Exactly one selector: neither is nothing to look up, and both could
+    // disagree — refusing to guess is the same discipline
+    // deleteConversationBySessionId applies to twins. Null, not a throw, so a
+    // malformed call reads as "no opinion" like every other miss here.
+    if (!!args.conversation_id === !!args.session_id) return null;
+
+    let conv = args.conversation_id ? await ctx.db.get(args.conversation_id) : null;
+    if (!conv && args.session_id) {
+      // NEWEST twin, never .first(): .first() is creation order, so it returns
+      // the OLDEST row bound to a session_id — the ct-36973 foot-gun that once
+      // made cleanup delete a live original instead of its doppelgänger. Here it
+      // would hand the daemon a dead twin's killed/stashed stamps for a session
+      // that is very much alive, and the reap gate would refuse to bring the
+      // live one back. Same newest-by-updated_at reduction resolveRestartTarget
+      // uses, and foreign twins are filtered out before the pick, so another
+      // user's row can neither be selected nor leak.
+      const twins = await ctx.db
+        .query("conversations")
+        .withIndex("by_session_id", (q) => q.eq("session_id", args.session_id!))
+        .collect();
+      const owned = twins.filter((t) => t.user_id === userId);
+      conv = owned.length > 0
+        ? owned.reduce((a, b) => ((b.updated_at ?? 0) > (a.updated_at ?? 0) ? b : a))
+        : null;
+    }
     if (!conv || conv.user_id !== userId) return null;
     return {
       status: conv.status,
@@ -10066,6 +10102,9 @@ export async function resolveRestartTarget(
     // refused to bring it back. The ghost-recovery path below already did this
     // for the twin it restores; the existing row was the gap. Patch only what's
     // actually set, so an ordinary restart of a live session writes nothing.
+    // Read the pre-patch state first: the re-arm below is decided on what the
+    // row looked like when the user hit Restart, not on what the patch left.
+    const wasRetired = !!(conv.inbox_dismissed_at || conv.inbox_killed_at);
     const revive: Record<string, any> = {};
     if (conv.status === "completed") revive.status = "active" as const;
     if (conv.inbox_killed_at) revive.inbox_killed_at = undefined;
@@ -10073,6 +10112,18 @@ export async function resolveRestartTarget(
     if (conv.inbox_stashed_at) revive.inbox_stashed_at = undefined;
     if (Object.keys(revive).length > 0) {
       await ctx.db.patch(conv._id, revive);
+      // A revival is a revival: undismiss re-arms the schedules the kill
+      // canceled (reactivateTasksCanceledOnKill), so Restart must too — without
+      // this, `cast undismiss X` brings a session's standing loops back but
+      // Restart leaves them dead forever, which is the more common gesture.
+      // Same two scans as the kill that canceled them: the RUNNER's schedules,
+      // plus the caller's when a second-party owner is restarting.
+      if (wasRetired) {
+        await reactivateTasksCanceledOnKill(ctx, conv.user_id, conv._id);
+        if (conv.user_id.toString() !== userId.toString()) {
+          await reactivateTasksCanceledOnKill(ctx, userId, conv._id);
+        }
+      }
       return { conv: (await ctx.db.get(conv._id))!, restored: false };
     }
     return { conv, restored: false };
@@ -10239,7 +10290,10 @@ export const killSession = mutation({
     let canceledSchedules = 0;
     let canceledMessages = 0;
     if (conv) {
-      const patch: Record<string, any> = { inbox_killed_at: Date.now() };
+      // First-kill time, preserved across re-kills (same rule as
+      // applyHideTransition): a repeat kill re-runs teardown, it doesn't
+      // rewrite when the session was retired.
+      const patch: Record<string, any> = conv.inbox_killed_at ? {} : { inbox_killed_at: Date.now() };
       // A persistent anchor session never auto-completes — a dismiss/kill gesture
       // on its pinned card puts it to sleep, it isn't retired. Only an explicit
       // decommissionAnchor (which clears `persistent` first) may complete it.

--- a/packages/convex/convex/conversations.ts
+++ b/packages/convex/convex/conversations.ts
@@ -9,7 +9,7 @@ import { Doc, Id } from "./_generated/dataModel";
 import { checkRateLimit } from "./rateLimit";
 import { verifyApiToken } from "./apiTokens";
 import { internal } from "./_generated/api";
-import { resetConversationPendingMessages } from "./pendingMessages";
+import { resetConversationPendingMessages, cancelQueuedMessagesOnKill } from "./pendingMessages";
 import { cancelTasksBoundToConversation, reactivateTasksCanceledOnKill } from "./agentTasks";
 import { advanceForkCopy, type ForkCopyCtx } from "./forkCopy";
 import { hasRecentPendingDaemonCommand, extractDaemonCommandConversationId } from "./daemonCommandUtils";
@@ -6318,6 +6318,7 @@ export const feedForCLI = query({
         hasPending,
         isUnresponsive: activity.isUnresponsive,
         messageCount: conv.message_count || 0,
+        killed: !!conv.inbox_killed_at,
       });
       workStateMap.set(conv._id.toString(), ws);
       return ws;
@@ -7461,6 +7462,9 @@ async function enrichInboxSessionRow(
     inbox_pinned_at: conv.inbox_pinned_at ?? null,
     inbox_dismissed_at: conv.inbox_dismissed_at ?? null,
     inbox_stashed_at: conv.inbox_stashed_at ?? null,
+    // The retired marker: classifyWorkState uses it to keep a killed row out of
+    // the Working bucket no matter what stale flags it still carries.
+    inbox_killed_at: conv.inbox_killed_at ?? null,
     agent_status: agentStatus,
     tmux_session: maps.tmuxSessionMap.get(conv._id.toString()) ?? null,
     permission_mode: maps.permissionModeMap.get(conv._id.toString()) ?? null,
@@ -7571,6 +7575,7 @@ function buildSubagentChildRow(child: any, maps: InboxSessionMaps, now: number, 
     inbox_pinned_at: null,
     inbox_dismissed_at: child.inbox_dismissed_at ?? null,
     inbox_stashed_at: child.inbox_stashed_at ?? null,
+    inbox_killed_at: child.inbox_killed_at ?? null,
     agent_status: childAgentStatus,
     tmux_session: maps.tmuxSessionMap.get(child._id.toString()) ?? null,
     permission_mode: maps.permissionModeMap.get(child._id.toString()) ?? null,
@@ -8376,6 +8381,7 @@ export const inboxForCLI = query({
         hasPending: s.has_pending,
         isUnresponsive: s.is_unresponsive,
         messageCount: s.message_count || 0,
+        killed: !!s.inbox_killed_at,
       });
       const is_live = !!s.is_connected;
 
@@ -8785,6 +8791,34 @@ export const markSessionActive = mutation({
   },
 });
 
+// The daemon's read of a conversation's LIFECYCLE state (api_token auth, so it
+// works from the CLI/daemon where there's no session cookie). It gates its reap
+// on this: a session the user killed or stashed must not be brought back by the
+// daemon's own recovery paths, and no existing daemon-facing query exposes the
+// hide stamps (devices.resolveConversationBySession returns status only).
+// Returns null for a missing conversation or one the caller doesn't run —
+// same silent-null convention as its siblings, and the daemon treats null (or
+// an undeployed query) as "no lifecycle opinion" and falls back.
+export const getConversationLifecycle = query({
+  args: {
+    api_token: v.optional(v.string()),
+    conversation_id: v.id("conversations"),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthenticatedUserId(ctx, args.api_token);
+    if (!userId) return null;
+    const conv = await ctx.db.get(args.conversation_id);
+    if (!conv || conv.user_id !== userId) return null;
+    return {
+      status: conv.status,
+      inbox_killed_at: conv.inbox_killed_at ?? null,
+      inbox_stashed_at: conv.inbox_stashed_at ?? null,
+      inbox_dismissed_at: conv.inbox_dismissed_at ?? null,
+      inbox_pinned_at: conv.inbox_pinned_at ?? null,
+    };
+  },
+});
+
 export const dismissFromInbox = mutation({
   args: {
     conversation_id: v.id("conversations"),
@@ -8854,6 +8888,7 @@ export const cliSetSessionVisibility = mutation({
       return { ok: true as const, short_id: shortId, action: args.action, was_hidden: wasHidden, rearmed_schedules: rearmed };
     }
 
+    const wasHidden = !!conv.inbox_dismissed_at;
     const patch =
       args.action === "kill"
         ? { inbox_dismissed_at: Date.now() }
@@ -8862,8 +8897,22 @@ export const cliSetSessionVisibility = mutation({
     // `conv` is the pre-patch row — applyHideTransition gates on the transition.
     // The nested group (Task subagents + agent-team teammates) comes down with
     // the card via its built-in cascade — see cascadeHideToNestedChildren.
-    const { action: outcome, canceledSchedules, cascaded } = await applyHideTransition(ctx, conv, patch);
-    return { ok: true as const, short_id: shortId, action: args.action, outcome, canceled_schedules: canceledSchedules, cascaded_children: cascaded };
+    // `cast kill` is an EXPLICIT kill gesture, so it forces teardown even on an
+    // already-dismissed session (whose worker a daemon bug may have revived) —
+    // a re-asserted quiet dismiss still doesn't.
+    const { action: outcome, canceledSchedules, canceledMessages, cascaded, teardownEnqueued } =
+      await applyHideTransition(ctx, conv, patch, { forceKill: args.action === "kill" });
+    return {
+      ok: true as const,
+      short_id: shortId,
+      action: args.action,
+      outcome,
+      was_hidden: wasHidden,
+      teardown_enqueued: teardownEnqueued,
+      canceled_schedules: canceledSchedules,
+      canceled_messages: canceledMessages,
+      cascaded_children: cascaded,
+    };
   },
 });
 
@@ -10009,6 +10058,23 @@ export async function resolveRestartTarget(
     // user) restarts from the owner's inbox exactly like their own; the daemon
     // commands are routed to the runner by the callers.
     if (conv.user_id !== userId && conv.owner_user_id !== userId) throw new Error("Not authorized");
+    // An explicit Restart IS the sanctioned revival — the same gesture class as
+    // a human send, so it gets the send path's wake-up rules
+    // (enqueuePendingMessage): clear the kill/hide stamps and re-activate, in
+    // the SAME transaction that enqueues the resume. Without this the daemon
+    // received "restart me" for a row still reading as killed and its hide gate
+    // refused to bring it back. The ghost-recovery path below already did this
+    // for the twin it restores; the existing row was the gap. Patch only what's
+    // actually set, so an ordinary restart of a live session writes nothing.
+    const revive: Record<string, any> = {};
+    if (conv.status === "completed") revive.status = "active" as const;
+    if (conv.inbox_killed_at) revive.inbox_killed_at = undefined;
+    if (conv.inbox_dismissed_at) revive.inbox_dismissed_at = undefined;
+    if (conv.inbox_stashed_at) revive.inbox_stashed_at = undefined;
+    if (Object.keys(revive).length > 0) {
+      await ctx.db.patch(conv._id, revive);
+      return { conv: (await ctx.db.get(conv._id))!, restored: false };
+    }
     return { conv, restored: false };
   }
   let sessionId = ghost.session_id;
@@ -10171,6 +10237,7 @@ export const killSession = mutation({
     });
 
     let canceledSchedules = 0;
+    let canceledMessages = 0;
     if (conv) {
       const patch: Record<string, any> = { inbox_killed_at: Date.now() };
       // A persistent anchor session never auto-completes — a dismiss/kill gesture
@@ -10189,13 +10256,19 @@ export const killSession = mutation({
       if (conv.user_id !== userId) {
         canceledSchedules += await cancelTasksBoundToConversation(ctx, userId, args.conversation_id);
       }
+      // Kill is terminal for messages already queued too — same reason the
+      // schedules die: a retained message that lands later revives the session
+      // the user just killed. Only the pre-kill queue; a later send re-enqueues.
+      canceledMessages = await cancelQueuedMessagesOnKill(ctx, args.conversation_id);
       // Take the nested group (Task subagents + agent-team teammates) down
       // with the card. The web store also sweeps optimistically for its own
-      // gesture; this server twin covers every other caller, and the
-      // already-hidden skip inside makes the two paths race-safe.
-      await cascadeHideToNestedChildren(ctx, conv, { inbox_dismissed_at: Date.now() });
+      // gesture; this server twin covers every other caller. Forced, like the
+      // unconditional enqueue above: this mutation IS an explicit kill gesture,
+      // so an already-hidden child whose worker came back gets torn down again
+      // rather than skipped — the group comes down as one unit.
+      await cascadeHideToNestedChildren(ctx, conv, { inbox_dismissed_at: Date.now() }, { forceKill: true });
     }
-    return { existed: !!conv, canceled_schedules: canceledSchedules };
+    return { existed: !!conv, canceled_schedules: canceledSchedules, canceled_messages: canceledMessages };
   },
 });
 

--- a/packages/convex/convex/conversations.ts
+++ b/packages/convex/convex/conversations.ts
@@ -8906,10 +8906,19 @@ export const cliSetSessionVisibility = mutation({
     const shortId = conv.short_id ?? conv._id.toString().slice(0, 7);
 
     if (args.action === "undismiss") {
-      const wasHidden = !!(conv.inbox_dismissed_at || conv.inbox_stashed_at);
+      const wasHidden = !!(conv.inbox_dismissed_at || conv.inbox_stashed_at || conv.inbox_killed_at);
+      // inbox_killed_at clears too, or undismiss can't do what it advertises: a
+      // killed row is hidden by shouldShowInInbox on that flag alone, so
+      // clearing only the hide stamps left it invisible and `cast kill`'s own
+      // "cast undismiss <id> to resurface" hint was a false promise. (It used to
+      // work by accident — the web's pin gesture wiped the flag through the
+      // patch rail, which is exactly the hole the dispatch guard just sealed.)
+      // `status` deliberately stays: undismiss resurfaces the CARD, it does not
+      // restart the agent — that's Restart's job.
       await ctx.db.patch(conv._id, {
         inbox_dismissed_at: undefined,
         inbox_stashed_at: undefined,
+        inbox_killed_at: undefined,
       });
       // The un-kill mirror (same as the web restore path in dispatch): bring
       // back the schedules the kill canceled, stamped tasks only. Scan the
@@ -10306,14 +10315,21 @@ export const killSession = mutation({
       // just killed (see cancelTasksBoundToConversation). Scan the RUNNER's
       // schedules (theirs are the ones bound to their session), plus the
       // caller's when a second-party owner is killing.
-      canceledSchedules = await cancelTasksBoundToConversation(ctx, conv.user_id, args.conversation_id);
-      if (conv.user_id !== userId) {
-        canceledSchedules += await cancelTasksBoundToConversation(ctx, userId, args.conversation_id);
+      // Both sweeps are RETIREMENT effects, so a persistent anchor is exempt
+      // from both — killing an anchor is dormancy, not death. Same guard as
+      // applyHideTransition: the two kill surfaces must agree about anchors, or
+      // the web button and `cast kill` leave the same session in different
+      // states (its queue survives one and not the other).
+      if (!conv.persistent) {
+        canceledSchedules = await cancelTasksBoundToConversation(ctx, conv.user_id, args.conversation_id);
+        if (conv.user_id !== userId) {
+          canceledSchedules += await cancelTasksBoundToConversation(ctx, userId, args.conversation_id);
+        }
+        // Kill is terminal for messages already queued too — same reason the
+        // schedules die: a retained message that lands later revives the session
+        // the user just killed. Only the pre-kill queue; a later send re-enqueues.
+        canceledMessages = await cancelQueuedMessagesOnKill(ctx, args.conversation_id);
       }
-      // Kill is terminal for messages already queued too — same reason the
-      // schedules die: a retained message that lands later revives the session
-      // the user just killed. Only the pre-kill queue; a later send re-enqueues.
-      canceledMessages = await cancelQueuedMessagesOnKill(ctx, args.conversation_id);
       // Take the nested group (Task subagents + agent-team teammates) down
       // with the card. The web store also sweeps optimistically for its own
       // gesture; this server twin covers every other caller. Forced, like the

--- a/packages/convex/convex/dispatch.test.ts
+++ b/packages/convex/convex/dispatch.test.ts
@@ -172,6 +172,59 @@ describe("explicit kill actions force teardown", () => {
   });
 });
 
+// inbox_killed_at is the retired marker the daemon's resurrection gate and
+// classifyWorkState both read. This generic patch rail carries whatever fields
+// an action's draft touched, so an unrelated gesture can wipe it — the web's pin
+// nulls it in its draft, and a killed row is only VISIBLE while pinned
+// (shouldShowInInbox), so pin-then-wipe hit exactly the rows the marker matters
+// most for, and re-armed daemon resurrection on a killed persistent anchor.
+describe("inbox_killed_at survives patches that are not a revival", () => {
+  const RUNNER = "users_runner";
+  const CONV = "conversations_killed";
+
+  const fixtures = () =>
+    makeFakeDb({
+      conversations: [{
+        _id: CONV, user_id: RUNNER, status: "completed", message_count: 12,
+        inbox_dismissed_at: 111, inbox_killed_at: 111,
+      }],
+      messages: [], pending_messages: [], client_state: [], managed_sessions: [],
+      agent_tasks: [], daemon_commands: [], session_owners: [],
+    });
+
+  test("a pin-shaped patch (pin set, killed nulled) leaves inbox_killed_at intact", async () => {
+    const db = fixtures();
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_pinned_at: 555, is_pinned: true, inbox_killed_at: null } },
+    });
+    const row = db._tables.conversations[0];
+    expect(row.inbox_killed_at).toBe(111); // the marker survives…
+    expect(row.inbox_pinned_at).toBe(555); // …and the rest of the patch still lands
+  });
+
+  test("an un-kill (a patch clearing inbox_dismissed_at) DOES clear it", async () => {
+    const db = fixtures();
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_killed_at: null } },
+    });
+    const row = db._tables.conversations[0];
+    expect(row.inbox_dismissed_at).toBeUndefined();
+    expect(row.inbox_killed_at).toBeUndefined();
+  });
+
+  test("SETTING inbox_killed_at is never blocked", async () => {
+    const db = makeFakeDb({
+      conversations: [{ _id: CONV, user_id: RUNNER, status: "active", message_count: 12 }],
+      messages: [], pending_messages: [], client_state: [], managed_sessions: [],
+      agent_tasks: [], daemon_commands: [], session_owners: [],
+    });
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_killed_at: 777 } },
+    });
+    expect(db._tables.conversations[0].inbox_killed_at).toBe(777);
+  });
+});
+
 describe("applyPatches bucket coverage", () => {
   test("a legacy generic bucket patch advances the v2 complete-view head once", async () => {
     const userId = "users_owner";

--- a/packages/convex/convex/dispatch.test.ts
+++ b/packages/convex/convex/dispatch.test.ts
@@ -3,6 +3,7 @@ import { applyPatches, classifyHideTransition, dispatch } from "./dispatch";
 import { reconfigureSession } from "./conversations";
 import { getReceipt } from "./localFirstCommands";
 import { makeFakeDb } from "./testDb";
+import { shouldShowInInbox } from "./inboxFilters";
 
 // The conversation hide-transition hook in applyPatches is the ONE place the
 // "dismiss = kill, stash = keep alive" contract is enforced — every dismiss
@@ -210,6 +211,23 @@ describe("inbox_killed_at survives patches that are not a revival", () => {
     const row = db._tables.conversations[0];
     expect(row.inbox_dismissed_at).toBeUndefined();
     expect(row.inbox_killed_at).toBeUndefined();
+  });
+
+  // …and the flip side of the guard: the web's restore gesture sends only the
+  // two hide stamps, but shouldShowInInbox hides a row on inbox_killed_at ALONE.
+  // The server un-kills on the dismissed-clear transition, so restore works
+  // without the client knowing the field exists (and old clients keep working).
+  test("a web-restore-shaped patch un-kills the row server-side", async () => {
+    const db = fixtures();
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_dismissed_at: null, inbox_stashed_at: null } },
+    });
+    const row = db._tables.conversations[0];
+    expect(row.inbox_dismissed_at).toBeUndefined();
+    expect(row.inbox_killed_at).toBeUndefined();
+    expect(shouldShowInInbox(row as any)).toBe(true); // visible with no pin required
+    // Restore brings the CARD back; it does not restart the agent.
+    expect(row.status).toBe("completed");
   });
 
   test("SETTING inbox_killed_at is never blocked", async () => {

--- a/packages/convex/convex/dispatch.test.ts
+++ b/packages/convex/convex/dispatch.test.ts
@@ -112,6 +112,66 @@ describe("applyPatches conversation owner gate", () => {
   });
 });
 
+// Kill is a DESIRED STATE, not an event. A kill patch is indistinguishable at
+// the FIELD level from a quiet re-assert of the same flag (a stub-rekey flush,
+// an undo replay), so the dispatched ACTION NAME is the only signal of intent
+// the server gets. Regression: a killed session whose worker a daemon bug
+// revived still carried inbox_dismissed_at, so the hide transition classified
+// "none" and no teardown was ever enqueued — the worker was unkillable.
+describe("explicit kill actions force teardown", () => {
+  const RUNNER = "users_runner";
+  const CONV = "conversations_killed";
+
+  function fixtures() {
+    return makeFakeDb({
+      // Already in the Killed bucket, with real work (so the empty-reap path
+      // can't fire) — the resurrection case.
+      conversations: [{
+        _id: CONV, user_id: RUNNER, session_id: "s-1", status: "completed",
+        message_count: 12, inbox_dismissed_at: 111, inbox_killed_at: 111,
+      }],
+      messages: [],
+      pending_messages: [],
+      client_state: [],
+      managed_sessions: [],
+      agent_tasks: [],
+      daemon_commands: [],
+      session_owners: [],
+    });
+  }
+
+  const run = (db: any, action: string) => (dispatch as any)._handler({
+    auth: { getUserIdentity: async () => ({ subject: `${RUNNER}|session` }) },
+    db,
+  }, {
+    action,
+    args: [],
+    patches: { conversations: { [CONV]: { inbox_dismissed_at: 222 } } },
+  });
+
+  const teardowns = (db: any) =>
+    db._tables.daemon_commands.filter((c: any) => c.command === "kill_session");
+
+  test("killSession re-enqueues teardown on an already-killed session", async () => {
+    const db = fixtures();
+    await run(db, "killSession");
+    expect(teardowns(db)).toHaveLength(1);
+    expect(JSON.parse(teardowns(db)[0].args)).toMatchObject({ conversation_id: CONV, session_id: "s-1" });
+  });
+
+  test("killSessions (the bulk gesture) forces the same way", async () => {
+    const db = fixtures();
+    await run(db, "killSessions");
+    expect(teardowns(db)).toHaveLength(1);
+  });
+
+  test("a quiet re-assert of the flag by any other action does NOT re-kill", async () => {
+    const db = fixtures();
+    await run(db, "patchConversation");
+    expect(teardowns(db)).toHaveLength(0);
+  });
+});
+
 describe("applyPatches bucket coverage", () => {
   test("a legacy generic bucket patch advances the v2 complete-view head once", async () => {
     const userId = "users_owner";

--- a/packages/convex/convex/dispatch.ts
+++ b/packages/convex/convex/dispatch.ts
@@ -107,7 +107,7 @@ export const dispatch = mutation({
       typeof patches === "object" &&
       !(hasReceiptCommandId(result) && RECEIPT_OWNS_SERVER_WRITE.has(action))
     ) {
-      await applyPatches(ctx, userId, patches);
+      await applyPatches(ctx, userId, patches, { forceKill: EXPLICIT_KILL_ACTIONS.has(action) });
     }
 
     const sideEffect = SIDE_EFFECTS[action];
@@ -269,11 +269,21 @@ function deepMergeField(existing: any, incoming: any): any {
 // visibility mutation. Re-exported here for the existing tests.
 export { classifyHideTransition } from "./cleanup";
 
+// The web's explicit kill gestures (inboxStore killSession / killSessions). A
+// kill patch is indistinguishable at the FIELD level from a quiet re-assert of
+// the same flag — a stub-rekey flushResolvedSessionFields, an applyUndoPatches
+// replay — so the dispatched ACTION NAME is the only signal of intent the
+// server gets, and a kill must tear down again even when the flag is already
+// set (see applyHideTransition's forceKill). Every other action patching
+// inbox_dismissed_at stays transition-gated.
+const EXPLICIT_KILL_ACTIONS = new Set(["killSession", "killSessions"]);
+
 // Exported for tests (the dispatch mutation is the only runtime caller).
 export async function applyPatches(
   ctx: HandlerCtx,
   userId: Id<"users">,
-  patches: Record<string, Record<string, Record<string, any>>>
+  patches: Record<string, Record<string, Record<string, any>>>,
+  opts?: { forceKill?: boolean }
 ) {
   let bucketViewChanged = false;
   for (const [table, docs] of Object.entries(patches)) {
@@ -331,7 +341,7 @@ export async function applyPatches(
         // dismiss/stash path funnels through here — the inbox shortcuts, the
         // palette, the /sessions toggle (patchConversation), and any future one.
         if (table === "conversations" && ((finalSafe as any).inbox_dismissed_at || (finalSafe as any).inbox_stashed_at)) {
-          await applyHideTransition(ctx, doc, finalSafe as any);
+          await applyHideTransition(ctx, doc, finalSafe as any, { forceKill: opts?.forceKill });
         }
         // The un-kill mirror: a patch CLEARING inbox_dismissed_at on a row that
         // had it is the restore/undo gesture (web restoreSession, undo of a

--- a/packages/convex/convex/dispatch.ts
+++ b/packages/convex/convex/dispatch.ts
@@ -347,6 +347,12 @@ export async function applyPatches(
           delete (finalSafe as any).inbox_killed_at;
         }
         if (Object.keys(finalSafe).length === 0) continue;
+        // Capture the PRE-patch hide state. The un-kill mirror below decides on
+        // what the row looked like BEFORE this write, and reading it afterwards
+        // would depend on ctx.db.get having handed back a snapshot rather than
+        // the row the patch mutates.
+        const wasDismissed = table === "conversations" && !!(doc as any).inbox_dismissed_at;
+        const wasKilled = table === "conversations" && !!(doc as any).inbox_killed_at;
         if (table === "comments") {
           const conversation = await ctx.db.get(doc.conversation_id as Id<"conversations">);
           if (!conversation || !(await canAccessConversation(ctx, userId, conversation))) continue;
@@ -375,8 +381,18 @@ export async function applyPatches(
           table === "conversations" &&
           "inbox_dismissed_at" in (finalSafe as any) &&
           !(finalSafe as any).inbox_dismissed_at &&
-          (doc as any).inbox_dismissed_at
+          wasDismissed
         ) {
+          // Un-kill the row server-side. The web's restore gesture only nulls
+          // the two hide stamps, but shouldShowInInbox hides a row on
+          // inbox_killed_at alone — so without this the restored session stays
+          // invisible unless it happens to be pinned. Doing it here (rather than
+          // trusting a client to send the field) also keeps old clients working
+          // and matches `cast undismiss`. `status` is left alone: restore brings
+          // the CARD back, Restart brings the agent back.
+          if (wasKilled) {
+            await ctx.db.patch(doc._id as Id<"conversations">, { inbox_killed_at: undefined });
+          }
           await reactivateTasksCanceledOnKill(ctx, (doc as any).user_id, doc._id as Id<"conversations">);
           if ((doc as any).user_id?.toString() !== userId.toString()) {
             await reactivateTasksCanceledOnKill(ctx, userId, doc._id as Id<"conversations">);

--- a/packages/convex/convex/dispatch.ts
+++ b/packages/convex/convex/dispatch.ts
@@ -325,6 +325,27 @@ export async function applyPatches(
         ) {
           delete finalSafe.is_favorite;
         }
+        // inbox_killed_at is the retired marker: the daemon's reap/resurrection
+        // gate and classifyWorkState both read it, and a killed persistent
+        // anchor stays daemon-proof only while it's set. This generic rail
+        // carries whatever fields an action's draft happened to touch, so a
+        // gesture with nothing to do with revival can wipe it — the web's pin
+        // nulls it in its draft (see ct-41083), which deleted the marker on the
+        // very rows it matters most for (a killed row is only visible while
+        // pinned, per shouldShowInInbox). Guard by FIELD, not by action name, so
+        // an old client shipping the same patch is caught too: a CLEAR is
+        // honored only when the patch is itself an un-kill (it clears
+        // inbox_dismissed_at as well). The other sanctioned revivals — a human
+        // send (pendingMessages.enqueue), delivery, Restart — are mutations and
+        // never ride this rail. SETTING it is untouched.
+        if (
+          table === "conversations"
+          && "inbox_killed_at" in finalSafe
+          && !(finalSafe as any).inbox_killed_at
+          && !("inbox_dismissed_at" in finalSafe && !(finalSafe as any).inbox_dismissed_at)
+        ) {
+          delete (finalSafe as any).inbox_killed_at;
+        }
         if (Object.keys(finalSafe).length === 0) continue;
         if (table === "comments") {
           const conversation = await ctx.db.get(doc.conversation_id as Id<"conversations">);

--- a/packages/convex/convex/executionBindings.test.ts
+++ b/packages/convex/convex/executionBindings.test.ts
@@ -25,6 +25,7 @@ import {
   requestExecutionSuccessorInDb,
   resolveAmbiguousDeliveryInDb,
   startDeliveryInDb,
+  cancelFencedDeliveriesOnKill,
 } from "./executionBindings";
 
 const USER = "users_1" as Id<"users">;
@@ -1376,5 +1377,72 @@ describe("conversation-global ordered delivery", () => {
     const replacementClaim = await claimDelivery(ctx, resent.messageId);
     expect(replacementClaim.permit.deliveryId).toBe("explicit-risk-resend");
     expect(replacementClaim.permit.conversationSequence).toBe("2");
+  });
+});
+
+// Kill teardown on a FENCED conversation. The legacy cancel path refuses these
+// rows on purpose (patching one behind the epoch machinery's back would strand
+// its attempt and the head's slot), so before this a kill cancelled NOTHING here
+// and the queue simply outlived the session.
+describe("cancelFencedDeliveriesOnKill", () => {
+  test("terminalizes unstarted deliveries, unwinds a claimed one, releases the head slot", async () => {
+    const db = makeFakeDb(tables());
+    const ctx = await initializeAndReady(db);
+    const firstId = await enqueue(ctx, "msg-1");
+    const secondId = await enqueue(ctx, "msg-2");
+    const claim = await claimDelivery(ctx, firstId);
+    expect(claim.permit.deliveryId).toBe("msg-1");
+
+    const result = await cancelFencedDeliveriesOnKill(ctx, CONVERSATION, 99);
+    expect(result).toEqual({ cancelled: 2, inFlight: 0 });
+
+    // Both rows are terminal, by the epoch machinery's own vocabulary.
+    for (const id of [firstId, secondId]) {
+      const row: any = await db.get(id);
+      expect(row.status).toBe("cancelled");
+      expect(row.delivery_status).toBe("cancelled-by-supersession");
+      expect(row.active_delivery_attempt_id).toBeUndefined();
+    }
+    // The claimed attempt is unwound, not orphaned…
+    const attempt: any = await db.get(claim.permit.attemptId);
+    expect(attempt.state).toBe("cancelled-by-supersession");
+    expect(attempt.completed_at).toBe(99);
+    // …and the conversation's delivery slot is free again.
+    const head: any = db._tables.conversation_execution_heads[0];
+    expect(head.active_delivery_attempt_id).toBeUndefined();
+    expect(head.active_delivery_state).toBeUndefined();
+  });
+
+  test("a delivery already landing in the pane is left for the delivery machinery", async () => {
+    const db = makeFakeDb(tables());
+    const ctx = await initializeAndReady(db);
+    const messageId = await enqueue(ctx, "msg-1");
+    const claim = await claimDelivery(ctx, messageId);
+    await startDeliveryInDb(ctx, USER, { ...fence(claim.permit), now: 21 });
+
+    // Never throws — a kill must not be abortable by the delivery state (the
+    // epoch path fails hard here; this one reports and moves on).
+    const result = await cancelFencedDeliveriesOnKill(ctx, CONVERSATION, 99);
+    expect(result).toEqual({ cancelled: 0, inFlight: 1 });
+    const row: any = await db.get(messageId);
+    expect(row.delivery_status).toBe("delivery-started");
+    expect(row.status).not.toBe("cancelled");
+  });
+
+  test("a started delivery revives the conversation it lands in", async () => {
+    const db = makeFakeDb(tables());
+    const ctx = await initializeAndReady(db);
+    const messageId = await enqueue(ctx, "msg-1");
+    const claim = await claimDelivery(ctx, messageId);
+    // The user kills the session AFTER the delivery was claimed — so the kill
+    // stamps land on a row whose delivery is already past the point of cancel
+    // (enqueue's own wake-up rules can't help here; they ran before the kill).
+    await db.patch(CONVERSATION, { inbox_killed_at: 5, inbox_dismissed_at: 5, status: "completed" });
+    await startDeliveryInDb(ctx, USER, { ...fence(claim.permit), now: 21 });
+
+    const conv: any = await db.get(CONVERSATION);
+    expect(conv.inbox_killed_at).toBeUndefined();
+    expect(conv.inbox_dismissed_at).toBeUndefined();
+    expect(conv.status).toBe("active");
   });
 });

--- a/packages/convex/convex/executionBindings.ts
+++ b/packages/convex/convex/executionBindings.ts
@@ -2246,9 +2246,28 @@ export async function cancelFencedDeliveriesOnKill(
   ctx: DbCtx,
   conversationId: Id<"conversations">,
   now: number = Date.now(),
+  limit: number = 300,
 ): Promise<{ cancelled: number; inFlight: number }> {
   const head = await executionHead(ctx, conversationId);
-  const messages = await fencedMessages(ctx, conversationId);
+  // Read the NON-TERMINAL queue through the status index, never the whole
+  // by_conversation_id history: pending_messages is dominated by terminal
+  // delivered rows, and collecting them all is what turns a kill on a busy
+  // session into a transaction that throws (the documented anti-pattern behind
+  // collectOldLegacyPendingMessages). Capped for the same reason — the caller
+  // schedules a continuation for anything left over.
+  const messages: any[] = [];
+  for (const status of ["pending", "injected", "failed", "undeliverable"] as const) {
+    if (messages.length >= limit) break;
+    const rows = await ctx.db
+      .query("pending_messages")
+      .withIndex("by_conversation_status", (q: any) =>
+        q.eq("conversation_id", conversationId).eq("status", status),
+      )
+      .take(limit - messages.length);
+    for (const row of rows) {
+      if (row.delivery_protocol_version !== undefined) messages.push(row);
+    }
+  }
   let cancelled = 0;
   let inFlight = 0;
   let releasedHeadSlot = false;

--- a/packages/convex/convex/executionBindings.ts
+++ b/packages/convex/convex/executionBindings.ts
@@ -15,7 +15,7 @@ import {
 } from "@codecast/shared/contracts";
 import type { Id } from "./_generated/dataModel";
 import { verifyApiToken } from "./apiTokens";
-import { insertRiskResendPendingMessage } from "./pendingMessageWrites";
+import { insertRiskResendPendingMessage, reviveConversationOnDelivery } from "./pendingMessageWrites";
 
 export const EXECUTION_PROTOCOL_VERSION = 1 as const;
 
@@ -1761,6 +1761,11 @@ export async function startDeliveryInDb(
     active_delivery_state: "delivery-started" as const,
     updated_at: fence.now,
   });
+  // The effect is now landing in the pane, so the conversation is alive by
+  // definition — clear any kill/dismiss stamps it still carries (the fenced
+  // twin of the legacy status path's revival). A fenced delivery that outlived
+  // a kill otherwise runs a session the record still calls retired.
+  await reviveConversationOnDelivery(ctx, head.conversation_id);
   return startedPermitWire({ ...attempt, state: "delivery-started" });
 }
 
@@ -2217,6 +2222,80 @@ async function cancelUnstartedOldEpoch(
     });
   }
   return { cancelled, remaining: messages.length - batch.length };
+}
+
+/**
+ * Kill teardown for a FENCED conversation: cancel every delivery that has not
+ * started, preserving the delivery-slot invariants.
+ *
+ * The legacy cancel path (pendingMessages.cancelQueuedMessagesOnKill) refuses
+ * fenced rows on purpose — patching one to "cancelled" behind the epoch
+ * machinery's back would strand its delivery_attempts row and the head's active
+ * slot. So on a fenced conversation a kill used to cancel NOTHING, and the
+ * queue simply outlived it. This is the sanctioned version of that cancel,
+ * modeled on cancelUnstartedOldEpoch: a `pending` message is terminalized
+ * outright; a `claimed` one also cancels its attempt and releases the head slot
+ * it holds.
+ *
+ * A `delivery-started` or `ambiguous` message is LEFT ALONE and only counted:
+ * its effect may already be in the pane, and only the delivery machinery may
+ * resolve it. Unlike the epoch path this never throws — a kill must not be
+ * abortable by whatever the delivery state happens to be.
+ */
+export async function cancelFencedDeliveriesOnKill(
+  ctx: DbCtx,
+  conversationId: Id<"conversations">,
+  now: number = Date.now(),
+): Promise<{ cancelled: number; inFlight: number }> {
+  const head = await executionHead(ctx, conversationId);
+  const messages = await fencedMessages(ctx, conversationId);
+  let cancelled = 0;
+  let inFlight = 0;
+  let releasedHeadSlot = false;
+  for (const message of messages) {
+    if (isTerminalDeliveryState(message.delivery_status)) continue;
+    if (
+      message.delivery_status === "delivery-started" ||
+      message.delivery_status === "ambiguous"
+    ) {
+      inFlight += 1;
+      continue;
+    }
+    if (message.delivery_status === "claimed") {
+      const attempt = message.active_delivery_attempt_id
+        ? await ctx.db.get(message.active_delivery_attempt_id)
+        : null;
+      // A claimed message whose attempt disagrees is not ours to unwind.
+      if (!attempt || attempt.state !== "claimed") {
+        inFlight += 1;
+        continue;
+      }
+      await ctx.db.patch(attempt._id, {
+        state: "cancelled-by-supersession" as const,
+        completed_at: now,
+      });
+      if (head && String(head.active_delivery_attempt_id) === String(attempt._id)) {
+        releasedHeadSlot = true;
+      }
+    } else if (message.delivery_status !== "pending") {
+      inFlight += 1;
+      continue;
+    }
+    await ctx.db.patch(message._id, {
+      delivery_status: "cancelled-by-supersession" as const,
+      active_delivery_attempt_id: undefined,
+      status: "cancelled" as const,
+    });
+    cancelled += 1;
+  }
+  if (releasedHeadSlot && head) {
+    await ctx.db.patch(head._id, {
+      active_delivery_attempt_id: undefined,
+      active_delivery_state: undefined,
+      updated_at: now,
+    });
+  }
+  return { cancelled, inFlight };
 }
 
 export async function activateExecutionSuccessorInDb(

--- a/packages/convex/convex/inboxFilters.test.ts
+++ b/packages/convex/convex/inboxFilters.test.ts
@@ -459,7 +459,7 @@ describe("classifyWorkState", () => {
   test("THE RULE: a settled session with content → needs_input (matches the web inbox)", () => {
     // The web inbox has no "idle with content" bucket — a finished turn waiting
     // to be read is the user's ball, so it files under NEEDS INPUT. The CLI
-    // matches; "idle" is reserved for blank sessions.
+    // matches; "idle" is reserved for blank (or killed) sessions.
     expect(classifyWorkState(wsi({ isIdle: true }))).toBe("needs_input");
   });
 
@@ -480,6 +480,22 @@ describe("classifyWorkState", () => {
     expect(classifyWorkState(wsi({ messageCount: 0, isIdle: false }))).toBe("idle");
     // ...but an actively-working empty session (just spawned) is still working.
     expect(classifyWorkState(wsi({ messageCount: 0, agentStatus: "starting" }))).toBe("working");
+  });
+
+  // A killed row is triaged — the user retired it. It used to read as "working"
+  // off a stale has_pending_messages flag (a message queued before the kill that
+  // outlived it) or off an agent_status from a worker a daemon bug revived, so
+  // the inbox showed a dead session busily working. Kill outranks all of it.
+  test("a KILLED row never classifies as working, whatever stale flags it carries", () => {
+    expect(classifyWorkState(wsi({ killed: true, hasPending: true }))).toBe("idle");
+    expect(classifyWorkState(wsi({ killed: true, agentStatus: "working" }))).toBe("idle");
+    expect(classifyWorkState(wsi({ killed: true, isIdle: false }))).toBe("idle");
+    // …and it stops demanding attention too: the user already dealt with it.
+    expect(classifyWorkState(wsi({ killed: true, isIdle: true }))).toBe("idle");
+    expect(classifyWorkState(wsi({ killed: true, awaitingInput: true }))).toBe("idle");
+    // A revived session clears inbox_killed_at (pendingMessages.enqueue), so an
+    // un-killed row classifies normally again.
+    expect(classifyWorkState(wsi({ killed: false, hasPending: true }))).toBe("working");
   });
 
   test("an unresponsive (dead-daemon) session with queued work does NOT count as working", () => {

--- a/packages/convex/convex/inboxFilters.ts
+++ b/packages/convex/convex/inboxFilters.ts
@@ -335,7 +335,9 @@ export function subagentKeepsParentWorking(input: {
 //                    session with output. This is the web's NEEDS INPUT bucket:
 //                    a settled session with content always lands here (pinned
 //                    included — a pin means "ping me when this is free").
-//   - "idle":        nothing to act on: blank sessions (no messages yet).
+//   - "idle":        nothing to act on: blank sessions (no messages yet), and
+//                    KILLED sessions — the user retired those, so they never
+//                    read as working or needs-input again (see `killed` below).
 // This is the server-side mirror of the web store's isSessionWaitingForInput,
 // minus the client-only queued-message signal, and is the ONE place the rule
 // lives — the CLI only ever string-matches the resulting work_state.
@@ -349,6 +351,8 @@ export interface WorkStateInput {
   hasPending: boolean;
   isUnresponsive: boolean;
   messageCount: number;
+  /** conversations.inbox_killed_at — the user retired this row. Outranks everything below. */
+  killed?: boolean;
 }
 
 // Accepted `--state` filter values for CLI discovery, normalized to a canonical
@@ -424,10 +428,22 @@ export const NEEDS_INPUT_AUQ_CHECK_DELAY_MS = 2_000;
 export const HEARTBEAT_ALIVE_MS = 90 * 1000;
 
 export function classifyWorkState(input: WorkStateInput): WorkState {
-  const { agentStatus, isIdle, awaitingInput, hasPending, isUnresponsive, messageCount } = input;
+  const { agentStatus, isIdle, awaitingInput, hasPending, isUnresponsive, messageCount, killed } = input;
   const dead = !!agentStatus && DEAD_AGENT_STATUSES.has(agentStatus);
   const canDeliver = !isUnresponsive && !dead;
   const hasMsgs = messageCount > 0;
+
+  // A KILLED row is triaged and outranks every signal below it: the user retired
+  // it, so nothing about it is actionable and it must never read as "working".
+  // Kill now cancels the messages queued before it, but a has_pending flag can
+  // still be stale (an in-flight fenced row, an older kill), and an agent_status
+  // can come from a worker a daemon bug revived — both used to park the dead row
+  // back in the Working bucket. inbox_killed_at is the right signal precisely
+  // because ANY new send clears it (pendingMessages.enqueue's wake-up rules), so
+  // a genuinely revived session classifies normally again. `status: "completed"`
+  // alone deliberately does NOT qualify — an ordinary finished session with a
+  // queued message really is about to work on it.
+  if (killed) return "idle";
 
   // Blocked on the user right now (open AskUserQuestion poll, or a tool-use
   // awaiting approve/deny) → needs input. A poll/permission on an empty session

--- a/packages/convex/convex/notifications.ts
+++ b/packages/convex/convex/notifications.ts
@@ -685,6 +685,7 @@ export async function performNeedsInputCheck(
     hasPending,
     isUnresponsive: activity.isUnresponsive,
     messageCount: conv.message_count || 0,
+    killed: !!conv.inbox_killed_at,
   });
   if (state !== "needs_input") return { notified: false, reason: "not_needs_input" };
 

--- a/packages/convex/convex/pendingMessageWrites.ts
+++ b/packages/convex/convex/pendingMessageWrites.ts
@@ -118,6 +118,40 @@ async function insertPendingMessageRow(
   });
 }
 
+/**
+ * The DELIVERY-side twin of the enqueue wake-up rules (pendingMessages'
+ * enqueuePendingMessage): if the system is injecting a message into a
+ * conversation, that conversation is alive, whatever its inbox flags still say.
+ *
+ * Without this a message that outlived a kill — a leftover legacy row, or a
+ * fenced delivery the kill could not cancel — lands in the pane and runs the
+ * session while the row still carries inbox_killed_at. The record then
+ * contradicts reality, and (since classifyWorkState now reads a killed row as
+ * "idle") it does so INVISIBLY: a session busily working while the inbox files
+ * it as retired. Record follows reality.
+ *
+ * Deliberately does NOT clear inbox_stashed_at: stash means "keep working out of
+ * my sight", so delivering into a stashed session is its intended behavior and
+ * must not drag it back into the active inbox (mirrors enqueue's machine-wake
+ * rule). Lives here, not in pendingMessages, so both the legacy status path and
+ * the fenced delivery path (executionBindings) can call it without an import
+ * cycle.
+ */
+export async function reviveConversationOnDelivery(
+  ctx: DbCtx,
+  conversationId: Id<"conversations">,
+): Promise<boolean> {
+  const conversation = await ctx.db.get(conversationId);
+  if (!conversation) return false;
+  const revive: Record<string, unknown> = {};
+  if (conversation.inbox_killed_at) revive.inbox_killed_at = undefined;
+  if (conversation.inbox_dismissed_at) revive.inbox_dismissed_at = undefined;
+  if (conversation.status === "completed") revive.status = "active";
+  if (Object.keys(revive).length === 0) return false;
+  await ctx.db.patch(conversationId, revive);
+  return true;
+}
+
 /** The sole raw insertion path for a newly admitted product/legacy message. */
 export async function insertEnqueuedPendingMessage(
   ctx: DbCtx,

--- a/packages/convex/convex/pendingMessages.test.ts
+++ b/packages/convex/convex/pendingMessages.test.ts
@@ -10,6 +10,7 @@ import {
   resetConversationPendingMessages,
   updatePendingMessageStatusForDaemon,
   cancelQueuedMessagesOnKill,
+  updateMessageStatus,
 } from "./pendingMessages";
 import { makeFakeDb } from "./testDb";
 
@@ -575,11 +576,66 @@ describe("cancelQueuedMessagesOnKill", () => {
   test("cancels UNSTARTED fenced deliveries through the epoch machinery", async () => {
     const db = mkDb([
       { _id: "m_fenced", status: "pending", delivery_protocol_version: 2, delivery_status: "pending" },
-    ]);
+    ], { execution_protocol_state: "fenced" });
     expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(1);
     expect(db._tables.pending_messages[0].status).toBe("cancelled");
     expect(db._tables.pending_messages[0].delivery_status).toBe("cancelled-by-supersession");
     expect(db._tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  // Kill must never be the gesture that fails on exactly the sessions it exists
+  // for. A runaway session's history is dominated by TERMINAL delivered rows, so
+  // the sweep reads only the status-scoped index — collecting by_conversation_id
+  // (the documented anti-pattern) is what blows the transaction's read limit.
+  test("never reads the conversation's whole history — status-scoped indexes only", async () => {
+    const history = Array.from({ length: 2000 }, (_, i) => ({ _id: `d${i}`, status: "delivered" }));
+    const db = mkDb([...history, { _id: "m_live", status: "pending" }], { execution_protocol_state: "fenced" });
+    const indexes: string[] = [];
+    const rawQuery = db.query.bind(db);
+    db.query = (table: string) => {
+      const builder = rawQuery(table);
+      const rawWithIndex = builder.withIndex.bind(builder);
+      builder.withIndex = (name: string, fn?: any) => {
+        if (table === "pending_messages") indexes.push(name);
+        return rawWithIndex(name, fn);
+      };
+      return builder;
+    };
+
+    expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(1);
+    expect(indexes.length).toBeGreaterThan(0);
+    expect(indexes.every((i) => i === "by_conversation_status")).toBe(true);
+    expect(db._tables.pending_messages.filter((r: any) => r.status === "delivered")).toHaveLength(2000);
+  });
+
+  // The fenced sweep is the expensive one; an ordinary conversation must not pay
+  // for it. (Its rows are legacy by construction, so there is nothing to find.)
+  test("skips the fenced sweep entirely on a conversation that isn't fenced", async () => {
+    const db = mkDb([{ _id: "m_pending", status: "pending" }]);
+    const heads: string[] = [];
+    const rawQuery = db.query.bind(db);
+    db.query = (table: string) => { heads.push(table); return rawQuery(table); };
+    await cancelQueuedMessagesOnKill({ db } as any, CONV as any);
+    expect(heads).not.toContain("conversation_execution_heads");
+  });
+
+  // Overflow: one transaction cancels at most the budget and hands the rest to a
+  // scheduled continuation, so the kill mutation itself always lands fast.
+  test("caps one transaction at the budget and schedules the remainder", async () => {
+    const db = mkDb(Array.from({ length: 350 }, (_, i) => ({ _id: `m${i}`, status: "pending" })));
+    const scheduled: any[] = [];
+    const ctx = { db, scheduler: { runAfter: async (_d: number, fn: any, a: any) => { scheduled.push([fn, a]); } } };
+
+    expect(await cancelQueuedMessagesOnKill(ctx as any, CONV as any)).toBe(300);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0][1]).toEqual({ conversation_id: CONV });
+    expect(db._tables.pending_messages.filter((r: any) => r.status === "pending")).toHaveLength(50);
+
+    // The continuation finishes the job (and doesn't need another).
+    scheduled.length = 0;
+    expect(await cancelQueuedMessagesOnKill(ctx as any, CONV as any)).toBe(50);
+    expect(db._tables.pending_messages.every((r: any) => r.status === "cancelled")).toBe(true);
+    expect(scheduled).toHaveLength(0);
   });
 
   // A delivery already landing in the pane is the one thing kill may not
@@ -589,7 +645,7 @@ describe("cancelQueuedMessagesOnKill", () => {
   test("leaves an in-flight fenced delivery alone and does not lie about the flag", async () => {
     const db = mkDb([
       { _id: "m_started", status: "pending", delivery_protocol_version: 2, delivery_status: "delivery-started" },
-    ]);
+    ], { execution_protocol_state: "fenced" });
     expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(0);
     expect(db._tables.pending_messages[0].status).toBe("pending");
     expect(db._tables.pending_messages[0].delivery_status).toBe("delivery-started");
@@ -623,6 +679,29 @@ describe("delivery revives a killed conversation", () => {
     // Stash survives on purpose: "keep working out of my sight" is exactly what
     // a delivering-but-hidden session is doing (mirrors enqueue's machine wake).
     expect(conv.inbox_stashed_at).toBe(111);
+  });
+
+  // The PUBLIC status mutation is not proof of delivery. With device_id omitted
+  // it writes through the same helper but its authorization passes on
+  // message.from_user_id alone — no conversation ownership — so a teammate who
+  // sent into my session (or a replay of their client) could post
+  // status:"injected" and un-retire a session I killed with nothing delivered.
+  // "injected" is self-reported and reversible; only the owning daemon's word counts.
+  test("the PUBLIC status mutation cannot revive a killed session", async () => {
+    const db = killedDb();
+    // The sender is a teammate — the conversation is mine.
+    db._tables.pending_messages[0].from_user_id = "u_teammate";
+    await (updateMessageStatus as any)._handler(
+      {
+        db,
+        auth: { getUserIdentity: async () => ({ subject: "u_teammate|session" }) },
+      },
+      { message_id: "m1", status: "injected" },
+    );
+    const conv = db._tables.conversations[0];
+    expect(db._tables.pending_messages[0].status).toBe("injected"); // the write itself still lands
+    expect(conv.inbox_killed_at).toBe(111); // …but the session stays retired
+    expect(conv.status).toBe("completed");
   });
 
   test("a CANCEL is not a delivery and revives nothing", async () => {

--- a/packages/convex/convex/pendingMessages.test.ts
+++ b/packages/convex/convex/pendingMessages.test.ts
@@ -9,7 +9,9 @@ import {
   planStuckMessageHeal,
   resetConversationPendingMessages,
   updatePendingMessageStatusForDaemon,
+  cancelQueuedMessagesOnKill,
 } from "./pendingMessages";
+import { makeFakeDb } from "./testDb";
 
 describe("collectOldLegacyPendingMessages", () => {
   test("reads only by_status and excludes recent and fenced rows", async () => {
@@ -515,5 +517,58 @@ describe("planStuckMessageHeal", () => {
     expect(recent("failed", "hi", old).kind).toBe("repend");
     expect(recent("injected", "real text", old).kind).toBe("repend");
     expect(recent("pending", "real text", old).kind).toBe("repend");
+  });
+});
+
+// Kill is TERMINAL for the messages already queued. The retry loop is otherwise
+// indefinite, so a retained message could land long after the kill and revive a
+// session still stamped inbox_killed_at (observed live), or — once its retries
+// were exhausted — strand the row as completed + has_pending_messages forever.
+describe("cancelQueuedMessagesOnKill", () => {
+  const CONV = "c1";
+  const mkDb = (rows: Array<Record<string, any>>, convExtra: Record<string, any> = {}) =>
+    makeFakeDb({
+      conversations: [{ _id: CONV, user_id: "u1", has_pending_messages: true, ...convExtra }],
+      pending_messages: rows.map((r) => ({ conversation_id: CONV, retry_count: 0, ...r })),
+    });
+
+  test("cancels every non-terminal queued message and clears the conversation flag", async () => {
+    const db = mkDb([
+      { _id: "m_pending", status: "pending" },
+      { _id: "m_injected", status: "injected" },
+      { _id: "m_failed", status: "failed" },
+      { _id: "m_undeliverable", status: "undeliverable" },
+      { _id: "m_delivered", status: "delivered" },
+      { _id: "m_cancelled", status: "cancelled" },
+    ]);
+
+    expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(4);
+    const row = (id: string) => db._tables.pending_messages.find((r: any) => r._id === id)!;
+    for (const id of ["m_pending", "m_injected", "m_failed", "m_undeliverable"]) {
+      expect(row(id).status).toBe("cancelled");
+    }
+    expect(row("m_delivered").status).toBe("delivered");
+    expect(db._tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  // The stranded-row repair: a kill whose queue already went terminal still has
+  // to clear the flag, or the row sits "completed + has pending work" forever.
+  test("clears a stale has_pending_messages flag even with nothing left to cancel", async () => {
+    const db = mkDb([{ _id: "m_delivered", status: "delivered" }]);
+    expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(0);
+    expect(db._tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  // Fenced (delivery-protocol v2) rows belong to the execution-binding epoch
+  // machinery — cancelling one here would strand its delivery attempt. Leaving
+  // the flag set is then the HONEST answer (classifyWorkState keeps the killed
+  // row out of the Working bucket regardless).
+  test("leaves fenced rows to the epoch machinery and does not lie about the flag", async () => {
+    const db = mkDb([
+      { _id: "m_fenced", status: "pending", delivery_protocol_version: 2, delivery_status: "pending" },
+    ]);
+    expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(0);
+    expect(db._tables.pending_messages[0].status).toBe("pending");
+    expect(db._tables.conversations[0].has_pending_messages).toBe(true);
   });
 });

--- a/packages/convex/convex/pendingMessages.test.ts
+++ b/packages/convex/convex/pendingMessages.test.ts
@@ -559,16 +559,77 @@ describe("cancelQueuedMessagesOnKill", () => {
     expect(db._tables.conversations[0].has_pending_messages).toBe(false);
   });
 
-  // Fenced (delivery-protocol v2) rows belong to the execution-binding epoch
-  // machinery — cancelling one here would strand its delivery attempt. Leaving
-  // the flag set is then the HONEST answer (classifyWorkState keeps the killed
-  // row out of the Working bucket regardless).
-  test("leaves fenced rows to the epoch machinery and does not lie about the flag", async () => {
+  // A queue deeper than one page must not survive a kill — the cancel drains,
+  // it doesn't sample.
+  test("drains a queue larger than one page", async () => {
+    const many = Array.from({ length: 250 }, (_, i) => ({ _id: `m${i}`, status: "pending" }));
+    const db = mkDb(many);
+    expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(250);
+    expect(db._tables.pending_messages.every((r: any) => r.status === "cancelled")).toBe(true);
+    expect(db._tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  // Fenced (delivery-protocol v2) rows can't be patched to "cancelled" behind
+  // the epoch machinery's back — kill routes them through its sanctioned cancel
+  // instead, so kill is terminal on a fenced conversation too.
+  test("cancels UNSTARTED fenced deliveries through the epoch machinery", async () => {
     const db = mkDb([
       { _id: "m_fenced", status: "pending", delivery_protocol_version: 2, delivery_status: "pending" },
     ]);
+    expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(1);
+    expect(db._tables.pending_messages[0].status).toBe("cancelled");
+    expect(db._tables.pending_messages[0].delivery_status).toBe("cancelled-by-supersession");
+    expect(db._tables.conversations[0].has_pending_messages).toBe(false);
+  });
+
+  // A delivery already landing in the pane is the one thing kill may not
+  // rewrite — only the delivery machinery resolves it. The flag stays true,
+  // which is the honest answer (classifyWorkState keeps the killed row out of
+  // the Working bucket regardless).
+  test("leaves an in-flight fenced delivery alone and does not lie about the flag", async () => {
+    const db = mkDb([
+      { _id: "m_started", status: "pending", delivery_protocol_version: 2, delivery_status: "delivery-started" },
+    ]);
     expect(await cancelQueuedMessagesOnKill({ db } as any, CONV as any)).toBe(0);
     expect(db._tables.pending_messages[0].status).toBe("pending");
+    expect(db._tables.pending_messages[0].delivery_status).toBe("delivery-started");
     expect(db._tables.conversations[0].has_pending_messages).toBe(true);
+  });
+});
+
+// The delivery-side twin of the enqueue wake-up rules: if the system injects a
+// message into a conversation, that conversation is alive whatever its inbox
+// flags say. Without this, a message that outlived a kill runs the session while
+// the row still reads killed — and classifyWorkState now files that as "idle",
+// so the contradiction is invisible.
+describe("delivery revives a killed conversation", () => {
+  const CONV = "c1";
+  const killedDb = () =>
+    makeFakeDb({
+      conversations: [{
+        _id: CONV, user_id: "u1", status: "completed",
+        inbox_killed_at: 111, inbox_dismissed_at: 111, inbox_stashed_at: 111,
+      }],
+      pending_messages: [{ _id: "m1", conversation_id: CONV, status: "pending", retry_count: 0 }],
+    });
+
+  test("an injection clears the kill/dismiss stamps and re-activates the row", async () => {
+    const db = killedDb();
+    await updatePendingMessageStatusForDaemon({ db } as any, "m1" as any, "u1" as any, "dev1", { status: "injected" });
+    const conv = db._tables.conversations[0];
+    expect(conv.inbox_killed_at).toBeUndefined();
+    expect(conv.inbox_dismissed_at).toBeUndefined();
+    expect(conv.status).toBe("active");
+    // Stash survives on purpose: "keep working out of my sight" is exactly what
+    // a delivering-but-hidden session is doing (mirrors enqueue's machine wake).
+    expect(conv.inbox_stashed_at).toBe(111);
+  });
+
+  test("a CANCEL is not a delivery and revives nothing", async () => {
+    const db = killedDb();
+    await cancelQueuedMessagesOnKill({ db } as any, CONV as any);
+    const conv = db._tables.conversations[0];
+    expect(conv.inbox_killed_at).toBe(111);
+    expect(conv.status).toBe("completed");
   });
 });

--- a/packages/convex/convex/pendingMessages.ts
+++ b/packages/convex/convex/pendingMessages.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { verifyApiToken } from "./apiTokens";
 import { Id } from "./_generated/dataModel";
+import { internal } from "./_generated/api";
 import { findConversationByAnyRef, findConversationByAnyRefWhere } from "./conversationSessionLookup";
 import { checkConversationAccess } from "./privacy";
 import { hasGrantedSendAccess } from "./collab";
@@ -137,13 +138,6 @@ async function patchPendingMessageStatus(
   await ctx.db.patch(message._id, patch);
   if (patch.status === "delivered" || patch.status === "cancelled") {
     await clearHasPendingIfQuiet(ctx, message.conversation_id);
-  }
-  // The choke point for every legacy status write, so it's also where DELIVERY
-  // wakes the conversation: a message reaching the pane means the session is
-  // alive whatever its inbox flags say (see reviveConversationOnDelivery). A
-  // cancel/failure obviously must not revive anything.
-  if (patch.status === "injected" || patch.status === "delivered") {
-    await reviveConversationOnDelivery(ctx, message.conversation_id);
   }
   return true;
 }
@@ -319,6 +313,18 @@ export async function updatePendingMessageStatusForDaemon(
     return { updated: false, skipped: true };
   }
   const updated = await patchPendingMessageStatus(ctx, message, patch);
+  // DELIVERY wakes the conversation — but ONLY here, behind the daemon gate.
+  // This must NOT live in patchPendingMessageStatus: the public
+  // updateMessageStatus mutation calls that helper directly when device_id is
+  // omitted, and its authorization (senderOrOwnerCanAct) passes on
+  // message.from_user_id alone — no conversation ownership. A teammate who sent
+  // into my session (or a replay of their client) could then post
+  // status:"injected" and un-retire a session I killed, with nothing delivered.
+  // "injected" is self-reported and reversible (the healer re-pends it), so it
+  // is only evidence of a landing when the DAEMON that owns the session says so.
+  if (updated && (patch.status === "injected" || patch.status === "delivered")) {
+    await reviveConversationOnDelivery(ctx, message.conversation_id);
+  }
   return { updated, skipped: !updated };
 }
 
@@ -851,25 +857,42 @@ export async function resetConversationPendingMessages(
 // everything that hasn't started and leaves a delivery-started/ambiguous effect for the delivery
 // machinery to resolve. Those few stay counted in has_pending_messages, which is the honest
 // answer; classifyWorkState keeps the killed row out of the Working bucket regardless.
+//
+// BUDGETED, because kill must never be the gesture that fails on exactly the sessions it exists
+// for. A runaway session can hold thousands of rows; an unbounded sweep would blow the mutation's
+// write limit and throw. So one transaction cancels at most KILL_CANCEL_BUDGET rows and hands any
+// remainder to a scheduled continuation — the kill itself always lands fast, and the queue still
+// drains to empty. Callers without a scheduler (tests, non-mutation ctx) simply stop at the budget.
+const KILL_CANCEL_BUDGET = 300;
+const KILL_CANCEL_PAGE = 100;
+
 export async function cancelQueuedMessagesOnKill(
-  ctx: { db: any },
+  ctx: { db: any; scheduler?: any },
   conversationId: Id<"conversations">
 ): Promise<number> {
-  const fenced = await cancelFencedDeliveriesOnKill(ctx, conversationId);
-  let cancelled = fenced.cancelled;
-  const PAGE = 200;
+  const conversation = await ctx.db.get(conversationId);
+  let budget = KILL_CANCEL_BUDGET;
+  let cancelled = 0;
+  // Only a FENCED conversation can hold fenced rows, and that sweep is the
+  // expensive one — gate it on the conversation's own marker rather than paying
+  // a scan on every ordinary kill.
+  if (conversation?.execution_protocol_state) {
+    const fenced = await cancelFencedDeliveriesOnKill(ctx, conversationId, Date.now(), budget);
+    cancelled += fenced.cancelled;
+    budget -= fenced.cancelled;
+  }
   for (const status of NON_TERMINAL_PENDING_STATUSES) {
     // DRAIN, don't sample: a queue deeper than one page must not survive a kill.
     // Each pass re-queries the same status because a cancel moves the row out of
     // it; stop as soon as a page cancels nothing, so a row this path may not
     // touch (an in-flight fenced delivery) can't spin the loop forever.
-    for (;;) {
+    while (budget > 0) {
       const rows = await ctx.db
         .query("pending_messages")
         .withIndex("by_conversation_status", (q: any) =>
           q.eq("conversation_id", conversationId).eq("status", status)
         )
-        .take(PAGE);
+        .take(Math.min(KILL_CANCEL_PAGE, budget));
       if (rows.length === 0) break;
       let progressed = 0;
       for (const row of rows) {
@@ -877,13 +900,31 @@ export async function cancelQueuedMessagesOnKill(
       }
       if (progressed === 0) break;
       cancelled += progressed;
+      budget -= progressed;
     }
   }
   // Also the repair for an ALREADY-stranded row: a kill whose queue has since gone terminal
   // (undeliverable → cancelled here, or nothing left at all) still clears the stale flag.
   await clearHasPendingIfQuiet(ctx, conversationId);
+  // Spent the whole budget → there may be more. Finish it in its own transaction;
+  // a continuation that finds nothing left simply stops.
+  if (budget <= 0 && ctx.scheduler) {
+    await ctx.scheduler.runAfter(0, internal.pendingMessages.continueKillCancellation, {
+      conversation_id: conversationId,
+    });
+  }
   return cancelled;
 }
+
+// Overflow continuation for cancelQueuedMessagesOnKill — one budgeted pass per run,
+// re-scheduling itself (from inside the same helper) while rows remain.
+export const continueKillCancellation = internalMutation({
+  args: { conversation_id: v.id("conversations") },
+  handler: async (ctx, args) => {
+    const cancelled = await cancelQueuedMessagesOnKill(ctx as any, args.conversation_id);
+    return { cancelled };
+  },
+});
 
 // Clear a conversation's has_pending_messages flag once nothing is still in flight — no
 // `pending` and no `injected` message remains. Every terminal transition (delivered, cancelled)

--- a/packages/convex/convex/pendingMessages.ts
+++ b/packages/convex/convex/pendingMessages.ts
@@ -9,12 +9,13 @@ import { hasGrantedSendAccess } from "./collab";
 import { addSessionOwnerRow, listSessionOwnerIds, syncPrimaryOwnerCache } from "./sessionOwners";
 import { requireUser } from "./lib/auth";
 import { runLocalCommand } from "./localFirstCommands";
-import { insertEnqueuedPendingMessage } from "./pendingMessageWrites";
+import { insertEnqueuedPendingMessage, reviveConversationOnDelivery } from "./pendingMessageWrites";
 import {
   messagesCommandCoverageTarget,
 } from "./messageViewContracts";
 import {
   allocateFencedDeliveryMetadata,
+  cancelFencedDeliveriesOnKill,
   isFencedPendingMessage,
   legacyConversationAcceptsDaemonWork,
 } from "./executionBindings";
@@ -136,6 +137,13 @@ async function patchPendingMessageStatus(
   await ctx.db.patch(message._id, patch);
   if (patch.status === "delivered" || patch.status === "cancelled") {
     await clearHasPendingIfQuiet(ctx, message.conversation_id);
+  }
+  // The choke point for every legacy status write, so it's also where DELIVERY
+  // wakes the conversation: a message reaching the pane means the session is
+  // alive whatever its inbox flags say (see reviveConversationOnDelivery). A
+  // cancel/failure obviously must not revive anything.
+  if (patch.status === "injected" || patch.status === "delivered") {
+    await reviveConversationOnDelivery(ctx, message.conversation_id);
   }
   return true;
 }
@@ -837,25 +845,38 @@ export async function resetConversationPendingMessages(
 // touched — a LATER send re-enqueues and revives the session normally, because enqueue clears the
 // dismissed/stashed/killed flags (see the wake-up rules above).
 //
-// Fenced (delivery-protocol v2) rows are deliberately left alone: their cancellation is governed
-// by the execution-binding epoch machinery (supersession, delivery-attempt invariants), and
-// patchPendingMessageStatus already refuses them. clearHasPendingIfQuiet therefore leaves the flag
-// set when one is genuinely still in flight — an honest flag, and classifyWorkState no longer
-// reads a killed row as "working" regardless.
+// Fenced (delivery-protocol v2) rows can't be patched to "cancelled" from here — that would
+// strand their delivery_attempts row and the execution head's active slot — so they go through
+// the epoch machinery's sanctioned cancel (cancelFencedDeliveriesOnKill), which terminalizes
+// everything that hasn't started and leaves a delivery-started/ambiguous effect for the delivery
+// machinery to resolve. Those few stay counted in has_pending_messages, which is the honest
+// answer; classifyWorkState keeps the killed row out of the Working bucket regardless.
 export async function cancelQueuedMessagesOnKill(
   ctx: { db: any },
   conversationId: Id<"conversations">
 ): Promise<number> {
-  let cancelled = 0;
+  const fenced = await cancelFencedDeliveriesOnKill(ctx, conversationId);
+  let cancelled = fenced.cancelled;
+  const PAGE = 200;
   for (const status of NON_TERMINAL_PENDING_STATUSES) {
-    const rows = await ctx.db
-      .query("pending_messages")
-      .withIndex("by_conversation_status", (q: any) =>
-        q.eq("conversation_id", conversationId).eq("status", status)
-      )
-      .take(200);
-    for (const row of rows) {
-      if (await patchPendingMessageStatus(ctx, row, { status: "cancelled" as const })) cancelled++;
+    // DRAIN, don't sample: a queue deeper than one page must not survive a kill.
+    // Each pass re-queries the same status because a cancel moves the row out of
+    // it; stop as soon as a page cancels nothing, so a row this path may not
+    // touch (an in-flight fenced delivery) can't spin the loop forever.
+    for (;;) {
+      const rows = await ctx.db
+        .query("pending_messages")
+        .withIndex("by_conversation_status", (q: any) =>
+          q.eq("conversation_id", conversationId).eq("status", status)
+        )
+        .take(PAGE);
+      if (rows.length === 0) break;
+      let progressed = 0;
+      for (const row of rows) {
+        if (await patchPendingMessageStatus(ctx, row, { status: "cancelled" as const })) progressed++;
+      }
+      if (progressed === 0) break;
+      cancelled += progressed;
     }
   }
   // Also the repair for an ALREADY-stranded row: a kill whose queue has since gone terminal

--- a/packages/convex/convex/pendingMessages.ts
+++ b/packages/convex/convex/pendingMessages.ts
@@ -825,6 +825,45 @@ export async function resetConversationPendingMessages(
   return resetCount;
 }
 
+// Kill is TERMINAL for messages already queued. The retry loop is otherwise indefinite, so a
+// message queued before a kill kept retrying afterwards and could still land — reviving a
+// conversation that carries kill metadata (observed live: a killed session woke up and ran 193
+// more messages while still stamped inbox_killed_at), or, once its retries were exhausted,
+// stranding the row as status "completed" + has_pending_messages true forever.
+//
+// This does NOT violate the cardinal rule (the system never drops a user message on its own):
+// killing a session is the user's own explicit stop gesture, and `cancelled` is exactly the
+// terminal state the per-message cancel button writes. Only messages queued BEFORE the kill are
+// touched — a LATER send re-enqueues and revives the session normally, because enqueue clears the
+// dismissed/stashed/killed flags (see the wake-up rules above).
+//
+// Fenced (delivery-protocol v2) rows are deliberately left alone: their cancellation is governed
+// by the execution-binding epoch machinery (supersession, delivery-attempt invariants), and
+// patchPendingMessageStatus already refuses them. clearHasPendingIfQuiet therefore leaves the flag
+// set when one is genuinely still in flight — an honest flag, and classifyWorkState no longer
+// reads a killed row as "working" regardless.
+export async function cancelQueuedMessagesOnKill(
+  ctx: { db: any },
+  conversationId: Id<"conversations">
+): Promise<number> {
+  let cancelled = 0;
+  for (const status of NON_TERMINAL_PENDING_STATUSES) {
+    const rows = await ctx.db
+      .query("pending_messages")
+      .withIndex("by_conversation_status", (q: any) =>
+        q.eq("conversation_id", conversationId).eq("status", status)
+      )
+      .take(200);
+    for (const row of rows) {
+      if (await patchPendingMessageStatus(ctx, row, { status: "cancelled" as const })) cancelled++;
+    }
+  }
+  // Also the repair for an ALREADY-stranded row: a kill whose queue has since gone terminal
+  // (undeliverable → cancelled here, or nothing left at all) still clears the stale flag.
+  await clearHasPendingIfQuiet(ctx, conversationId);
+  return cancelled;
+}
+
 // Clear a conversation's has_pending_messages flag once nothing is still in flight — no
 // `pending` and no `injected` message remains. Every terminal transition (delivered, cancelled)
 // funnels through here so the flag, and therefore the inbox "Working" bucket, can never drift

--- a/packages/shared/contracts/workState.ts
+++ b/packages/shared/contracts/workState.ts
@@ -6,7 +6,9 @@
 //   - "needs_input": the ball is in the user's court — a finished turn waiting
 //                    to be read, an open question / permission prompt, or a dead
 //                    session with output (matches the web inbox's NEEDS INPUT).
-//   - "idle":        nothing to act on: blank sessions with no messages yet.
+//   - "idle":        nothing to act on: blank sessions with no messages yet, and
+//                    killed sessions (the user already retired them, so no
+//                    stale queued work or revived worker can make them look busy).
 //
 // PURE isomorphic data — safe to import from the Convex runtime, the daemon, and
 // the browser.


### PR DESCRIPTION
Fixes six confirmed defects in the session-teardown lifecycle (pl-260), found and verified live on 2026-08-02/03.

## Defects fixed
- **Resurrection ignored kill state** — heartbeat health-check, delivery resume, and warm pool reconstituted killed/completed conversations. Now gated at the single resume chokepoint on conversation lifecycle; explicit Restart bypasses via `userInitiated`; lookups fail open so a Convex blip can't strand a crashed live session.
- **Re-asserted kill was a no-op** — an explicit kill now always enqueues teardown (`forceKill` through `applyHideTransition`); quiet re-asserted dismiss patches keep their no-re-kill race guard.
- **Resume/kill ownership asymmetry** — no device hosts a pane for a session owned by another live device (dead-owner failover preserved); `kill_session` sweeps physically-local panes by id regardless of recorded owner before deferring to the owner device.
- **Un-reapable wedged panes** — transcripts ending on an unanswered user turn classified "active" forever (~9% of idle panes). Reaper gains a 24h escape hatch (message timestamps, never mtime; AUQ-ordering guard; pending tool_use always blocks), stamped-pane eligibility (stashed/dismissed/killed only; pinned/visible never; unknown fails closed; single-pane sessions only), and per-pass skip-reason logging including zero-reap passes.
- **Kill wasn't terminal for queued messages** — queued messages now cancel on kill (fenced conversations via epoch machinery; 300-row budget with scheduled continuation); persistent anchors keep both schedules and queue (dormancy). Revival paths: explicit send, Restart (clears flags + re-arms kill-canceled triggers), undismiss (resurfaces the card). Delivery-driven revival fires only from the daemon-gated status path.
- **Killed rows displayed "working"** — `inbox_killed_at` outranks stale pending state in the work-state classifier; the dispatch rail refuses to clear kill state except via un-kill-shaped patches (a web pin previously deleted it).

## Review
Two independent adversarial reviewers over the committed diff, then verify passes over the fixups: 25 findings total — 21 fixed, 2 accepted with rationale (twin-card kill semantics; in-flight deliveries completing honestly), 2 deferred and filed (ct-41071 Codex metrics misattribution, ct-41083 web killed-state alignment). The verify pass caught two HIGH defects introduced by the first fixup round (client-writable revive path; unbounded history scan making busy sessions unkillable) — both closed.

## Deploy order (load-bearing)
**Convex first, then the CLI binary.** The daemon's stamped-pane reap gate fails closed (correctly but inert) until `conversations:getConversationLifecycle` is deployed; the resurrection gate works against pre-deploy prod via a status-only fallback scoped to the heartbeat path.

## Verification
- packages/convex: 1143 pass / 0 fail, typecheck clean
- packages/cli: deterministic suite 1774 pass / 0 fail (the four subprocess-spawning test families are load-sensitive and fail identically on untouched main under contention), typecheck clean
- ~150 tests added; each review fix individually mutation-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)