### PR TITLE
Teardown follow-ups: codex subagent kill safety + killed-state alignment

### DIFF
--- a/packages/cli/src/daemon.codex-shared-process.test.ts
+++ b/packages/cli/src/daemon.codex-shared-process.test.ts
@@ -1,0 +1,390 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { sessionProcessOwnership } from "./daemon.js";
+import { planSessionTeardown, shortId } from "./sessionProcessMatcher.js";
+
+// ct-41071, anchored to the incident that produced it: ~/.codex/sessions/2026/08/02.
+//
+// findSessionProcess Strategy A2 discovers a Codex session's process by asking
+// lsof "who holds this rollout open?" — and for a subagent THREAD the answer is
+// its parent TUI, because such a subagent has no process of its own. Observed live
+// that day: 15+ distinct session ids all resolved to pid 55521, each reporting the
+// byte-identical cpu=0.1% mem=265.0MB procs=10, summed into the fleet total once
+// per session.
+//
+// The borrowed pid is CORRECT for reaching the agent (parent and subagent share a
+// terminal, and the subagent's permission prompt renders in the parent's pane) and
+// catastrophic for owning it: destroying that process on a subagent's behalf
+// SIGKILLs the parent TUI and every sibling thread.
+//
+// Fixtures carry the REAL session_meta shapes, copied here so the tests don't
+// depend on those rollouts still existing on disk. Both parent-carrying shapes are
+// modelled, because they have OPPOSITE process semantics and a census of 214 local
+// rollouts found them in nearly equal numbers (28 exec-review vs 31 thread-spawn).
+
+const realHome = process.env.HOME;
+let tmpHome: string;
+let rolloutDir: string;
+
+// The parent TUI. originator "codex-tui" / thread_source "user" — note a root is
+// identified by the ABSENCE of a parent, never by its originator.
+const PARENT = "019fc25f-ea9d-7f22-b8ae-8d232737fc7b";
+
+// In-process subagent THREADS of PARENT — the borrowers. Three collide on the
+// 8-char prefix "019fc262" and two more on "019fc275": real evidence that UUIDv7
+// sibling ids are indistinguishable at the old log width.
+const THREAD_SUBAGENTS = [
+  "019fc262-3cff-7ec0-8a92-9c7097998f9d", // /root/cli_review
+  "019fc262-55d4-7140-8332-e0750c22e6a9", // /root/routing_review
+  "019fc262-7655-7042-82ae-d526436c2ee3", // /root/provenance_audit
+  "019fc270-af22-78b0-a8fa-2eef525bddcf", // /root/dismissal_verify
+  "019fc275-16d1-79a0-bf22-22137ca92a61", // /root/dismissal_verify_fast
+  "019fc275-fcb2-73d1-9db6-771b61a86a93", // /root/clusters_verify
+  "019fc27e-93d7-7923-8354-71f63f9dc7b4", // /root/dismissal_verify_final
+  "019fc288-b7c4-79a3-804a-9e0a4ffbcce4", // /root/dismissal_verify_final3
+];
+
+// `codex exec` review children. These ALSO carry parent_thread_id, which is why
+// parent_thread_id alone is the wrong discriminator — they are spawned as separate
+// OS processes and own their pids. 28 of 59 parent-carrying rollouts in the census
+// have this shape; treating them as borrowers would leave a review process running
+// after the user killed its card.
+const EXEC_SUBAGENTS = [
+  "019f82c1-5826-7fa2-a022-0cf5faf6c8d2",
+  "019f8836-88cc-70f3-8dd7-db0b87cb9d59",
+];
+
+// The ct-41115 control: a genuinely DISTINCT root that the daemon log still matched
+// to another root's pid. Root-to-root collisions are a separate defect; this guard
+// must leave that case completely alone rather than papering over it.
+const ROOT_SIBLING = "019fc268-e3a0-77a2-bf01-18174ce04a9b";
+
+const CLAUDE_SESSION = "5b1c47b3-16c0-42d5-a6d2-82459a01f640";
+
+function metaLine(sessionId: string, payload: Record<string, unknown>): string {
+  return JSON.stringify({
+    type: "session_meta",
+    payload: { id: sessionId, cwd: "/Users/jasonbenn/code/codecast", ...payload },
+  });
+}
+
+function writeRollout(sessionId: string, payload: Record<string, unknown>, stamp = "14-08-13"): string {
+  const p = path.join(rolloutDir, `rollout-2026-08-02T${stamp}-${sessionId}.jsonl`);
+  // readCodexSessionMetaHead reads complete lines until the first non-meta one.
+  fs.writeFileSync(p, metaLine(sessionId, payload) + "\n" +
+    JSON.stringify({ type: "event_msg", payload: { type: "task_started" } }) + "\n");
+  return p;
+}
+
+/** An in-process thread: source.subagent is an OBJECT carrying thread_spawn. */
+function writeThreadSubagent(sessionId: string, agentPath: string): string {
+  return writeRollout(sessionId, {
+    parent_thread_id: PARENT,
+    originator: "codex-tui",
+    thread_source: "subagent",
+    source: {
+      subagent: {
+        thread_spawn: { parent_thread_id: PARENT, depth: 1, agent_path: agentPath, agent_role: null },
+      },
+    },
+  });
+}
+
+/** A `codex exec` child: source.subagent is the bare STRING "review". */
+function writeExecSubagent(sessionId: string): string {
+  return writeRollout(sessionId, {
+    parent_thread_id: PARENT,
+    originator: "codex_exec",
+    thread_source: "subagent",
+    source: { subagent: "review" },
+  });
+}
+
+beforeAll(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-shared-process-"));
+  process.env.HOME = tmpHome;
+  rolloutDir = path.join(tmpHome, ".codex", "sessions", "2026", "08", "02");
+  fs.mkdirSync(rolloutDir, { recursive: true });
+
+  writeRollout(PARENT, { originator: "codex-tui", source: "cli", thread_source: "user" });
+  THREAD_SUBAGENTS.forEach((sid, i) => writeThreadSubagent(sid, `/root/verify_${i}`));
+  EXEC_SUBAGENTS.forEach(writeExecSubagent);
+  writeRollout(ROOT_SIBLING, { originator: "codex_cli_rs", source: "cli" }, "14-18-01");
+
+  const claudeDir = path.join(tmpHome, ".claude", "projects", "-Users-jasonbenn-code-codecast");
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, `${CLAUDE_SESSION}.jsonl`),
+    JSON.stringify({ type: "user", cwd: "/Users/jasonbenn/code/codecast" }) + "\n",
+  );
+});
+
+afterAll(() => {
+  process.env.HOME = realHome;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+describe("sessionProcessOwnership — the incident's own sessions", () => {
+  test("every in-process subagent THREAD of 019fc25f borrows the parent's process", () => {
+    for (const sid of THREAD_SUBAGENTS) {
+      expect(sessionProcessOwnership(sid)).toBe("borrowed");
+    }
+  });
+
+  test("a `codex exec` review child OWNS its process despite having a parent", () => {
+    // The over-fire that parent_thread_id alone would cause. These are separate
+    // OS processes; calling them borrowers means killing a review card silently
+    // leaves the review running.
+    for (const sid of EXEC_SUBAGENTS) {
+      expect(sessionProcessOwnership(sid)).toBe("owned");
+    }
+  });
+
+  test("the parent TUI owns its process", () => {
+    expect(sessionProcessOwnership(PARENT)).toBe("owned");
+  });
+
+  test("a distinct root session owns its process (ct-41115 stays out of scope)", () => {
+    expect(sessionProcessOwnership(ROOT_SIBLING)).toBe("owned");
+  });
+
+  test("a Claude session always owns its process", () => {
+    expect(sessionProcessOwnership(CLAUDE_SESSION)).toBe("owned");
+  });
+
+  test("an id with no file on disk is UNKNOWN, not owned", () => {
+    // "unknown" is what makes the destructive paths fail closed.
+    expect(sessionProcessOwnership("00000000-0000-0000-0000-000000000000")).toBe("unknown");
+  });
+
+  test("a materialized Claude JSONL must not override the Codex rollout", () => {
+    // NEW-1, the regression that silently restored the whole defect.
+    // materializeSession writes a CLAUDE-shaped transcript under a CODEX session
+    // id (clientOwnsSessionStore excludes codex, so its skip never fires), and
+    // findSessionFile searches ~/.claude/projects BEFORE ~/.codex/sessions. A
+    // real subagent therefore resolved as agentType "claude" -> "owned" -> and
+    // was MEMOIZED, so every later kill/dismiss/move reaped the parent, sticky
+    // until daemon restart. Reachable whenever the session id misses the local
+    // conversation cache — a second machine, a move_to_device target (the very
+    // gesture guard #2 exists for), a reset cache, or the startup race.
+    const MAT = "019fc292-0000-7000-8000-00000000000b";
+    writeThreadSubagent(MAT, "/root/materialized");
+    const matDir = path.join(tmpHome, ".claude", "projects", "-Users-jasonbenn-code-codecast");
+    fs.mkdirSync(matDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(matDir, `${MAT}.jsonl`),
+      JSON.stringify({ type: "user", cwd: "/Users/jasonbenn/code/codecast" }) + "\n",
+    );
+
+    expect(sessionProcessOwnership(MAT)).toBe("borrowed");
+    expect(planSessionTeardown(sessionProcessOwnership(MAT))).toEqual({
+      reapPidTree: false,
+      killCachedResumeTmux: false,
+    });
+  });
+
+  test("a rollout whose session_meta is still being written is UNKNOWN, not owned", () => {
+    // The race that matters: session_meta is ~37KB because base_instructions
+    // embeds the system prompt, while Strategy A2 matches on the PATH, which
+    // exists the instant the file is created. A half-written first line parses
+    // to no metadata — collapsing that to "owned" would authorize a SIGKILL
+    // during the exact window the guard exists for.
+    const PARTIAL = "019fc291-0000-7000-8000-00000000000a";
+    const full = metaLine(PARTIAL, {
+      parent_thread_id: PARENT,
+      originator: "codex-tui",
+      source: { subagent: { thread_spawn: { parent_thread_id: PARENT, depth: 1 } } },
+    });
+    const p = path.join(rolloutDir, `rollout-2026-08-02T14-08-13-${PARTIAL}.jsonl`);
+    fs.writeFileSync(p, full.slice(0, Math.floor(full.length / 2))); // truncated mid-line
+    expect(sessionProcessOwnership(PARTIAL)).toBe("unknown");
+
+    // …and once the writer finishes, the real answer must still be reachable —
+    // i.e. the undecided pass must NOT have been memoized.
+    fs.writeFileSync(p, full + "\n" + JSON.stringify({ type: "event_msg", payload: {} }) + "\n");
+    expect(sessionProcessOwnership(PARTIAL)).toBe("borrowed");
+  });
+});
+
+describe("planSessionTeardown — what a kill may destroy", () => {
+  // This is the seam. Both destructive sites (killConversationBackends,
+  // stopLocalSessionBackends) do TWO process-destroying things, and both must be
+  // gated. An earlier revision guarded only reapPidTree and left the cached-resume
+  // tmux kill wide open — resumeSessionCache is keyed by session id but its VALUE
+  // can be the PARENT's tmux, because resolveLiveTmuxTarget fills it via the
+  // borrowed pid. These assertions are what catch that class of miss.
+
+  test("a borrower may destroy NOTHING", () => {
+    const plan = planSessionTeardown("borrowed");
+    expect(plan.reapPidTree).toBe(false);
+    expect(plan.killCachedResumeTmux).toBe(false);
+  });
+
+  test("an UNKNOWN session may destroy nothing either (fails closed)", () => {
+    const plan = planSessionTeardown("unknown");
+    expect(plan.reapPidTree).toBe(false);
+    expect(plan.killCachedResumeTmux).toBe(false);
+  });
+
+  test("an owner may destroy both its pid tree and its cached resume tmux", () => {
+    const plan = planSessionTeardown("owned");
+    expect(plan.reapPidTree).toBe(true);
+    expect(plan.killCachedResumeTmux).toBe(true);
+  });
+
+  test("resuming then killing a subagent card cannot kill the parent's tmux", () => {
+    // The S1 bypass, end to end at the decision level: Resume caches the PARENT's
+    // tmux name under the SUBAGENT's id, then a later kill/dismiss reads it back.
+    for (const sid of THREAD_SUBAGENTS) {
+      expect(planSessionTeardown(sessionProcessOwnership(sid)).killCachedResumeTmux).toBe(false);
+    }
+  });
+
+  test("killing the PARENT still tears everything down", () => {
+    // The over-fire case: cascadeHideToNestedChildren enqueues a per-child
+    // kill_session when a parent is killed, and those children no-op — but the
+    // parent's own kill must still reap the shared process exactly once.
+    const plan = planSessionTeardown(sessionProcessOwnership(PARENT));
+    expect(plan.reapPidTree).toBe(true);
+    expect(plan.killCachedResumeTmux).toBe(true);
+  });
+
+  test("killing a `codex exec` review card still reaps it", () => {
+    for (const sid of EXEC_SUBAGENTS) {
+      expect(planSessionTeardown(sessionProcessOwnership(sid)).reapPidTree).toBe(true);
+    }
+  });
+});
+
+describe("the guards are actually wired into the kill sites", () => {
+  // Structural, on purpose. The previous revision of this file asserted only the
+  // predicate, so a reviewer could DELETE both guards — reintroducing the whole
+  // defect — and every test still passed. killConversationBackends and
+  // stopLocalSessionBackends take no deps object, and dependency-injecting a kill
+  // path purely for test convenience is the riskiest change available here, so
+  // this checks the wiring at the source level instead.
+  //
+  // It is deliberately shallow: it proves each destructive site consults the plan
+  // and reads BOTH of its fields. It cannot prove the branches are correct — the
+  // planSessionTeardown tests above cover the policy, and these cover that the
+  // policy is actually consulted. Together they close the gap that let S1 through,
+  // where the reap was gated and the cached-resume-tmux kill was not.
+  const daemonSrc = fs.readFileSync(path.join(import.meta.dir, "daemon.ts"), "utf-8");
+
+  /** Source with comments stripped. A comment mentioning the flag must never be
+   *  able to satisfy these assertions — "a comment standing in for behavior" is
+   *  the exact failure mode that let the original bypass survive two readings. */
+  function codeOnly(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .split("\n")
+      .map((l) => l.replace(/\/\/.*$/, ""))
+      .join("\n");
+  }
+
+  function bodyOf(signature: string): string {
+    const start = daemonSrc.indexOf(signature);
+    expect(start).toBeGreaterThan(-1);
+    // Up to the next top-level `\nasync function ` / `\nfunction ` declaration.
+    const rest = daemonSrc.slice(start + signature.length);
+    const end = rest.search(/\n(?:async )?function /);
+    return codeOnly(end === -1 ? rest : rest.slice(0, end));
+  }
+
+  for (const sig of [
+    "async function killConversationBackends(",
+    "async function stopLocalSessionBackends(",
+  ]) {
+    const name = sig.replace("async function ", "").replace("(", "");
+
+    test(`${name} gates BOTH destructive actions on the plan`, () => {
+      const body = bodyOf(sig);
+      // Sanity: this really is a destructive site, so the assertions below matter.
+      expect(body).toContain("reapPidTree(");
+      expect(body).toContain("resumeSessionCache.get(");
+
+      expect(body).toContain("planSessionTeardown(");
+      expect(body).toContain("teardownPlan.reapPidTree");
+      // The S1 bypass: the cached resume tmux can be the PARENT's pane name.
+      expect(body).toContain("teardownPlan.killCachedResumeTmux");
+    });
+
+    test(`${name} never kills the cached resume tmux outside a plan-gated branch`, () => {
+      // Token presence alone let a mutation pass that deleted the guard and left
+      // the flag's name in a comment. Tie the flag to the ACTION instead: the
+      // tmux read out of resumeSessionCache must only be killed inside a branch
+      // testing killCachedResumeTmux.
+      //
+      // The variable name is READ FROM THE SOURCE rather than hardcoded. Matching
+      // a literal `cachedTmux` made this vacuous under a plain rename: the loop
+      // found nothing, iterated zero times, and passed while S1 was fully
+      // reintroduced. Binding to whatever `resumeSessionCache.get()` is assigned
+      // to survives renames, and the count assertion below turns "found nothing"
+      // into a failure instead of a pass — an aliased kill drops the count to 0.
+      const body = bodyOf(sig);
+      const binding = body.match(/const (\w+) = resumeSessionCache\.get\(/);
+      expect(binding).not.toBeNull();
+      const cacheVar = binding![1];
+
+      const lines = body.split("\n");
+      const killPattern = new RegExp(`killTmuxSessionAndTree\\(\\s*${cacheVar}\\s*\\)`);
+      let checked = 0;
+      for (let i = 0; i < lines.length; i++) {
+        if (!killPattern.test(lines[i])) continue;
+        checked++;
+        const preceding = lines.slice(Math.max(0, i - 6), i).join("\n");
+        expect(preceding).toContain("killCachedResumeTmux");
+      }
+      // A zero-iteration loop must FAIL, not pass vacuously. Each site kills the
+      // cached tmux exactly once; if that call is gone or reached via an alias,
+      // this is the assertion that catches it.
+      expect(checked).toBe(1);
+    });
+
+    test(`${name} gates on the plan with the correct polarity`, () => {
+      // Catches a wholesale inversion — every borrower destroyed, every owner
+      // spared — which token matching cannot see. The reap must be skipped when
+      // the plan says NOT to reap, and performed when it says to.
+      const body = bodyOf(sig);
+      const skipsWhenDenied = /!teardownPlan\.reapPidTree/.test(body);
+      const actsWhenAllowed = /if \(teardownPlan\.reapPidTree\)/.test(body);
+      expect(skipsWhenDenied || actsWhenAllowed).toBe(true);
+      // …and never both-negated, which would be the inverted form.
+      expect(/if \(!teardownPlan\.reapPidTree\) \{\s*\n\s*const proc = await findSessionProcess/.test(body)).toBe(false);
+    });
+  }
+});
+
+describe("memoization", () => {
+  test("a session whose rollout appears later is re-decided, not cached as owned", () => {
+    const LATE = "019fc290-0000-7000-8000-000000000001";
+    expect(sessionProcessOwnership(LATE)).toBe("unknown");
+    writeThreadSubagent(LATE, "/root/late");
+    expect(sessionProcessOwnership(LATE)).toBe("borrowed");
+  });
+
+  test("a decided answer is memoized (session_meta is immutable once written)", () => {
+    const STABLE = "019fc290-0000-7000-8000-000000000002";
+    const p = writeThreadSubagent(STABLE, "/root/stable");
+    expect(sessionProcessOwnership(STABLE)).toBe("borrowed");
+    fs.rmSync(p);
+    expect(sessionProcessOwnership(STABLE)).toBe("borrowed");
+  });
+});
+
+describe("shortId on the incident's ids", () => {
+  test("disambiguates the three subagents that collide at 8 chars", () => {
+    const colliding = THREAD_SUBAGENTS.filter((s) => s.startsWith("019fc262"));
+    expect(colliding.length).toBe(3);
+    expect(new Set(colliding.map((s) => s.slice(0, 8))).size).toBe(1); // old width: one id
+    expect(new Set(colliding.map(shortId)).size).toBe(3);              // new width: three
+  });
+
+  test("distinguishes the parent from every one of its subagents", () => {
+    for (const sid of THREAD_SUBAGENTS) {
+      expect(shortId(sid)).not.toBe(shortId(PARENT));
+    }
+  });
+});

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -72,7 +72,11 @@ import {
   matchStartedConversation,
   parseLsofPidPaths,
   parsePidPpidMap,
+  planSessionTeardown,
   resolveSpawnerSessionId,
+  classifyProcessOwnership,
+  shortId,
+  type ProcessOwnership,
 } from "./sessionProcessMatcher.js";
 import { parseSessionFile, parseTranscriptFor, extractSlug, extractParentUuid, extractSummaryTitle, extractCwd, extractCodexCwd, extractCodexForkRoot, extractCodexSessionMetadata, isCompletedStandaloneCodexReview, isCompletedNativeCodexReviewChild, extractGeminiProjectHash, extractPiCwd, extractTeamInfo, detectCliFlags, type ParsedMessage } from "./parser.js";
 import { extractMessagesFromCursorDb } from "./cursorProcessor.js";
@@ -2488,7 +2492,36 @@ async function killConversationBackends(
   // client's cached copy of a deleted row) — fall back to it when the local
   // conversation cache has no mapping (remapped or ghost conversations).
   const sessionId = reverse[conversationId] ?? sessionIdHint;
-  if (sessionId && !result) {
+  // A Codex subagent thread has NO process of its own — it runs inside its parent
+  // TUI's process, so findSessionProcess resolves it to the PARENT's pid and tty
+  // (see sessionProcessOwnership). Destroying that on one nested card's behalf
+  // SIGKILLs the parent agent and every sibling thread. Reachable from three user
+  // gestures today, including a plain `cast dismiss`.
+  //
+  // The plan covers BOTH process-destroying actions here, not just the reap.
+  // resumeSessionCache is keyed by session id but its VALUE can be the PARENT's
+  // tmux name: resolveLiveTmuxTarget resolves a subagent through the borrowed pid
+  // to the parent's pane and caches that. So "resume a subagent card, then kill or
+  // dismiss it" would kill the parent's tmux even with the reap guarded. Guarding
+  // only the reap is not enough — see killCachedResumeTmux below.
+  //
+  // Only PROCESS teardown is skipped. Everything else still runs, so the card
+  // retires exactly like any other kill: heartbeats stop, caches clear,
+  // delivery/resume state is wiped, and the caller acks with no error. The honest
+  // residual is that the thread keeps running inside the parent until it finishes
+  // — a subagent genuinely cannot be killed independently of its parent.
+  //
+  // This deliberately no-ops the per-child kill_session that
+  // cascadeHideToNestedChildren enqueues when a PARENT is killed: the parent's own
+  // kill_session reaps the shared process once, so the children have nothing left
+  // to do. Do not "restore" their reaps — they would each re-kill the same
+  // already-dead tree, and the guard is what makes killing a child alone safe. The
+  // parent's own kill is unaffected: it owns its process, so it takes the branch
+  // below and tears its tree down normally.
+  const teardownPlan = planSessionTeardown(sessionId ? sessionProcessOwnership(sessionId) : "owned");
+  if (sessionId && !result && !teardownPlan.reapPidTree) {
+    log(`[REMOTE] Skipping process teardown for ${shortId(sessionId)}: does not own its process (conversation ${conversationId.slice(0, 12)})`);
+  } else if (sessionId && !result) {
     const proc = await findSessionProcess(sessionId, detectSessionAgentType(sessionId));
     if (proc) {
       const tmuxTarget = await findTmuxPaneForTty(proc.tty);
@@ -2512,9 +2545,14 @@ async function killConversationBackends(
 
   if (sessionId) {
     const cachedTmux = resumeSessionCache.get(sessionId);
-    if (cachedTmux && validateTmuxTarget(cachedTmux)) {
+    if (cachedTmux && validateTmuxTarget(cachedTmux) && !teardownPlan.killCachedResumeTmux) {
+      // The cached name is the PARENT's tmux, reached through the borrowed pid.
+      // Forget the mapping without killing anything — the parent owns that pane.
+      resumeSessionCache.delete(sessionId);
+      log(`[REMOTE] Dropped cached resume tmux ${cachedTmux} for ${shortId(sessionId)} without killing it (session does not own that pane)`);
+    } else if (cachedTmux && validateTmuxTarget(cachedTmux)) {
       await killTmuxSessionAndTree(cachedTmux);
-      log(`[REMOTE] Killed cached resume tmux ${cachedTmux} (+process tree) for session ${sessionId.slice(0, 8)}`);
+      log(`[REMOTE] Killed cached resume tmux ${cachedTmux} (+process tree) for session ${shortId(sessionId)}`);
       resumeSessionCache.delete(sessionId);
       if (!result) result = "killed_tmux";
     }
@@ -5088,6 +5126,75 @@ function resolveCodexForkRoot(filePath: string): string | undefined {
   }
   codexForkRootCache.set(filePath, root);
   return root;
+}
+
+// Does this session OWN the process that findSessionProcess resolves for it?
+//
+// "borrowed" for a Codex subagent THREAD, which has no process of its own: it runs
+// inside the parent TUI's process, and the parent is what holds the subagent's
+// rollout open — precisely what Strategy A2 matches on, so the lookup returns the
+// PARENT's pid and tty.
+//
+// That answer is CORRECT for reaching the agent (they share a terminal, and the
+// subagent's permission prompt renders in the parent's pane), so the injection
+// paths deliberately do not consult this. It is wrong for the two things that
+// treat a pid as property: attributing the subtree to the subagent double-counts
+// it in fleet metrics, and reaping the tree on its behalf SIGKILLs the parent TUI
+// and every sibling thread.
+//
+// Three-valued on purpose. "unknown" is not "owned": a rollout can exist on disk
+// with its leading session_meta only PARTIALLY written — that record is ~37KB
+// because base_instructions embeds the whole system prompt, while Strategy A2
+// matches on the path, which exists the instant the file is created. Reading it
+// mid-write yields no metadata, and collapsing that to "owned" would authorize a
+// SIGKILL during the exact race the guard exists for. Callers choose the safe
+// direction for their side: destructive paths fail closed, metrics fail open.
+//
+// Memoized only once DECIDED. The leading session_meta is immutable after it is
+// fully written (same reasoning as codexForkRootCache), so a decided answer never
+// changes; an undecided one must not be cached or the race becomes permanent.
+// Note the cost asymmetry this leaves: an undecidable id re-walks findSessionFile
+// on every call (~3.5ms), which is deliberate — correctness over a cached guess.
+const sessionOwnershipCache = new Map<string, ProcessOwnership>();
+export function sessionProcessOwnership(sessionId: string): ProcessOwnership {
+  const memo = sessionOwnershipCache.get(sessionId);
+  if (memo !== undefined) return memo;
+
+  // Ask the Codex rollout store DIRECTLY. Routing this through findSessionFile
+  // was a live hole: that helper searches ~/.claude/projects first, and
+  // materializeSession writes a CLAUDE-shaped JSONL under a Codex session id
+  // (clientOwnsSessionStore excludes codex, so its regeneration skip never fires).
+  // A materialized Codex subagent therefore resolved as agentType "claude" →
+  // "owned" → memoized, silently restoring the full SIGKILL-the-parent defect and
+  // keeping it until daemon restart. The rollout is the authority on what a Codex
+  // session is; a materialized mirror is a copy, and must never answer this.
+  const rolloutPath = findCodexRolloutPath(sessionId);
+  if (!rolloutPath) {
+    // No rollout: either a genuinely non-Codex session (only Codex threads can
+    // borrow, so it owns its process) or an id we know nothing about yet.
+    if (!findSessionFile(sessionId)) return "unknown";
+    sessionOwnershipCache.set(sessionId, "owned");
+    return "owned";
+  }
+
+  let meta: ReturnType<typeof extractCodexSessionMetadata>;
+  try {
+    meta = extractCodexSessionMetadata(readCodexSessionMetaHead(rolloutPath));
+  } catch {
+    return "unknown"; // unreadable this pass
+  }
+  if (!meta) return "unknown"; // file exists but session_meta isn't complete yet
+  const ownership = classifyProcessOwnership(meta);
+  if (ownership === "unknown") return "unknown"; // an unrecognized shape may change meaning; don't cache
+  sessionOwnershipCache.set(sessionId, ownership);
+  return ownership;
+}
+
+/** Metrics fail OPEN: only a session we positively know to be a borrower is
+ *  denied credit for its subtree. An undecided session keeps reporting — the
+ *  worst case is a transiently double-counted tree, not a lost signal. */
+function sessionBorrowsProcess(sessionId: string): boolean {
+  return sessionProcessOwnership(sessionId) === "borrowed";
 }
 
 // ── Agent-team "spawned by" linking ──────────────────────────────────────────
@@ -8012,7 +8119,7 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
   // Check process cache first
   const cached = await getCachedSessionProcess(sessionId);
   if (cached) {
-    log(`Process cache hit for session ${sessionId.slice(0, 8)}: pid=${cached.pid}`);
+    log(`Process cache hit for session ${shortId(sessionId)}: pid=${cached.pid}`);
     return cached;
   }
 
@@ -8032,11 +8139,11 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
         const { stdout: checkPs } = await execAsync(`ps -o comm= -p ${pid} 2>/dev/null`);
         if (checkPs.trim()) {
           if (agentType === "codex") {
-            log(`Ignoring registry candidate for codex session ${sessionId.slice(0, 8)} (pid=${pid})`);
+            log(`Ignoring registry candidate for codex session ${shortId(sessionId)} (pid=${pid})`);
           } else {
           const result = { pid, tty, sessionId, termProgram };
           cacheSessionProcess(sessionId, result);
-          log(`Found session ${sessionId.slice(0, 8)} via registry: pid=${pid}, tty=${tty}, term=${termProgram ?? "unknown"}`);
+          log(`Found session ${shortId(sessionId)} via registry: pid=${pid}, tty=${tty}, term=${termProgram ?? "unknown"}`);
           return result;
           }
         } else {
@@ -8068,7 +8175,7 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
           }
           const result = { pid, tty: normalizedTty, sessionId };
           cacheSessionProcess(sessionId, result);
-          log(`Found session ${sessionId.slice(0, 8)} via resume process match: pid=${pid}`);
+          log(`Found session ${shortId(sessionId)} via resume process match: pid=${pid}`);
           return result;
         }
         if (agentType === "gemini") {
@@ -8081,7 +8188,7 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
           const only = geminiCandidates[0];
           const result = { pid: only.pid, tty: only.tty, sessionId };
           cacheSessionProcess(sessionId, result);
-          log(`Found Gemini session ${sessionId.slice(0, 8)} via single process candidate: pid=${only.pid}`);
+          log(`Found Gemini session ${shortId(sessionId)} via single process candidate: pid=${only.pid}`);
           return result;
         }
 
@@ -8100,14 +8207,14 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
         if (newest) {
           const result = { pid: newest.pid, tty: newest.tty, sessionId };
           cacheSessionProcess(sessionId, result);
-          log(`Found Gemini session ${sessionId.slice(0, 8)} via newest process heuristic: pid=${newest.pid}`);
+          log(`Found Gemini session ${shortId(sessionId)} via newest process heuristic: pid=${newest.pid}`);
           return result;
         }
 
         const fallback = geminiCandidates[0];
         const result = { pid: fallback.pid, tty: fallback.tty, sessionId };
         cacheSessionProcess(sessionId, result);
-        log(`Found Gemini session ${sessionId.slice(0, 8)} via fallback process candidate: pid=${fallback.pid}`);
+        log(`Found Gemini session ${shortId(sessionId)} via fallback process candidate: pid=${fallback.pid}`);
         return result;
       }
     } catch {}
@@ -8144,9 +8251,9 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
           const result = { pid: preferred.pid, tty: preferred.tty, sessionId };
           cacheSessionProcess(sessionId, result, preferred.tmuxTarget || undefined);
           if (preferred.tmuxTarget) {
-            log(`Found codex session ${sessionId.slice(0, 8)} via lsof session file match (tmux): pid=${preferred.pid}`);
+            log(`Found codex session ${shortId(sessionId)} via lsof session file match (tmux): pid=${preferred.pid}`);
           } else {
-            log(`Found codex session ${sessionId.slice(0, 8)} via lsof session file match (non-tmux preferred): pid=${preferred.pid}`);
+            log(`Found codex session ${shortId(sessionId)} via lsof session file match (non-tmux preferred): pid=${preferred.pid}`);
           }
           return result;
         }
@@ -8155,7 +8262,7 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
           const candidate = codexResumeCandidates[0];
           const result = { pid: candidate.pid, tty: candidate.tty, sessionId };
           cacheSessionProcess(sessionId, result);
-          log(`Found codex session ${sessionId.slice(0, 8)} via resume process fallback: pid=${candidate.pid}`);
+          log(`Found codex session ${shortId(sessionId)} via resume process fallback: pid=${candidate.pid}`);
           return result;
         }
       } catch {}
@@ -8180,14 +8287,14 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
                 if (!isNaN(childPid)) {
                   const result = { pid: childPid, tty: normalizeTty(paneTty), sessionId };
                   cacheSessionProcess(sessionId, result, `${tmuxName}:0.0`);
-                  log(`Found session ${sessionId.slice(0, 8)} via tmux session ${tmuxName}: pid=${childPid}`);
+                  log(`Found session ${shortId(sessionId)} via tmux session ${tmuxName}: pid=${childPid}`);
                   return result;
                 }
                 // No agent child process found - check if pane shell itself is an agent
                 if (isAgentProcess(panePid)) {
                   const result = { pid: panePid, tty: normalizeTty(paneTty), sessionId };
                   cacheSessionProcess(sessionId, result, `${tmuxName}:0.0`);
-                  log(`Found session ${sessionId.slice(0, 8)} via tmux session ${tmuxName}: pid=${panePid} (direct)`);
+                  log(`Found session ${shortId(sessionId)} via tmux session ${tmuxName}: pid=${panePid} (direct)`);
                   return result;
                 }
                 log(`Tmux session ${tmuxName} has no active agent (shell pid=${panePid}), skipping`);
@@ -8248,7 +8355,7 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
             if (unclaimed.length === 1) {
               const result = { pid: unclaimed[0].pid, tty: unclaimed[0].tty, sessionId };
               cacheSessionProcess(sessionId, result);
-              log(`Found session ${sessionId.slice(0, 8)} via CWD match: pid=${unclaimed[0].pid}, cwd=${projectCwd}`);
+              log(`Found session ${shortId(sessionId)} via CWD match: pid=${unclaimed[0].pid}, cwd=${projectCwd}`);
               return result;
             } else if (unclaimed.length > 1) {
               // Disambiguate using JSONL birth time vs process start time
@@ -8271,12 +8378,12 @@ async function findSessionProcessImpl(sessionId: string, agentType: AgentClientI
               if (bestCandidate && bestDelta < 300_000) {
                 const result = { pid: bestCandidate.pid, tty: bestCandidate.tty, sessionId };
                 cacheSessionProcess(sessionId, result);
-                log(`Found session ${sessionId.slice(0, 8)} via CWD+timing match: pid=${bestCandidate.pid}, delta=${Math.round(bestDelta / 1000)}s`);
+                log(`Found session ${shortId(sessionId)} via CWD+timing match: pid=${bestCandidate.pid}, delta=${Math.round(bestDelta / 1000)}s`);
                 return result;
               }
-              log(`CWD match found ${unclaimed.length} unclaimed candidates for ${sessionId.slice(0, 8)}, could not disambiguate`);
+              log(`CWD match found ${unclaimed.length} unclaimed candidates for ${shortId(sessionId)}, could not disambiguate`);
             } else {
-              log(`CWD match found ${candidates.length} candidates for ${sessionId.slice(0, 8)} but all claimed by other sessions`);
+              log(`CWD match found ${candidates.length} candidates for ${shortId(sessionId)} but all claimed by other sessions`);
             }
           } catch {}
         }
@@ -10495,6 +10602,39 @@ async function injectViaTerminal(
 
 type SessionFileInfo = { path: string; agentType: AgentClientId };
 
+/** The Codex rollout for a session id, if one exists:
+ *  ~/.codex/sessions/YYYY/MM/DD/<name>-<timestamp>-<sessionId>.jsonl
+ *
+ *  Separate from findSessionFile because the rollout is the AUTHORITY on whether
+ *  a session is a Codex thread, while findSessionFile answers a different
+ *  question — "which transcript should I read?" — and searches ~/.claude/projects
+ *  first. Those diverge whenever materializeSession has written a Claude-shaped
+ *  mirror under a Codex session id (it does: clientOwnsSessionStore excludes
+ *  codex, so the regeneration skip never fires for it). See
+ *  sessionProcessOwnership, which must never be answered by the mirror. */
+function findCodexRolloutPath(sessionId: string): string | null {
+  const codexSessionsDir = path.join(process.env.HOME || "", ".codex", "sessions");
+  if (!fs.existsSync(codexSessionsDir)) return null;
+  try {
+    const findCodex = (dir: string): string | null => {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          const found = findCodex(fullPath);
+          if (found) return found;
+        } else if (entry.isFile() && entry.name.endsWith(".jsonl") && entry.name.includes(sessionId)) {
+          return fullPath;
+        }
+      }
+      return null;
+    };
+    return findCodex(codexSessionsDir);
+  } catch {
+    return null;
+  }
+}
+
 function findSessionJsonlPath(sessionId: string): string | null {
   return findSessionFile(sessionId)?.path ?? null;
 }
@@ -10535,27 +10675,8 @@ export function findSessionFile(sessionId: string): SessionFileInfo | null {
     }
   }
 
-  // Codex sessions: ~/.codex/sessions/YYYY/MM/DD/<name>-<timestamp>-<sessionId>.jsonl
-  const codexSessionsDir = path.join(process.env.HOME || "", ".codex", "sessions");
-  if (fs.existsSync(codexSessionsDir)) {
-    try {
-      const findCodex = (dir: string): string | null => {
-        const entries = fs.readdirSync(dir, { withFileTypes: true });
-        for (const entry of entries) {
-          const fullPath = path.join(dir, entry.name);
-          if (entry.isDirectory()) {
-            const found = findCodex(fullPath);
-            if (found) return found;
-          } else if (entry.isFile() && entry.name.endsWith(".jsonl") && entry.name.includes(sessionId)) {
-            return fullPath;
-          }
-        }
-        return null;
-      };
-      const codexPath = findCodex(codexSessionsDir);
-      if (codexPath) return { path: codexPath, agentType: "codex" };
-    } catch {}
-  }
+  const codexPath = findCodexRolloutPath(sessionId);
+  if (codexPath) return { path: codexPath, agentType: "codex" };
 
   // Gemini sessions: ~/.gemini/tmp/<hash>/chats/<sessionId>.json
   const geminiTmpDir = path.join(process.env.HOME || "", ".gemini", "tmp");
@@ -10807,19 +10928,36 @@ function teardownConversationBackendsLive(
 async function stopLocalSessionBackends(conversationId: string, sessionId: string | undefined): Promise<void> {
   await teardownConversationBackendsLive(conversationId, { interruptActiveTurn: true }).catch(() => {});
   if (!sessionId) return;
+  // Same borrowed-pid hazard as killConversationBackends, and the same TWO unsafe
+  // actions: reaping the resolved pid tree, and killing the tmux in
+  // resumeSessionCache. Both can belong to the PARENT — the cache is keyed by
+  // session id, but resolveLiveTmuxTarget fills it by resolving a subagent through
+  // the borrowed pid to the parent's PANE, so the value is the parent's tmux name.
+  // The session id being ours says nothing about who owns what it points at.
+  // This is what keeps move_to_device / release_session from stranding a user's
+  // running parent TUI. The tmux-name sweep further down is genuinely safe
+  // unguarded: it matches names derived from THIS session's id, which a parent's
+  // tmux never carries.
+  const teardownPlan = planSessionTeardown(sessionProcessOwnership(sessionId));
   try {
-    const proc = await findSessionProcess(sessionId, detectSessionAgentType(sessionId));
-    if (proc) {
-      const tmuxTarget = await findTmuxPaneForTty(proc.tty);
-      if (tmuxTarget && validateTmuxTarget(tmuxTarget)) {
-        await killTmuxSessionAndTree(tmuxTarget.split(":")[0]).catch(() => {});
+    if (teardownPlan.reapPidTree) {
+      const proc = await findSessionProcess(sessionId, detectSessionAgentType(sessionId));
+      if (proc) {
+        const tmuxTarget = await findTmuxPaneForTty(proc.tty);
+        if (tmuxTarget && validateTmuxTarget(tmuxTarget)) {
+          await killTmuxSessionAndTree(tmuxTarget.split(":")[0]).catch(() => {});
+        }
+        await reapPidTree(proc.pid).catch(() => 0);
       }
-      await reapPidTree(proc.pid).catch(() => 0);
     }
   } catch { /* best-effort */ }
   const cachedTmux = resumeSessionCache.get(sessionId);
   if (cachedTmux && validateTmuxTarget(cachedTmux)) {
-    await killTmuxSessionAndTree(cachedTmux).catch(() => {});
+    if (teardownPlan.killCachedResumeTmux) {
+      await killTmuxSessionAndTree(cachedTmux).catch(() => {});
+    } else {
+      log(`Dropped cached resume tmux ${cachedTmux} for ${shortId(sessionId)} without killing it (session does not own that pane)`);
+    }
     resumeSessionCache.delete(sessionId);
   }
   stopManagedSessionHeartbeat(sessionId);
@@ -12767,12 +12905,19 @@ async function collectResourceSnapshot(): Promise<void> {
   if (sessionProcessCache.size === 0) return;
 
   const sessionPids = new Map<string, number>();
+  // Sessions whose cached pid is borrowed rather than owned (a Codex subagent
+  // thread shares its parent's process): they must not be credited with a subtree
+  // that isn't theirs, or the parent's usage lands in the fleet total once per
+  // child. Fails OPEN — an undecided session keeps reporting, since the cost is a
+  // transiently double-counted tree rather than a lost liveness signal.
+  const sharedPidSessions = new Set<string>();
   for (const [sessionId, info] of sessionProcessCache) {
     sessionPids.set(sessionId, info.pid);
+    if (sessionBorrowsProcess(sessionId)) sharedPidSessions.add(sessionId);
   }
 
   try {
-    const resources = await collectSessionResources(sessionPids);
+    const resources = await collectSessionResources(sessionPids, sharedPidSessions);
     latestSessionResources.clear();
     for (const [sessionId, r] of resources) {
       latestSessionResources.set(sessionId, r);
@@ -12792,6 +12937,11 @@ async function collectResourceSnapshot(): Promise<void> {
         status: lastSentAgentStatus.get(sessionId),
         elapsedMs: elapsed,
         sleepSkip,
+        // Never accrue idle time on a cpu=0 we zeroed ourselves — see
+        // nextAwakeIdleMs. Before the dedupe a borrower inherited the parent's
+        // real CPU, so a busy parent kept resetting this; now nothing would, and
+        // the row would drift into the Sessions page's bulk-kill bucket.
+        sharesRootPid: r.sharesRootPid,
       }));
     }
     // Drop counters for sessions whose process tree is gone (no longer collected).

--- a/packages/cli/src/formatter.test.ts
+++ b/packages/cli/src/formatter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { formatMonitor } from "./formatter";
+
+// The `cast sessions` SNAPSHOT renderer. The watch stream already handled kills
+// correctly (a killed row emits `gone`, not a transition), but the snapshot did
+// not: classifyWorkState collapses a retired row to "idle" — kill outranks every
+// other signal — so a killed session printed as an ordinary idle one, with its
+// tmux and process possibly still alive. These pin the killed marker's rendering.
+
+// Colors are on whenever stdout is a TTY, which differs between a local run and
+// CI, so assert on the text with escapes stripped.
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+function session(overrides: Record<string, any> = {}) {
+  return {
+    id: "conversations_abc123",
+    session_id: "sess-1",
+    title: "Ship the thing",
+    project_path: "/Users/x/code/proj",
+    updated_at: new Date().toISOString(),
+    message_count: 12,
+    agent_type: "claude",
+    work_state: "idle",
+    is_pinned: false,
+    is_live: false,
+    awaiting_input: false,
+    idle_summary: null,
+    last_user_message: null,
+    active_plan: null,
+    active_task: null,
+    ...overrides,
+  };
+}
+
+function result(sessions: any[], counts: Record<string, number> = {}) {
+  return {
+    sessions,
+    counts: {
+      working: 0, needs_input: 0, idle: sessions.length, pinned: 0, live: 0,
+      total: sessions.length, ...counts,
+    } as any,
+    scope: "you",
+  };
+}
+
+describe("formatMonitor renders the killed marker", () => {
+  test("a killed row is badged `killed`", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true })]), { all: true }));
+    expect(out).toContain("killed");
+    expect(out).toContain("Ship the thing");
+  });
+
+  test("an ordinary idle row is NOT badged killed", () => {
+    const out = strip(formatMonitor(result([session()]), { all: true }));
+    expect(out).not.toContain("killed");
+  });
+
+  // The regression proper: kill collapses work_state to "idle", so the badge is
+  // the ONLY thing distinguishing a retired session from a live-but-quiet one.
+  // Without the marker these two rows render identically.
+  test("killed and ordinary idle rows do not render identically", () => {
+    const killedOut = strip(formatMonitor(result([session({ is_killed: true })]), { all: true }));
+    const idleOut = strip(formatMonitor(result([session()]), { all: true }));
+    expect(killedOut).not.toBe(idleOut);
+  });
+
+  // A killed row stays pinned-visible; both tags must show, not one replacing
+  // the other — pinned is why it is still listed, killed is what it is.
+  test("a killed AND pinned row shows both tags", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true, is_pinned: true })]), { all: true }));
+    expect(out).toContain("killed");
+    expect(out).toContain("pinned");
+  });
+
+  test("the killed tag rides the state badge line, next to the work state", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true })]), { all: true }));
+    const badgeLine = out.split("\n").find((l) => l.includes("Ship the thing"))!;
+    expect(badgeLine).toMatch(/idle\s+killed/);
+  });
+});
+
+// Where the badge actually shows. A killed row classifies as idle
+// (classifyWorkState gives kill precedence), and the DEFAULT view renders only
+// NEEDS INPUT + WORKING, collapsing idle to a "+ N idle" line — so plain
+// `cast sessions` shows no card for a killed session at all, pinned or not.
+// That is intended (a killed row IS idle, and idle rows collapse), but the
+// feature is narrower than "the snapshot badges killed rows" suggests, so it
+// gets pinned here rather than left for the next reader to discover.
+describe("formatMonitor default view collapses killed rows", () => {
+  test("plain `cast sessions` renders no card for a killed row", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true })])));
+    expect(out).not.toContain("Ship the thing");
+    expect(out).toContain("+ 1 idle");
+  });
+
+  // Pinning changes sort order, not grouping — it does not add a group.
+  test("pinning a killed row does not surface it in the default view", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true, is_pinned: true })])));
+    expect(out).not.toContain("Ship the thing");
+    expect(out).not.toContain("killed");
+  });
+
+  test("-a reveals the row and its killed badge", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true })]), { all: true }));
+    expect(out).toContain("Ship the thing");
+    expect(out).toContain("killed");
+  });
+
+  test("--state idle also reveals it", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true })]), { state: "idle" }));
+    expect(out).toContain("killed");
+  });
+
+  // The summary line is the ONLY killed signal in the default view.
+  test("the summary still reports the killed count in the default view", () => {
+    const out = strip(formatMonitor(result([session({ is_killed: true })], { killed: 1 })));
+    expect(out.split("\n")[1]).toContain("killed 1");
+  });
+});
+
+// The summary line reported stashed and dismissed as ONE `dismissed` figure,
+// which hid how many agents were still running: stashed keeps the agent ALIVE,
+// dismissed does not. Killed is a third state again, distinct from both.
+describe("formatMonitor reports the three retirement states separately", () => {
+  const summaryOf = (counts: Record<string, number>) =>
+    strip(formatMonitor(result([], counts))).split("\n")[1];
+
+  test("stashed is reported under its own name, not folded into dismissed", () => {
+    const line = summaryOf({ stashed: 4, dismissed: 7 });
+    expect(line).toContain("stashed 4");
+    expect(line).toContain("dismissed 7");
+  });
+
+  test("killed is reported separately from dismissed", () => {
+    const line = summaryOf({ dismissed: 7, killed: 1 });
+    expect(line).toContain("killed 1");
+    expect(line).toContain("dismissed 7");
+  });
+
+  test("all three appear together when all three are nonzero", () => {
+    const line = summaryOf({ stashed: 4, dismissed: 7, killed: 1 });
+    expect(line).toMatch(/stashed 4.*dismissed 7.*killed 1/);
+  });
+
+  // Zero-valued states stay off the line — the summary only names what exists.
+  test("a state with no rows is omitted", () => {
+    const line = summaryOf({ dismissed: 7 });
+    expect(line).toContain("dismissed 7");
+    expect(line).not.toContain("stashed");
+    expect(line).not.toContain("killed");
+  });
+});

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -220,16 +220,29 @@ function colorForState(ws: string): string {
 }
 
 // Compact one-token status badge: a liveness dot (● live / ○ not live), the
-// work-state word, the raw agent_status when it adds detail, and a pinned tag.
-function formatStateBadge(s: { work_state?: string; is_live?: boolean; is_pinned?: boolean; agent_status?: string }): string {
+// work-state word, the raw agent_status when it adds detail, and killed/pinned
+// tags. The killed tag is not cosmetic: classifyWorkState collapses a retired
+// row to "idle" (kill outranks every other signal), so without it a killed
+// session is indistinguishable from an ordinary idle one — while its tmux and
+// process may still be alive. Both surfaces that render this badge ship
+// is_killed from the server (inboxForCLI and the feed).
+//
+// WHERE IT ACTUALLY SHOWS, so nobody expects more than it does: because a
+// killed row classifies as idle, the DEFAULT `cast sessions` view (NEEDS INPUT
+// + WORKING only, idle collapsed to a "+ N idle" line) renders no card for it
+// at all. The tag appears under -a, --state idle/pinned, and --by-label. Pinning
+// affects sort order, not grouping, so a pinned killed row is still collapsed in
+// the default view. formatter.test.ts pins this rather than the docs alone.
+function formatStateBadge(s: { work_state?: string; is_live?: boolean; is_pinned?: boolean; is_killed?: boolean; agent_status?: string }): string {
   const ws = s.work_state || "idle";
   const liveGlyph = s.is_live ? `${c.green}●${c.reset}` : `${c.gray}○${c.reset}`;
   const label = WORK_STATE_LABEL[ws] ?? ws;
   const detail = s.is_live && s.agent_status && s.agent_status !== ws && WORK_STATE_LABEL[s.agent_status] === undefined
     ? `${c.dim}:${s.agent_status}${c.reset}`
     : "";
+  const kill = s.is_killed ? ` ${c.red}killed${c.reset}` : "";
   const pin = s.is_pinned ? ` ${c.magenta}pinned${c.reset}` : "";
-  return `${liveGlyph} ${colorForState(ws)}${label}${c.reset}${detail}${pin}`;
+  return `${liveGlyph} ${colorForState(ws)}${label}${c.reset}${detail}${kill}${pin}`;
 }
 
 function wrapText(text: string, indent: string, maxWidth: number = 72): string {
@@ -853,6 +866,9 @@ interface MonitorSession {
   agent_type?: string;
   agent_status?: string;
   work_state: string;
+  /** Retired (inbox_killed_at). Shipped by inboxForCLI; the watch stream reads
+   * it to emit a kill as a departure, and the snapshot badges it. */
+  is_killed?: boolean;
   is_pinned: boolean;
   is_live: boolean;
   awaiting_input: boolean;
@@ -869,7 +885,10 @@ interface MonitorSession {
 
 interface MonitorResult {
   sessions: MonitorSession[];
-  counts: { working: number; needs_input: number; idle: number; pinned: number; live: number; dismissed?: number; total: number };
+  // stashed / dismissed / killed are three distinct retirement states, not one
+  // "hidden" figure: stashed = hidden but agent ALIVE, dismissed = hidden and
+  // agent torn down, killed = retired (outranks both, so they never double-count).
+  counts: { working: number; needs_input: number; idle: number; pinned: number; live: number; stashed?: number; dismissed?: number; killed?: number; total: number };
   labels?: Array<{ name: string; count: number }>;
   scope: string;
 }
@@ -941,7 +960,24 @@ export function formatMonitor(result: MonitorResult, options: MonitorOptions = {
   const extra: string[] = [];
   if (counts.pinned) extra.push(`${c.magenta}pinned ${counts.pinned}${c.reset}`);
   if (counts.live) extra.push(`${c.green}live ${counts.live}${c.reset}`);
+  // Stashed keeps an agent ALIVE while dismissed does not, so merging them into
+  // one figure hid how many processes were still running. All three are TALLIES
+  // like `pinned` and `live` above — NOT a partition of the work-state buckets
+  // to their left. A row carries at most one retirement state (classifyRetirement
+  // picks one), but a LISTED one is also in its work_state figure and in
+  // `total`: a pinned killed session shows up in `idle 1 (pinned 1, killed 1)`.
+  // That is the intended reading of this line, not double-counting.
+  //
+  // EXPECTED, not a bug: this `stashed` figure and the web's Stashed group count
+  // different SETS for a stashed-then-killed row. The web tracks a bucket plus an
+  // orthogonal killed flag, so that row stays in its Stashed group; here killed
+  // wins the single tally, so it lands in `killed` instead. Both are right for
+  // their surface, and this one is the more useful answer where they differ —
+  // `stashed` advertises "agents still running", and a killed agent isn't one.
+  // See classifyRetirement (convex/inboxFilters.ts) for the full scope.
+  if (counts.stashed) extra.push(`${c.dim}stashed ${counts.stashed}${c.reset}`);
   if (counts.dismissed) extra.push(`${c.dim}dismissed ${counts.dismissed}${c.reset}`);
+  if (counts.killed) extra.push(`${c.red}killed ${counts.killed}${c.reset}`);
   lines.push(
     summary.join(`  ${c.dim}·${c.reset}  `) +
     (extra.length ? `   ${c.dim}(${extra.join(", ")})${c.reset}` : "")

--- a/packages/cli/src/parser.ts
+++ b/packages/cli/src/parser.ts
@@ -786,11 +786,22 @@ export function extractCodexSessionId(content: string): string | undefined {
   return undefined;
 }
 
+/** A Codex subagent spawned IN-PROCESS as a thread of its parent TUI. The nested
+ *  `thread_spawn` object is what distinguishes it from a `codex exec` child, which
+ *  is a separate OS process and writes `subagent: "review"` (a bare string). Only
+ *  the thread shape shares its parent's pid — see classifyProcessOwnership. */
+export interface CodexThreadSpawn {
+  parent_thread_id?: string;
+  depth?: number;
+  agent_path?: string;
+  agent_nickname?: string;
+}
+
 export interface CodexSessionMetadata {
   id?: string;
   parentThreadId?: string;
   originator?: string;
-  source?: string | { subagent?: string; custom?: string };
+  source?: string | { subagent?: string | { thread_spawn?: CodexThreadSpawn }; custom?: string };
 }
 
 export function extractCodexSessionMetadata(content: string): CodexSessionMetadata | undefined {

--- a/packages/cli/src/resourceMonitor.test.ts
+++ b/packages/cli/src/resourceMonitor.test.ts
@@ -11,6 +11,7 @@ import {
   IDLE_METRICS_REFRESH_MS,
   type ProcessInfo,
   type ReportedMetrics,
+  type SessionResources,
 } from "./resourceMonitor.js";
 
 describe("resourceMonitor", () => {
@@ -103,7 +104,7 @@ describe("resourceMonitor", () => {
       const sessionPids = new Map<string, number>([
         ["test-session-self", process.pid],
       ]);
-      const result = await collectSessionResources(sessionPids);
+      const result = await collectSessionResources(sessionPids, new Set());
       expect(result.size).toBe(1);
       const r = result.get("test-session-self")!;
       expect(r.sessionId).toBe("test-session-self");
@@ -117,8 +118,100 @@ describe("resourceMonitor", () => {
       const sessionPids = new Map<string, number>([
         ["dead-session", 999999999],
       ]);
-      const result = await collectSessionResources(sessionPids);
+      const result = await collectSessionResources(sessionPids, new Set());
       expect(result.size).toBe(0);
+    });
+
+    // Real Codex ids from ~/.codex/sessions/2026/08/02: UUIDv7, so a parent and
+    // the subagents it spawns share the leading millisecond timestamp.
+    const PARENT = "019fb73a-a85c-7d31-b0a2-3f9c5e2d8a41";
+    const SUBAGENT = "019fb73a-a740-7c02-9e11-6b4d0a7f3c88";
+
+    it("credits a shared root pid to exactly one session", async () => {
+      if (process.platform !== "darwin") return;
+      // The live defect: 15 distinct Codex session ids all resolved to pid 55521
+      // and each reported the SAME subtree, summed 15x into the fleet total.
+      const sessionPids = new Map<string, number>([
+        [PARENT, process.pid],
+        [SUBAGENT, process.pid],
+      ]);
+      const result = await collectSessionResources(sessionPids, new Set());
+
+      expect(result.size).toBe(2);
+      const credited = [...result.values()].filter((r) => r.pidCount > 0);
+      expect(credited.length).toBe(1);
+      // Lexicographically smallest wins, so the winner does not depend on the
+      // caller's (unstable) map iteration order.
+      expect(credited[0].sessionId).toBe(SUBAGENT);
+      const loser = result.get(PARENT)!;
+      expect(loser.sharesRootPid).toBe(true);
+      expect(loser.cpu).toBe(0);
+      expect(loser.memory).toBe(0);
+      expect(loser.pidCount).toBe(0);
+    });
+
+    it("never credits a session that shares another's process, even when it sorts first", async () => {
+      if (process.platform !== "darwin") return;
+      // SUBAGENT sorts BEFORE parent, so it would win the tie-break — being a
+      // known borrower must override that entirely.
+      const sessionPids = new Map<string, number>([
+        [SUBAGENT, process.pid],
+        [PARENT, process.pid],
+      ]);
+      const result = await collectSessionResources(sessionPids, new Set([SUBAGENT]));
+
+      const parent = result.get(PARENT)!;
+      expect(parent.pidCount).toBeGreaterThanOrEqual(1);
+      expect(parent.memory).toBeGreaterThan(0);
+      expect(parent.sharesRootPid).toBeUndefined();
+
+      const sub = result.get(SUBAGENT)!;
+      expect(sub.sharesRootPid).toBe(true);
+      expect(sub.cpu).toBe(0);
+      expect(sub.memory).toBe(0);
+      expect(sub.pidCount).toBe(0);
+    });
+
+    it("leaves a subtree uncounted when every claimant is a borrower", async () => {
+      if (process.platform !== "darwin") return;
+      // Two subagents of a parent that isn't tracked: nobody owns the tree, so
+      // nobody is credited. Uncounted beats attributed to the wrong session.
+      const sessionPids = new Map<string, number>([
+        [SUBAGENT, process.pid],
+        [PARENT, process.pid],
+      ]);
+      const result = await collectSessionResources(sessionPids, new Set([SUBAGENT, PARENT]));
+      expect([...result.values()].every((r) => r.sharesRootPid === true && r.pidCount === 0)).toBe(true);
+    });
+
+    it("picks the same winner regardless of insertion order", async () => {
+      if (process.platform !== "darwin") return;
+      // The process cache is evicted and refilled between ticks. If the winner
+      // followed iteration order, the credited session would alternate and both
+      // sessions' graphs would flicker.
+      const forward = await collectSessionResources(
+        new Map([[PARENT, process.pid], [SUBAGENT, process.pid]]), new Set(),
+      );
+      const reverse = await collectSessionResources(
+        new Map([[SUBAGENT, process.pid], [PARENT, process.pid]]), new Set(),
+      );
+      const winner = (m: Map<string, SessionResources>) =>
+        [...m.values()].find((r) => r.pidCount > 0)!.sessionId;
+      expect(winner(forward)).toBe(winner(reverse));
+    });
+
+    // CONTROL (passes pre-fix by construction): guards against the dedupe
+    // OVER-firing and starving ordinary, non-colliding sessions of metrics.
+    it("still counts distinct root pids independently", async () => {
+      if (process.platform !== "darwin") return;
+      const sessionPids = new Map<string, number>([
+        [PARENT, process.pid],
+        [SUBAGENT, process.ppid],
+      ]);
+      const result = await collectSessionResources(sessionPids, new Set());
+      expect([...result.values()].every((r) => !r.sharesRootPid)).toBe(true);
+      expect(result.get(PARENT)!.pidCount).toBeGreaterThanOrEqual(1);
+      expect(result.get(SUBAGENT)!.pidCount).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -140,6 +233,38 @@ describe("resourceMonitor", () => {
     it("resets to 0 on a working status even at near-zero CPU (blocked on a tool/network call)", () => {
       const idle = nextAwakeIdleMs({ prevIdleMs: 5 * TICK, cpu: 0.0, status: "working", elapsedMs: TICK, sleepSkip: false });
       expect(idle).toBe(0);
+    });
+
+    it("does NOT accrue idle time on a cpu=0 we zeroed ourselves", () => {
+      // A shared-root-pid row reports cpu=0 because its subtree was credited to
+      // the session that OWNS the pid. Accruing on that fiction would march the
+      // counter toward the Sessions page's 2h "idle" bucket, which feeds the bulk
+      // "Kill all" selection — manufacturing a kill candidate from our own zero.
+      // Pre-dedupe a borrower inherited the parent's real CPU, so a busy parent
+      // kept resetting it; nothing would now.
+      const banked = 90 * 60 * 1000;
+      const after = nextAwakeIdleMs({
+        prevIdleMs: banked, cpu: 0, status: undefined, elapsedMs: TICK,
+        sleepSkip: false, sharesRootPid: true,
+      });
+      expect(after).toBe(banked);
+    });
+
+    it("a borrower that is actually WORKING still resets to 0", () => {
+      // Order matters: the activity test runs before the carry-forward, so a
+      // stale total can't survive on a session the agent says is working.
+      const after = nextAwakeIdleMs({
+        prevIdleMs: 90 * 60 * 1000, cpu: 0, status: "working", elapsedMs: TICK,
+        sleepSkip: false, sharesRootPid: true,
+      });
+      expect(after).toBe(0);
+    });
+
+    it("an ordinary session still accrues normally (sharesRootPid absent)", () => {
+      const after = nextAwakeIdleMs({
+        prevIdleMs: TICK, cpu: 0, status: "idle", elapsedMs: TICK, sleepSkip: false,
+      });
+      expect(after).toBe(2 * TICK);
     });
 
     it("does NOT count a sleep gap as idle (laptop closed for 2h)", () => {
@@ -178,6 +303,26 @@ describe("resourceMonitor", () => {
       expect(result).toContain("cpu=15.5%");
       expect(result).toContain("mem=100.0MB");
       expect(result).toContain("procs=5");
+    });
+
+    it("distinguishes a Codex parent from its subagent (UUIDv7 prefixes collide)", () => {
+      // Both ids start "019fb73a" — the shared UUIDv7 millisecond timestamp — so
+      // an 8-char log prefix rendered a parent and its subagent as the same
+      // session, which is exactly what made the live misattribution unreadable.
+      const parent = "019fb73a-a85c-7d31-b0a2-3f9c5e2d8a41";
+      const subagent = "019fb73a-a740-7c02-9e11-6b4d0a7f3c88";
+      const result = formatResourcesLog(new Map([
+        [parent, { sessionId: parent, cpu: 12, memory: 104857600, pidCount: 10, collectedAt: 1 }],
+        [subagent, { sessionId: subagent, cpu: 0, memory: 0, pidCount: 0, collectedAt: 1, sharesRootPid: true }],
+      ]));
+
+      expect(result).toContain("019fb73a-a85c");
+      expect(result).toContain("019fb73a-a740");
+      // The two rendered ids must actually differ — the whole point.
+      const ids = [...result.matchAll(/019fb73a-[0-9a-f]+/g)].map((m) => m[0]);
+      expect(new Set(ids).size).toBe(2);
+      // And the borrower is reported as not counted, not as a real 0% session.
+      expect(result).toContain("shares another session's pid (not counted)");
     });
   });
 

--- a/packages/cli/src/resourceMonitor.ts
+++ b/packages/cli/src/resourceMonitor.ts
@@ -1,4 +1,5 @@
 import { execFile } from "./proc.js";
+import { shortId } from "./sessionProcessMatcher.js";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
@@ -16,6 +17,11 @@ export interface SessionResources {
   memory: number;
   pidCount: number;
   collectedAt: number;
+  /** This session's root pid belongs to ANOTHER session, which was credited with
+   *  the subtree instead. cpu/memory/pidCount are zero so a fleet total counts
+   *  each process tree exactly once; the session still reports, so it keeps a
+   *  liveness signal rather than going dark. */
+  sharesRootPid?: boolean;
 }
 
 // Below this CPU% (and not in a working status) a tick counts as idle.
@@ -76,6 +82,14 @@ export function shouldReportMetrics(args: {
  * oversized gap from suspend/stall) carries the previous value forward unchanged,
  * so a closed-lid period never inflates idle time. Any sign of activity — CPU at
  * or above the floor, or a working status — resets the counter to 0.
+ *
+ * `sharesRootPid` is the same carry-forward, for a different lie: that session's
+ * cpu is 0 because its subtree was credited to the session that OWNS the pid, not
+ * because it is idle. Accruing on it would march the counter past the threshold
+ * the Sessions page buckets as "idle" and offers up to bulk kill — a kill
+ * candidate manufactured from a number we zeroed ourselves. Checked AFTER the
+ * activity test on purpose: a borrower whose agent_status says it's working must
+ * still reset to 0 rather than carry a stale total forward.
  */
 export function nextAwakeIdleMs(params: {
   prevIdleMs: number;
@@ -83,9 +97,10 @@ export function nextAwakeIdleMs(params: {
   status: string | undefined;
   elapsedMs: number;
   sleepSkip: boolean;
+  sharesRootPid?: boolean;
 }): number {
   if (isSessionActive(params.cpu, params.status)) return 0;
-  if (params.sleepSkip) return params.prevIdleMs;
+  if (params.sharesRootPid || params.sleepSkip) return params.prevIdleMs;
   return params.prevIdleMs + params.elapsedMs;
 }
 
@@ -161,18 +176,58 @@ export function getSubtreeResources(
   return { cpu: Math.round(cpu * 100) / 100, memory, pidCount };
 }
 
+/**
+ * Per-session resource usage, with each process tree credited EXACTLY ONCE.
+ *
+ * Two sessions can map to the same root pid. A Codex subagent thread shares its
+ * parent TUI's process by design, and process discovery can also collide two
+ * unrelated roots. Walking the subtree per session with no collision awareness
+ * reported the same tree N times — observed live on 2026-08-02, 15 distinct Codex
+ * session ids all resolved to pid 55521 and each reported the byte-identical
+ * cpu=0.1% mem=265.0MB procs=10, summed 15x into the fleet total.
+ *
+ * `sharedPidSessions` names sessions already KNOWN not to own their root pid
+ * (see the daemon's sessionProcessOwnership); they are never credited, so the
+ * tree goes to the real owner. If no owner is tracked, the tree is simply not
+ * counted — better uncounted than attributed to a session that doesn't own it.
+ *
+ * Among sessions with equal claim, the lexicographically smallest id wins. That
+ * tie-break is deliberate: iteration order follows the caller's process cache,
+ * which is evicted and refilled between ticks, so ordering by it would hand the
+ * subtree to a different session on alternating ticks and make both sessions'
+ * graphs flicker.
+ */
 export async function collectSessionResources(
   sessionPids: Map<string, number>,
+  sharedPidSessions: ReadonlySet<string>,
 ): Promise<Map<string, SessionResources>> {
   if (process.platform !== "darwin") return new Map();
 
   const snapshot = await captureProcessSnapshot();
   if (snapshot.size === 0) return new Map();
 
+  const ownerByRootPid = new Map<number, string>();
+  for (const [sessionId, rootPid] of sessionPids) {
+    if (sharedPidSessions.has(sessionId)) continue;
+    const incumbent = ownerByRootPid.get(rootPid);
+    if (incumbent === undefined || sessionId < incumbent) ownerByRootPid.set(rootPid, sessionId);
+  }
+
   const result = new Map<string, SessionResources>();
   const now = Date.now();
   for (const [sessionId, rootPid] of sessionPids) {
     if (!snapshot.has(rootPid)) continue;
+    if (ownerByRootPid.get(rootPid) !== sessionId) {
+      result.set(sessionId, {
+        sessionId,
+        cpu: 0,
+        memory: 0,
+        pidCount: 0,
+        collectedAt: now,
+        sharesRootPid: true,
+      });
+      continue;
+    }
     const resources = getSubtreeResources(snapshot, rootPid);
     if (resources.pidCount === 0) continue;
     result.set(sessionId, {
@@ -188,8 +243,12 @@ export function formatResourcesLog(resources: Map<string, SessionResources>): st
   if (resources.size === 0) return "No active sessions with resource data";
   const lines: string[] = [];
   for (const [sessionId, r] of resources) {
+    if (r.sharesRootPid) {
+      lines.push(`${shortId(sessionId)}: shares another session's pid (not counted)`);
+      continue;
+    }
     const memMB = (r.memory / (1024 * 1024)).toFixed(1);
-    lines.push(`${sessionId.slice(0, 8)}: cpu=${r.cpu}% mem=${memMB}MB procs=${r.pidCount}`);
+    lines.push(`${shortId(sessionId)}: cpu=${r.cpu}% mem=${memMB}MB procs=${r.pidCount}`);
   }
   return `Resource snapshot (${resources.size} sessions): ${lines.join(", ")}`;
 }

--- a/packages/cli/src/sessionProcessMatcher.test.ts
+++ b/packages/cli/src/sessionProcessMatcher.test.ts
@@ -9,7 +9,10 @@ import {
   matchStartedConversation,
   parseLsofPidPaths,
   parsePidPpidMap,
+  planSessionTeardown,
   resolveSpawnerSessionId,
+  classifyProcessOwnership,
+  shortId,
 } from "./sessionProcessMatcher.js";
 
 describe("isRecognizedAgentComm", () => {
@@ -109,6 +112,114 @@ describe("isResumeInvocation", () => {
       { pid: 22222, tty: "/dev/ttys011", tmuxTarget: "cx-resume-b:0.0" },
     ]);
     expect(chosen?.pid).toBe(11111);
+  });
+
+  test("an lsof match alone does NOT mean the process is the session's own", () => {
+    // The parent TUI appends its subagent's rollout, so it holds BOTH files open.
+    // hasCodexSessionFileOpen says yes to both ids for the same pid — which is why
+    // ownership needs a second question rather than a stricter fd rule (a parent
+    // with live subagents legitimately holds several rollouts open).
+    const lsofOutput = [
+      "codex 55521 jason 20w REG ... /Users/jason/.codex/sessions/2026/08/02/rollout-2026-08-02T09-15-01-019fb73a-a85c-7d31-b0a2-3f9c5e2d8a41.jsonl",
+      "codex 55521 jason 21w REG ... /Users/jason/.codex/sessions/2026/08/02/rollout-2026-08-02T09-15-01-019fb73a-a740-7c02-9e11-6b4d0a7f3c88.jsonl",
+    ].join("\n");
+    expect(hasCodexSessionFileOpen(lsofOutput, "019fb73a-a85c-7d31-b0a2-3f9c5e2d8a41")).toBe(true);
+    expect(hasCodexSessionFileOpen(lsofOutput, "019fb73a-a740-7c02-9e11-6b4d0a7f3c88")).toBe(true);
+  });
+});
+
+describe("classifyProcessOwnership", () => {
+  const PARENT = "019fc25f-ea9d-7f22-b8ae-8d232737fc7b";
+
+  test("an in-process subagent THREAD borrows its parent's process", () => {
+    // source.subagent is an OBJECT carrying thread_spawn — the only shape that
+    // actually runs inside the parent TUI's process.
+    expect(classifyProcessOwnership({
+      parentThreadId: PARENT,
+      source: { subagent: { thread_spawn: { parent_thread_id: PARENT, depth: 1 } } },
+    })).toBe("borrowed");
+  });
+
+  test("thread_spawn alone is enough — the top-level parent id is redundant", () => {
+    // thread_spawn.parent_thread_id carries the same value in all 31 real
+    // rollouts, so requiring BOTH created a fail-open direction: drop the
+    // top-level field and a genuine borrower read as "owned".
+    expect(classifyProcessOwnership({
+      source: { subagent: { thread_spawn: { parent_thread_id: PARENT } } },
+    })).toBe("borrowed");
+  });
+
+  test("a `codex exec` review child OWNS its process, despite carrying a parent", () => {
+    // The over-fire that `parent_thread_id` alone would cause. A census of 214
+    // local rollouts found 28 of these against 31 thread_spawn — nearly half of
+    // all parent-carrying sessions. They are separate OS processes (originator
+    // codex_exec, spawned via another session's Bash tool), so calling them
+    // borrowers would leave a review running after the user killed its card.
+    expect(classifyProcessOwnership({
+      parentThreadId: PARENT,
+      originator: "codex_exec",
+      source: { subagent: "review" },
+    })).toBe("owned");
+  });
+
+  test("a root session owns its own process", () => {
+    // 019fc268 is a distinct root (originator codex_cli_rs, no parent) that the
+    // daemon still matched to another root's pid. Root-to-root collisions are a
+    // separate defect; this classifier must not paper over them.
+    expect(classifyProcessOwnership({ originator: "codex_cli_rs", source: "cli" })).toBe("owned");
+    expect(classifyProcessOwnership({ source: "exec" })).toBe("owned");
+    expect(classifyProcessOwnership({})).toBe("owned");
+    expect(classifyProcessOwnership(undefined)).toBe("owned");
+  });
+
+  test("a parent with an UNRECOGNIZED shape is unknown, never owned", () => {
+    // Fails CLOSED. Every unrecognized shape that resolved to "owned" re-opened
+    // the SIGKILL hole; "unknown" costs only a card that retires without reaping,
+    // since planSessionTeardown treats unknown and borrowed identically.
+    expect(classifyProcessOwnership({ parentThreadId: PARENT })).toBe("unknown");
+    expect(classifyProcessOwnership({ parentThreadId: PARENT, source: { custom: "x" } })).toBe("unknown");
+    // A renamed/unseen nesting under subagent — e.g. a future Codex spawn kind.
+    expect(classifyProcessOwnership({
+      parentThreadId: PARENT,
+      source: { subagent: { process_spawn: { parent_thread_id: PARENT } } },
+    })).toBe("unknown");
+  });
+});
+
+describe("planSessionTeardown", () => {
+  // The seam. Both destructive sites do TWO process-destroying things — reap the
+  // resolved pid tree, and kill the tmux recorded in resumeSessionCache. An
+  // earlier revision guarded only the reap, leaving the cached-tmux kill as a live
+  // bypass: that cache is keyed by session id but its VALUE can be the PARENT's
+  // tmux, since resolveLiveTmuxTarget fills it through the borrowed pid.
+
+  test("a borrower may destroy nothing", () => {
+    expect(planSessionTeardown("borrowed")).toEqual({ reapPidTree: false, killCachedResumeTmux: false });
+  });
+
+  test("unknown ownership fails CLOSED", () => {
+    // An unreadable or half-written rollout must never authorize a SIGKILL.
+    expect(planSessionTeardown("unknown")).toEqual({ reapPidTree: false, killCachedResumeTmux: false });
+  });
+
+  test("an owner may destroy both", () => {
+    expect(planSessionTeardown("owned")).toEqual({ reapPidTree: true, killCachedResumeTmux: true });
+  });
+});
+
+describe("shortId", () => {
+  test("distinguishes a Codex parent from a subagent spawned in the same millisecond", () => {
+    // UUIDv7: the first 48 bits are a ms timestamp, so a parent and the subagents
+    // it spawns collide on 8 chars BY CONSTRUCTION. These two are 150ms apart.
+    const parent = "019fb73a-a740-7c02-9e11-6b4d0a7f3c88";
+    const subagent = "019fb73a-a85c-7d31-b0a2-3f9c5e2d8a41";
+    expect(parent.slice(0, 8)).toBe(subagent.slice(0, 8)); // the old prefix: identical
+    expect(shortId(parent)).not.toBe(shortId(subagent));
+    expect(shortId(parent)).toBe("019fb73a-a740");
+  });
+
+  test("leaves ids shorter than the cutoff intact", () => {
+    expect(shortId("abc")).toBe("abc");
   });
 });
 

--- a/packages/cli/src/sessionProcessMatcher.ts
+++ b/packages/cli/src/sessionProcessMatcher.ts
@@ -74,6 +74,116 @@ export function choosePreferredCodexCandidate(
   return candidates.find((c) => !c.tmuxTarget) || candidates[0];
 }
 
+// ── Borrowed pids: a session that does not own the process we resolve for it ──
+// hasCodexSessionFileOpen above asks only "does this process hold session X's
+// rollout open?" — never "does it hold ONLY X?". For a Codex subagent THREAD the
+// honest answer is that no process is exclusively its own: it runs INSIDE its
+// parent TUI's process, and the parent is what holds its rollout open. So the
+// lookup returns the PARENT's pid.
+//
+// That pid is the right answer for REACHING the agent — parent and subagent share
+// a terminal, and the subagent's permission prompt renders in the parent's pane —
+// and the wrong answer for OWNING it. Callers that attribute resources or destroy
+// processes must ask this first; callers that only inject keystrokes must not.
+//
+// CRITICAL: `parent_thread_id` alone is the WRONG discriminator. A census of 214
+// local rollouts found two different parent-carrying shapes, and they have
+// opposite process semantics:
+//
+//   28  originator=codex_exec  source={"subagent":"review"}          ← own process
+//   31  originator=codex-tui   source={"subagent":{"thread_spawn"…}} ← shared
+//
+// `codex exec` review children are spawned by another session's Bash tool as a
+// separate OS process (see the daemon's own note where it nests them under their
+// spawner). They own their pid, so treating them as borrowers would silently
+// leave a review running after the user killed its card — an over-fire on nearly
+// half of all parent-carrying sessions. Key POSITIVELY on the in-process shape:
+// a nested `thread_spawn` object, never the mere presence of a parent.
+// `originator` is deliberately NOT the discriminator even though it correlates:
+// the census found thread_spawn under BOTH "codex-tui" (27) and "codecast" (4),
+// so a new front-end shipping a third originator would silently be misclassified.
+// The structural shape is the invariant; the originator is branding.
+//
+// Returns "unknown", not "owned", for a session that clearly has a parent but
+// whose shape we do not recognize. That direction matters: every unrecognized
+// shape that resolves to "owned" re-opens the SIGKILL hole, while "unknown" costs
+// only a card that retires without reaping (planSessionTeardown treats the two
+// identically). A renamed `thread_spawn` key, or a future nesting we've never
+// seen, must not be read as permission to destroy a process.
+export function classifyProcessOwnership(
+  meta: { parentThreadId?: string; originator?: string; source?: unknown } | undefined,
+): ProcessOwnership {
+  const source = meta?.source;
+  const subagent =
+    source && typeof source === "object" ? (source as { subagent?: unknown }).subagent : undefined;
+
+  if (subagent !== undefined && subagent !== null) {
+    // An OBJECT carrying thread_spawn is the in-process thread — the borrower.
+    // Checked without requiring the top-level parent_thread_id, which is
+    // redundant (thread_spawn.parent_thread_id carries the same value in all 31
+    // real rollouts) and whose absence must not downgrade this to "owned".
+    if (typeof subagent === "object") {
+      return (subagent as { thread_spawn?: unknown }).thread_spawn !== undefined
+        ? "borrowed"
+        : "unknown"; // an object shape we don't recognize — fail closed
+    }
+    // A bare string ("review") is the `codex exec` child: a separate OS process
+    // spawned via another session's Bash tool, so it owns its pid.
+    if (typeof subagent === "string") return "owned";
+    return "unknown";
+  }
+
+  // No subagent marker at all. A parent id with nothing to explain it is a shape
+  // we can't classify; anything else is a plain root session.
+  return meta?.parentThreadId ? "unknown" : "owned";
+}
+
+// ── What a teardown may touch for a given session ───────────────────────────
+// Both destructive call sites (killConversationBackends, stopLocalSessionBackends)
+// do TWO process-destroying things: reap the resolved pid tree, and kill the tmux
+// cached in resumeSessionCache. Both are unsafe for a borrower, and for the same
+// reason — resumeSessionCache is keyed by session id but its VALUE can be the
+// PARENT's tmux name, because resolveLiveTmuxTarget resolves a subagent through
+// the borrowed pid to the parent's pane and caches that. Guarding only the reap
+// leaves the tmux kill as a live bypass that SIGKILLs the parent anyway.
+//
+// Expressed as one pure decision so both sites branch identically and a test can
+// assert the policy without dependency-injecting a kill path.
+export type ProcessOwnership = "owned" | "borrowed" | "unknown";
+
+export interface SessionTeardownPlan {
+  /** May we SIGKILL the resolved pid and its descendants? */
+  reapPidTree: boolean;
+  /** May we kill the tmux recorded in resumeSessionCache for this session? */
+  killCachedResumeTmux: boolean;
+}
+
+/** Destructive teardown fails CLOSED: only a session we positively know owns its
+ *  process may have it destroyed. "unknown" (an unreadable or half-written
+ *  rollout) must not authorize a SIGKILL — the cost of skipping is a card that
+ *  retires without reaping, the cost of guessing wrong is a dead parent TUI. */
+export function planSessionTeardown(ownership: ProcessOwnership): SessionTeardownPlan {
+  const owned = ownership === "owned";
+  return { reapPidTree: owned, killCachedResumeTmux: owned };
+}
+
+// ── Session ids in logs ──────────────────────────────────────────────────────
+// Codex mints session ids as UUIDv7, whose leading 48 bits are a millisecond
+// timestamp. A parent TUI and the subagents it spawns are minted inside the same
+// timestamp window BY CONSTRUCTION, so they collide on an 8-char prefix
+// systematically — observed live: 019fb73a-a740-… and 019fb73a-a85c-…, 150ms
+// apart, are both "019fb73a". Truncating logs there collapsed a parent and its
+// subagents into one indistinguishable id in exactly the lines you need to
+// untangle a misattribution. Print through the second group so the
+// sub-millisecond bits survive.
+const LOG_SESSION_ID_LEN = 13;
+
+/** A session id truncated for log lines, short enough to skim and long enough
+ *  to tell a Codex parent apart from its subagents. */
+export function shortId(sessionId: string): string {
+  return sessionId.slice(0, LOG_SESSION_ID_LEN);
+}
+
 export function matchStartedConversation(
   entries: Iterable<[string, StartedSessionEntry]>,
   {

--- a/packages/convex/convex/conversations.listRecent.test.ts
+++ b/packages/convex/convex/conversations.listRecent.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { makeFakeDb } from "./testDb";
+import { performListRecentSessions } from "./conversations";
+
+// The command palette builds its list from TWO row sources: favorites carry
+// whole store rows (so inbox_killed_at arrives) while recents come from this
+// projection. Omitting the marker here left it permanently undefined on half
+// the palette's rows, so killed-awareness silently could not work for them —
+// the same class of gap as /sessions dropping killed rows entirely.
+
+const USER = "u".repeat(31) + "a";
+
+function fixtures(convs: Array<Record<string, any>>) {
+  return makeFakeDb({
+    users: [{ _id: USER, name: "Jason" }],
+    conversations: convs.map((c) => ({
+      user_id: USER,
+      status: "active",
+      updated_at: Date.now(),
+      ...c,
+    })),
+  });
+}
+
+describe("listRecentSessions projects the killed marker", () => {
+  test("a killed session carries inbox_killed_at", async () => {
+    const db = fixtures([
+      { _id: "conv_killed", title: "Retired", inbox_killed_at: 111 },
+    ]);
+    const rows = await performListRecentSessions({ db } as any, USER as any);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].inbox_killed_at).toBe(111);
+  });
+
+  test("a live session reports the marker as undefined, not a stale value", async () => {
+    const db = fixtures([{ _id: "conv_live", title: "Working" }]);
+    const rows = await performListRecentSessions({ db } as any, USER as any);
+    expect(rows[0].inbox_killed_at).toBeUndefined();
+  });
+
+  // Both palette sources must agree, which is the whole point of the projection.
+  test("killed and live rows are distinguishable in one result set", async () => {
+    const db = fixtures([
+      { _id: "conv_killed", title: "Retired", inbox_killed_at: 111 },
+      { _id: "conv_live", title: "Working" },
+    ]);
+    const rows = await performListRecentSessions({ db } as any, USER as any);
+    const killed = rows.filter((r: any) => r.inbox_killed_at);
+    expect(killed).toHaveLength(1);
+    expect(killed[0].title).toBe("Retired");
+  });
+});

--- a/packages/convex/convex/conversations.tallyInbox.test.ts
+++ b/packages/convex/convex/conversations.tallyInbox.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { tallyInboxRows } from "./conversations";
+
+// The `cast sessions` tally. This logic has been wrong twice — a killed row
+// double-counted under a comment denying it, then `-a` zeroing the retirement
+// figures while still listing those rows — and both times adversarial review
+// caught it because nothing here was tested. These pin the contract so either
+// regression fails a test instead of shipping.
+//
+// The contract: the three retirement figures are TALLIES, not a partition of
+// the work-state buckets. Counting is unconditional; only the COLLAPSE depends
+// on -a, and a killed row never collapses.
+
+const labelByConv = new Map<string, string>();
+
+function session(overrides: Record<string, any> = {}) {
+  return {
+    _id: "conversations_1",
+    session_id: "sess-1",
+    title: "Ship the thing",
+    project_path: "/proj",
+    updated_at: Date.now(),
+    message_count: 5,
+    agent_type: "claude",
+    agent_status: undefined,
+    is_idle: true,
+    awaiting_input: false,
+    has_pending: false,
+    is_unresponsive: false,
+    is_pinned: false,
+    is_connected: false,
+    is_subagent: false,
+    ...overrides,
+  };
+}
+
+const tally = (s: any[], showAll = false) =>
+  tallyInboxRows(s, { showAll, stateFilter: null, labelByConv });
+
+// Which work-state bucket a listed row lands in depends on liveness signals
+// that are beside the point for a tally test; what matters is that it lands in
+// exactly one. (Killed is the exception — classifyWorkState forces it to idle,
+// and that IS load-bearing, so those tests assert `idle` directly.)
+const workStateTotal = (c: any) => c.needs_input + c.working + c.idle;
+
+describe("tallyInboxRows — retirement figures are tallies, not a partition", () => {
+  test("an ordinary row: counted in total and its work state, no retirement figure", () => {
+    const { counts, rows } = tally([session()]);
+    expect(counts.total).toBe(1);
+    expect(workStateTotal(counts)).toBe(1);
+    expect(counts.killed + counts.dismissed + counts.stashed).toBe(0);
+    expect(rows).toHaveLength(1);
+  });
+
+  // The F1 regression. A killed row is an OVERLAY: it lands in `killed` AND in
+  // total/work_state/pinned. Re-adding a `continue` after the tally breaks this.
+  test("a killed row is listed AND counted in total, idle, pinned and killed", () => {
+    const { counts, rows } = tally([session({ inbox_killed_at: 111, is_pinned: true })]);
+    expect(counts.killed).toBe(1);
+    expect(counts.total).toBe(1);
+    expect(counts.idle).toBe(1); // classifyWorkState collapses killed → idle
+    expect(counts.pinned).toBe(1);
+    expect(rows).toHaveLength(1); // renders through — never collapsed
+  });
+
+  test("a killed row renders through under -a as well", () => {
+    const { counts, rows } = tally([session({ inbox_killed_at: 111 })], true);
+    expect(counts.killed).toBe(1);
+    expect(rows).toHaveLength(1);
+  });
+
+  test("dismissed without -a: counted, collapsed out of the listing and totals", () => {
+    const { counts, rows } = tally([session({ inbox_dismissed_at: 111 })]);
+    expect(counts.dismissed).toBe(1);
+    expect(counts.total).toBe(0);
+    expect(workStateTotal(counts)).toBe(0);
+    expect(rows).toHaveLength(0);
+  });
+
+  test("stashed without -a: counted, collapsed out of the listing and totals", () => {
+    const { counts, rows } = tally([session({ inbox_stashed_at: 111 })]);
+    expect(counts.stashed).toBe(1);
+    expect(counts.total).toBe(0);
+    expect(rows).toHaveLength(0);
+  });
+
+  // The F4 regression. Re-gating the tally on !showAll zeroes these while the
+  // rows are listed — which gutted `stashed`, whose whole purpose is telling you
+  // how many agents are still running.
+  test("dismissed WITH -a: still counted, and now also listed and in totals", () => {
+    const { counts, rows } = tally([session({ inbox_dismissed_at: 111 })], true);
+    expect(counts.dismissed).toBe(1); // NOT zeroed by -a
+    expect(counts.total).toBe(1);
+    expect(workStateTotal(counts)).toBe(1);
+    expect(rows).toHaveLength(1);
+  });
+
+  test("stashed WITH -a: still counted, and now also listed and in totals", () => {
+    const { counts, rows } = tally([session({ inbox_stashed_at: 111 })], true);
+    expect(counts.stashed).toBe(1); // NOT zeroed by -a
+    expect(counts.total).toBe(1);
+    expect(rows).toHaveLength(1);
+  });
+
+  // Precedence at the tally, not just in the classifier: cast kill writes both
+  // stamps, and the row must be reported once, as killed.
+  test("a row with both kill and dismiss stamps counts once, as killed", () => {
+    const { counts } = tally([session({ inbox_killed_at: 111, inbox_dismissed_at: 111 })]);
+    expect(counts.killed).toBe(1);
+    expect(counts.dismissed).toBe(0);
+  });
+
+  test("subagent rows are excluded from every figure", () => {
+    const { counts, rows } = tally([session({ is_subagent: true })]);
+    expect(counts.total).toBe(0);
+    expect(rows).toHaveLength(0);
+  });
+
+  // The same class as F1/F4, one figure over: pinned/live tally RENDERED rows
+  // (they sit after the collapse), so a collapsed dismissed+pinned row must not
+  // inflate `pinned` — that would claim a pinned card the inbox doesn't show.
+  // Moving `counts.pinned++` above the collapse breaks this.
+  test("a collapsed dismissed+pinned row is not counted as pinned", () => {
+    const { counts } = tally([session({ inbox_dismissed_at: 111, is_pinned: true })]);
+    expect(counts.dismissed).toBe(1);
+    expect(counts.pinned).toBe(0);
+  });
+
+  // stateFilter narrows the LISTING only — counts stay whole-fleet, or the
+  // summary line would change meaning with every --state flag.
+  test("stateFilter=pinned narrows rows to pinned without touching counts", () => {
+    const { counts, rows } = tallyInboxRows(
+      [session({ _id: "a", is_pinned: true }), session({ _id: "b" })],
+      { showAll: false, stateFilter: "pinned", labelByConv },
+    );
+    expect(counts.total).toBe(2);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_pinned).toBe(true);
+  });
+
+  test("a work-state filter keeps only matching rows, counts untouched", () => {
+    // killed is forced idle by classifyWorkState; a quiet row WITH messages is
+    // needs_input (settled-with-content routes to the user), so these two rows
+    // land in different buckets by construction.
+    const { counts, rows } = tallyInboxRows(
+      [session({ _id: "a", inbox_killed_at: 111, is_pinned: true }), session({ _id: "b" })],
+      { showAll: false, stateFilter: "idle", labelByConv },
+    );
+    expect(counts.total).toBe(2);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_killed).toBe(true);
+  });
+
+  test("labelByConv stamps the row label; absent entries read null", () => {
+    const labels = new Map([["conversations_a", "fleet"]]);
+    const { rows } = tallyInboxRows(
+      [session({ _id: "conversations_a" }), session({ _id: "conversations_b" })],
+      { showAll: false, stateFilter: null, labelByConv: labels },
+    );
+    expect(rows.find((r) => r.id === "conversations_a")!.label).toBe("fleet");
+    expect(rows.find((r) => r.id === "conversations_b")!.label).toBe(null);
+  });
+
+  // The whole point of splitting stashed from dismissed.
+  test("a mixed fleet reports each retirement state separately", () => {
+    const { counts } = tally([
+      session({ _id: "a" }),
+      session({ _id: "b", inbox_stashed_at: 111 }),
+      session({ _id: "c", inbox_dismissed_at: 111 }),
+      session({ _id: "d", inbox_killed_at: 111 }),
+    ]);
+    expect(counts.stashed).toBe(1);
+    expect(counts.dismissed).toBe(1);
+    expect(counts.killed).toBe(1);
+    // Listed: the ordinary row and the killed one; the other two collapsed.
+    expect(counts.total).toBe(2);
+  });
+});

--- a/packages/convex/convex/conversations.ts
+++ b/packages/convex/convex/conversations.ts
@@ -14,7 +14,7 @@ import { cancelTasksBoundToConversation, reactivateTasksCanceledOnKill } from ".
 import { advanceForkCopy, type ForkCopyCtx } from "./forkCopy";
 import { hasRecentPendingDaemonCommand, extractDaemonCommandConversationId } from "./daemonCommandUtils";
 import { AGENT_MODEL_CONFIG, AGENT_CLIENTS, modelAgentKey, findModelOption, fromConvexAgentType, toConvexAgentType } from "@codecast/shared/contracts";
-import { shouldShowInInbox, isSessionIdle, deriveSessionActivity, classifyWorkState, normalizeWorkStateFilter, trustedAgentStatus, subagentKeepsParentWorking, type WorkState } from "./inboxFilters";
+import { shouldShowInInbox, isSessionIdle, deriveSessionActivity, classifyWorkState, classifyRetirement, normalizeWorkStateFilter, trustedAgentStatus, subagentKeepsParentWorking, type WorkState } from "./inboxFilters";
 import { subagentLinkFields } from "./ccAccountsShared";
 import { isSessionOwner } from "./sessionOwners";
 import { filterUserMessages, isImportNotice } from "./userMessagesFilter";
@@ -2942,93 +2942,105 @@ export const getConversationPublic = query({
   },
 });
 
+// The command palette's row set. Split from the query wrapper (like
+// performListActiveSessions) so the projection is testable without auth.
+export async function performListRecentSessions(ctx: { db: QueryCtx["db"] }, userId: Id<"users">) {
+  const user = await ctx.db.get(userId);
+  const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+
+  const own = await ctx.db
+    .query("conversations")
+    .withIndex("by_user_updated", (q) =>
+      q.eq("user_id", userId).gte("updated_at", thirtyDaysAgo)
+    )
+    .order("desc")
+    .filter((q) =>
+      q.and(
+        q.neq(q.field("is_subagent"), true),
+        q.or(
+          q.eq(q.field("status"), "active"),
+          q.eq(q.field("status"), "completed")
+        )
+      )
+    )
+    .take(100);
+
+  type ConvRow = typeof own[number];
+  const isSessionRow = (c: ConvRow) =>
+    c.is_subagent !== true && (c.status === "active" || c.status === "completed");
+
+  const byId = new Map<string, { conv: ConvRow; isOwn: boolean }>();
+  for (const c of own) byId.set(c._id.toString(), { conv: c, isOwn: true });
+
+  // Merge in team-visible sessions so teammates' work shows in the palette too.
+  const effectiveTeamId = user?.active_team_id;
+  const authorById = new Map<string, { name: string; avatar: string | null }>();
+  if (effectiveTeamId) {
+    const feedFilter = await createTeamFeedFilter(ctx, effectiveTeamId);
+    const visibleMembers = feedFilter.memberships.filter((m) => {
+      if (m.user_id.toString() === userId.toString()) return false;
+      return ((m as any).visibility || "summary") !== "hidden";
+    });
+    const perMember = await Promise.all(
+      visibleMembers.map(async (m) => {
+        const convs = await ctx.db
+          .query("conversations")
+          .withIndex("by_team_user_updated", (q) =>
+            q.eq("team_id", effectiveTeamId).eq("user_id", m.user_id).gte("updated_at", thirtyDaysAgo)
+          )
+          .order("desc")
+          .take(10);
+        return convs.filter((c) => isSessionRow(c) && feedFilter.isVisible(c));
+      })
+    );
+    const memberUsers = await Promise.all(visibleMembers.map((m) => ctx.db.get(m.user_id)));
+    for (const u of memberUsers) {
+      if (u) authorById.set(u._id.toString(), {
+        name: (u as any).name || (u as any).email?.split("@")[0] || "Unknown",
+        avatar: (u as any).image || (u as any).github_avatar_url || null,
+      });
+    }
+    for (const c of perMember.flat()) {
+      const id = c._id.toString();
+      if (!byId.has(id)) byId.set(id, { conv: c, isOwn: false });
+    }
+  }
+
+  return Array.from(byId.values())
+    .sort((a, b) => b.conv.updated_at - a.conv.updated_at)
+    .slice(0, 100)
+    .map(({ conv: c, isOwn }) => {
+      const author = isOwn ? null : authorById.get(c.user_id.toString());
+      return {
+        _id: c._id,
+        session_id: c.session_id,
+        title: c.title,
+        subtitle: c.subtitle,
+        idle_summary: c.idle_summary,
+        updated_at: c.updated_at,
+        project_path: c.project_path,
+        git_root: c.git_root,
+        agent_type: c.agent_type,
+        message_count: c.message_count,
+        // The command palette builds its list from two sources: favorites
+        // carry whole store rows (so the marker arrives), while recents come
+        // from THIS projection. Omitting it left inbox_killed_at permanently
+        // undefined on half the rows, so killed-awareness silently could not
+        // work there. The conversation doc is already in hand — no extra read.
+        inbox_killed_at: c.inbox_killed_at,
+        isOwn,
+        authorName: author?.name ?? null,
+        authorAvatar: author?.avatar ?? null,
+      };
+    });
+}
+
 export const listRecentSessions = query({
   args: {},
   handler: async (ctx) => {
     const userId = await getAuthUserId(ctx);
     if (!userId) return [];
-    const user = await ctx.db.get(userId);
-    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-
-    const own = await ctx.db
-      .query("conversations")
-      .withIndex("by_user_updated", (q) =>
-        q.eq("user_id", userId).gte("updated_at", thirtyDaysAgo)
-      )
-      .order("desc")
-      .filter((q) =>
-        q.and(
-          q.neq(q.field("is_subagent"), true),
-          q.or(
-            q.eq(q.field("status"), "active"),
-            q.eq(q.field("status"), "completed")
-          )
-        )
-      )
-      .take(100);
-
-    type ConvRow = typeof own[number];
-    const isSessionRow = (c: ConvRow) =>
-      c.is_subagent !== true && (c.status === "active" || c.status === "completed");
-
-    const byId = new Map<string, { conv: ConvRow; isOwn: boolean }>();
-    for (const c of own) byId.set(c._id.toString(), { conv: c, isOwn: true });
-
-    // Merge in team-visible sessions so teammates' work shows in the palette too.
-    const effectiveTeamId = user?.active_team_id;
-    const authorById = new Map<string, { name: string; avatar: string | null }>();
-    if (effectiveTeamId) {
-      const feedFilter = await createTeamFeedFilter(ctx, effectiveTeamId);
-      const visibleMembers = feedFilter.memberships.filter((m) => {
-        if (m.user_id.toString() === userId.toString()) return false;
-        return ((m as any).visibility || "summary") !== "hidden";
-      });
-      const perMember = await Promise.all(
-        visibleMembers.map(async (m) => {
-          const convs = await ctx.db
-            .query("conversations")
-            .withIndex("by_team_user_updated", (q) =>
-              q.eq("team_id", effectiveTeamId).eq("user_id", m.user_id).gte("updated_at", thirtyDaysAgo)
-            )
-            .order("desc")
-            .take(10);
-          return convs.filter((c) => isSessionRow(c) && feedFilter.isVisible(c));
-        })
-      );
-      const memberUsers = await Promise.all(visibleMembers.map((m) => ctx.db.get(m.user_id)));
-      for (const u of memberUsers) {
-        if (u) authorById.set(u._id.toString(), {
-          name: (u as any).name || (u as any).email?.split("@")[0] || "Unknown",
-          avatar: (u as any).image || (u as any).github_avatar_url || null,
-        });
-      }
-      for (const c of perMember.flat()) {
-        const id = c._id.toString();
-        if (!byId.has(id)) byId.set(id, { conv: c, isOwn: false });
-      }
-    }
-
-    return Array.from(byId.values())
-      .sort((a, b) => b.conv.updated_at - a.conv.updated_at)
-      .slice(0, 100)
-      .map(({ conv: c, isOwn }) => {
-        const author = isOwn ? null : authorById.get(c.user_id.toString());
-        return {
-          _id: c._id,
-          session_id: c.session_id,
-          title: c.title,
-          subtitle: c.subtitle,
-          idle_summary: c.idle_summary,
-          updated_at: c.updated_at,
-          project_path: c.project_path,
-          git_root: c.git_root,
-          agent_type: c.agent_type,
-          message_count: c.message_count,
-          isOwn,
-          authorName: author?.name ?? null,
-          authorAvatar: author?.avatar ?? null,
-        };
-      });
+    return performListRecentSessions(ctx, userId);
   },
 });
 
@@ -8262,6 +8274,117 @@ export const teamSessionsLiveness = query({
   },
 });
 
+// The `cast sessions` tally + row filter, split out of inboxForCLI as a PURE
+// function over already-enriched rows. This logic has been wrong twice — a
+// killed row double-counted under a comment denying it, then `-a` zeroing the
+// retirement figures while listing the rows — and both times a test would have
+// caught it, so it gets a seam rather than living inside a db-heavy query.
+export function tallyInboxRows(
+  sessions: any[],
+  opts: { showAll?: boolean; stateFilter?: string | null; labelByConv: Map<string, string> },
+) {
+  const counts = { working: 0, needs_input: 0, idle: 0, pinned: 0, live: 0, stashed: 0, dismissed: 0, killed: 0, total: 0 };
+  const rows: Array<{
+    id: string;
+    session_id: string;
+    title: string;
+    project_path: string | null;
+    updated_at: string;
+    ts: number;
+    message_count: number;
+    agent_type?: string;
+    agent_status?: string;
+    work_state: WorkState;
+    is_killed: boolean;
+    is_pinned: boolean;
+    is_live: boolean;
+    is_unresponsive: boolean;
+    awaiting_input: boolean;
+    idle_summary: string | null;
+    last_user_message: string | null;
+    label: string | null;
+    active_plan: { short_id: string; title: string } | null;
+    active_task: { short_id: string; title: string } | null;
+    // Second-party ownership: run_by = the member whose account runs the
+    // session when that isn't the caller; owner = the assigned owner if any.
+    run_by: string | null;
+    owner: { name: string | null; email: string | null } | null;
+    owned_by_me: boolean;
+  }> = [];
+
+  for (const s of sessions) {
+    if (s.is_subagent) continue; // keep the monitor to top-level sessions
+    // The three retirement states are TALLIES, not buckets — the same shape as
+    // `pinned` and `live`, and deliberately NOT mutually exclusive with the
+    // work-state counts. A rendered row lands in both its work_state figure
+    // and its retirement figure (a pinned killed session is counted in `idle`,
+    // `pinned`, `killed` and `total`); a collapsed row appears only in its
+    // retirement figure. Counting is therefore unconditional — gating it on
+    // !show_all left every figure at 0 under `-a` while the rows were listed,
+    // which made `stashed` useless for its whole purpose (how many agents are
+    // still running). See classifyRetirement for why killed outranks the rest.
+    //
+    // Only the COLLAPSE is conditional. A killed row renders through: it only
+    // reaches here while pinned (shouldShowInInbox drops killed-and-unpinned),
+    // and pinning is how you hold onto a killed row — swallowing it was the
+    // CLI overriding a decision the server already made. Stashed and dismissed
+    // keep collapsing, mirroring the web's separate parked group, so
+    // already-triaged sessions don't inflate the active buckets; `-a` lists them.
+    const retired = classifyRetirement(s);
+    if (retired) counts[retired]++;
+    if (retired && retired !== "killed" && !opts.showAll) continue;
+    const work_state = classifyWorkState({
+      agentStatus: s.agent_status,
+      isIdle: s.is_idle,
+      awaitingInput: s.awaiting_input,
+      hasPending: s.has_pending,
+      isUnresponsive: s.is_unresponsive,
+      messageCount: s.message_count || 0,
+      killed: !!s.inbox_killed_at,
+    });
+    const is_live = !!s.is_connected;
+
+    counts.total++;
+    counts[work_state]++;
+    if (s.is_pinned) counts.pinned++;
+    if (is_live) counts.live++;
+    const rowLabel = opts.labelByConv.get(s._id.toString()) ?? null;
+
+    if (opts.stateFilter === "pinned" && !s.is_pinned) continue;
+    if (opts.stateFilter === "live" && !is_live) continue;
+    if (opts.stateFilter && opts.stateFilter !== "pinned" && opts.stateFilter !== "live" && work_state !== opts.stateFilter) continue;
+
+    rows.push({
+      id: s._id,
+      session_id: s.session_id,
+      title: s.title || s.last_user_message || "New Session",
+      project_path: s.project_path || null,
+      updated_at: new Date(s.updated_at).toISOString(),
+      ts: s.updated_at,
+      message_count: s.message_count || 0,
+      agent_type: s.agent_type,
+      agent_status: s.agent_status,
+      work_state,
+      // A retired row (still listed while pinned, or under --all). The watch
+      // stream reads it to emit a kill as a departure, not a transition.
+      is_killed: !!s.inbox_killed_at,
+      is_pinned: !!s.is_pinned,
+      is_live,
+      is_unresponsive: !!s.is_unresponsive,
+      awaiting_input: !!s.awaiting_input,
+      idle_summary: s.idle_summary || null,
+      last_user_message: s.last_user_message || null,
+      label: rowLabel,
+      active_plan: s.active_plan ? { short_id: s.active_plan.short_id, title: s.active_plan.title } : null,
+      active_task: s.active_task ? { short_id: s.active_task.short_id, title: s.active_task.title } : null,
+      run_by: s.author_name ?? null,
+      owner: s.owner_user_id ? { name: s.owner_name ?? null, email: s.owner_email ?? null } : null,
+      owned_by_me: !!s.owned_by_me,
+    });
+  }
+  return { counts, rows };
+}
+
 // CLI-facing inbox: the same fully-enriched, per-user session set the web inbox
 // renders (computeInboxSessions), collapsed to a single `work_state` per row via
 // the shared classifier and sorted most-actionable-first. Powers `cast monitor`
@@ -8342,91 +8465,11 @@ export const inboxForCLI = query({
     const stateFilter = normalizeWorkStateFilter(args.state);
     const ORDER: Record<WorkState, number> = { needs_input: 0, working: 1, idle: 2 };
 
-    const counts = { working: 0, needs_input: 0, idle: 0, pinned: 0, live: 0, dismissed: 0, total: 0 };
-    const rows: Array<{
-      id: string;
-      session_id: string;
-      title: string;
-      project_path: string | null;
-      updated_at: string;
-      ts: number;
-      message_count: number;
-      agent_type?: string;
-      agent_status?: string;
-      work_state: WorkState;
-      is_killed: boolean;
-      is_pinned: boolean;
-      is_live: boolean;
-      is_unresponsive: boolean;
-      awaiting_input: boolean;
-      idle_summary: string | null;
-      last_user_message: string | null;
-      label: string | null;
-      active_plan: { short_id: string; title: string } | null;
-      active_task: { short_id: string; title: string } | null;
-      // Second-party ownership: run_by = the member whose account runs the
-      // session when that isn't the caller; owner = the assigned owner if any.
-      run_by: string | null;
-      owner: { name: string | null; email: string | null } | null;
-      owned_by_me: boolean;
-    }> = [];
-
-    for (const s of sessions) {
-      if (s.is_subagent) continue; // keep the monitor to top-level sessions
-      // Dismissed sessions are returned by computeInboxSessions but the web parks
-      // them in a separate collapsed group, out of the active buckets. Mirror that
-      // so cast monitor counts match the web inbox (don't inflate idle with
-      // already-triaged sessions). `cast monitor -a` includes them.
-      if ((s.inbox_dismissed_at || s.inbox_stashed_at) && !args.show_all) { counts.dismissed++; continue; }
-      const work_state = classifyWorkState({
-        agentStatus: s.agent_status,
-        isIdle: s.is_idle,
-        awaitingInput: s.awaiting_input,
-        hasPending: s.has_pending,
-        isUnresponsive: s.is_unresponsive,
-        messageCount: s.message_count || 0,
-        killed: !!s.inbox_killed_at,
-      });
-      const is_live = !!s.is_connected;
-
-      counts.total++;
-      counts[work_state]++;
-      if (s.is_pinned) counts.pinned++;
-      if (is_live) counts.live++;
-      const rowLabel = labelByConv.get(s._id.toString()) ?? null;
-
-      if (stateFilter === "pinned" && !s.is_pinned) continue;
-      if (stateFilter === "live" && !is_live) continue;
-      if (stateFilter && stateFilter !== "pinned" && stateFilter !== "live" && work_state !== stateFilter) continue;
-
-      rows.push({
-        id: s._id,
-        session_id: s.session_id,
-        title: s.title || s.last_user_message || "New Session",
-        project_path: s.project_path || null,
-        updated_at: new Date(s.updated_at).toISOString(),
-        ts: s.updated_at,
-        message_count: s.message_count || 0,
-        agent_type: s.agent_type,
-        agent_status: s.agent_status,
-        work_state,
-        // A retired row (still listed while pinned, or under --all). The watch
-        // stream reads it to emit a kill as a departure, not a transition.
-        is_killed: !!s.inbox_killed_at,
-        is_pinned: !!s.is_pinned,
-        is_live,
-        is_unresponsive: !!s.is_unresponsive,
-        awaiting_input: !!s.awaiting_input,
-        idle_summary: s.idle_summary || null,
-        last_user_message: s.last_user_message || null,
-        label: rowLabel,
-        active_plan: s.active_plan ? { short_id: s.active_plan.short_id, title: s.active_plan.title } : null,
-        active_task: s.active_task ? { short_id: s.active_task.short_id, title: s.active_task.title } : null,
-        run_by: s.author_name ?? null,
-        owner: s.owner_user_id ? { name: s.owner_name ?? null, email: s.owner_email ?? null } : null,
-        owned_by_me: !!s.owned_by_me,
-      });
-    }
+    const { counts, rows } = tallyInboxRows(sessions, {
+      showAll: args.show_all,
+      stateFilter,
+      labelByConv,
+    });
 
     // Most-actionable first: pinned, then needs_input → working → idle, recent first.
     rows.sort((a, b) => {

--- a/packages/convex/convex/dispatch.test.ts
+++ b/packages/convex/convex/dispatch.test.ts
@@ -243,6 +243,90 @@ describe("inbox_killed_at survives patches that are not a revival", () => {
   });
 });
 
+// The un-kill mirror re-arms the schedules a kill canceled. It used to gate on
+// the dismissed stamp alone, but the two kill surfaces write different fields:
+// applyHideTransition (cast kill, dismiss→kill) stamps inbox_dismissed_at AND
+// inbox_killed_at, while the killSession command stamps the marker ALONE. So
+// restoring a command-killed row cleared its marker and brought the card back
+// while its standing loop stayed silently dead — reachable from the UI for the
+// first time via the /sessions restore button.
+describe("un-kill re-arms schedules for BOTH kill surfaces", () => {
+  const RUNNER = "users_runner";
+  const CONV = "conversations_killed";
+
+  // `killed` carries the kill stamp; `natural` completed on its own and must
+  // never come back. Both are the runner's, both bound to this conversation.
+  const fixtures = (conv: Record<string, any>) =>
+    makeFakeDb({
+      conversations: [{
+        _id: CONV, user_id: RUNNER, status: "completed", message_count: 12, ...conv,
+      }],
+      agent_tasks: [
+        {
+          _id: "task_killed", user_id: RUNNER, status: "completed",
+          canceled_on_kill_at: 111, originating_conversation_id: CONV,
+          schedule_type: "recurring", interval_ms: 60 * 60 * 1000,
+        },
+        {
+          _id: "task_natural", user_id: RUNNER, status: "completed",
+          originating_conversation_id: CONV,
+          schedule_type: "recurring", interval_ms: 60 * 60 * 1000,
+        },
+      ],
+      messages: [], pending_messages: [], client_state: [], managed_sessions: [],
+      daemon_commands: [], session_owners: [],
+    });
+
+  const task = (db: any, id: string) =>
+    db._tables.agent_tasks.find((t: any) => t._id === id);
+
+  // The regression. A killSession-killed row has NO inbox_dismissed_at, so the
+  // old wasDismissed gate never fired for it.
+  test("restoring a COMMAND-killed row (marker alone) re-arms its schedules", async () => {
+    const db = fixtures({ inbox_killed_at: 111 });
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_killed_at: null } },
+    });
+    expect(db._tables.conversations[0].inbox_killed_at).toBeUndefined();
+    expect(task(db, "task_killed").status).toBe("scheduled");
+    expect(task(db, "task_killed").canceled_on_kill_at).toBeUndefined();
+    // Only the stamped one — a natural completion stays done.
+    expect(task(db, "task_natural").status).toBe("completed");
+  });
+
+  test("restoring a cast-kill-killed row (both stamps) still re-arms", async () => {
+    const db = fixtures({ inbox_dismissed_at: 111, inbox_killed_at: 111 });
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_killed_at: null } },
+    });
+    expect(db._tables.conversations[0].inbox_killed_at).toBeUndefined();
+    expect(task(db, "task_killed").status).toBe("scheduled");
+  });
+
+  // Widening the trigger must NOT widen who can un-retire a row. A pin-shaped
+  // patch is not un-kill-shaped, so the guard strips inbox_killed_at before the
+  // mirror ever sees it — no clear, and no re-arm.
+  test("a pin-shaped patch on a command-killed row neither un-kills nor re-arms", async () => {
+    const db = fixtures({ inbox_killed_at: 111 });
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_pinned_at: 555, is_pinned: true, inbox_killed_at: null } },
+    });
+    expect(db._tables.conversations[0].inbox_killed_at).toBe(111);
+    expect(db._tables.conversations[0].inbox_pinned_at).toBe(555);
+    expect(task(db, "task_killed").status).toBe("completed");
+  });
+
+  // A row that was never killed or dismissed has nothing to revive: a patch
+  // nulling stamps it never had must not resurrect stale stamped schedules.
+  test("clearing stamps on a row that was never hidden re-arms nothing", async () => {
+    const db = fixtures({});
+    await applyPatches({ db } as any, RUNNER as any, {
+      conversations: { [CONV]: { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_killed_at: null } },
+    });
+    expect(task(db, "task_killed").status).toBe("completed");
+  });
+});
+
 describe("applyPatches bucket coverage", () => {
   test("a legacy generic bucket patch advances the v2 complete-view head once", async () => {
     const userId = "users_owner";

--- a/packages/convex/convex/dispatch.ts
+++ b/packages/convex/convex/dispatch.ts
@@ -370,18 +370,37 @@ export async function applyPatches(
         if (table === "conversations" && ((finalSafe as any).inbox_dismissed_at || (finalSafe as any).inbox_stashed_at)) {
           await applyHideTransition(ctx, doc, finalSafe as any, { forceKill: opts?.forceKill });
         }
-        // The un-kill mirror: a patch CLEARING inbox_dismissed_at on a row that
-        // had it is the restore/undo gesture (web restoreSession, undo of a
-        // kill) — re-arm the schedules the kill canceled, or the user gets
-        // their session back with its standing loop silently dead. Only tasks
-        // stamped canceled_on_kill_at re-arm; natural completions stay done.
-        // Same two scans as the kill: the runner's schedules, plus the caller's
-        // when a second-party owner is restoring.
+        // The un-kill mirror: a patch CLEARING either hide stamp on a row that
+        // had it is the restore/undo gesture (web restoreSession, the /sessions
+        // restore, undo of a kill) — re-arm the schedules the kill canceled, or
+        // the user gets their session back with its standing loop silently dead.
+        // Only tasks stamped canceled_on_kill_at re-arm; natural completions
+        // stay done. Same two scans as the kill: the runner's schedules, plus
+        // the caller's when a second-party owner is restoring.
+        //
+        // BOTH stamps have to count, because the two kill surfaces do not write
+        // the same fields: applyHideTransition (cast kill, dismiss→kill) stamps
+        // inbox_dismissed_at AND inbox_killed_at, but the killSession command
+        // stamps the marker ALONE. Keying on the dismissed stamp only meant
+        // restoring a command-killed row cleared its marker and brought the card
+        // back while its schedules stayed dead. This does not widen WHO may
+        // un-kill: the guard above already stripped inbox_killed_at from the
+        // patch unless it is un-kill-shaped, so a clear reaching here passed it.
+        //
+        // It does widen WHAT an un-kill does, on one path: a command-killed row
+        // restored by a second-party OWNER now re-arms the RUNNER's schedules
+        // (the first reactivate call below scans doc.user_id, not the caller).
+        // That is deliberate and symmetric — the owner already had exactly this
+        // effect on the dismissed path, and the schedules a kill canceled are
+        // the runner's by construction, so restoring without them would hand
+        // back a session whose standing loop is silently dead.
+        const clearsDismissed =
+          "inbox_dismissed_at" in (finalSafe as any) && !(finalSafe as any).inbox_dismissed_at;
+        const clearsKilled =
+          "inbox_killed_at" in (finalSafe as any) && !(finalSafe as any).inbox_killed_at;
         if (
           table === "conversations" &&
-          "inbox_dismissed_at" in (finalSafe as any) &&
-          !(finalSafe as any).inbox_dismissed_at &&
-          wasDismissed
+          ((clearsDismissed && wasDismissed) || (clearsKilled && wasKilled))
         ) {
           // Un-kill the row server-side. The web's restore gesture only nulls
           // the two hide stamps, but shouldShowInInbox hides a row on

--- a/packages/convex/convex/inboxFilters.test.ts
+++ b/packages/convex/convex/inboxFilters.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+// The REAL web helpers, imported so the cross-check below enforces the
+// convex/web agreement instead of restating it.
+import { isSessionStashed, isSessionKilled, isSessionDismissed } from "../../web/store/inboxStore";
 import {
   isNoiseTitle,
   isOrphanOrSubagent,
@@ -11,6 +14,7 @@ import {
   CLIENT_ERROR_BANNER_PREFIX,
   apiErrorBatchAction,
   classifyWorkState,
+  classifyRetirement,
   normalizeWorkStateFilter,
   trustedAgentStatus,
   subagentKeepsParentWorking,
@@ -125,6 +129,112 @@ describe("isViableInboxParent", () => {
 
 // Inbox visibility is now a single filter. Dismissed conversations stay in the
 // inbox — clients categorize them via the `inbox_dismissed_at` field.
+// stashed / dismissed / killed were reported to `cast sessions` as one
+// "dismissed" figure, hiding the difference that matters operationally: a
+// stashed agent is still RUNNING, a dismissed one was torn down.
+describe("classifyRetirement", () => {
+  test("a live session is not retired", () => {
+    expect(classifyRetirement(conv())).toBe(null);
+  });
+
+  test("stashed (agent alive) is its own state", () => {
+    expect(classifyRetirement(conv({ inbox_stashed_at: 100 }))).toBe("stashed");
+  });
+
+  test("dismissed (agent torn down) is its own state", () => {
+    expect(classifyRetirement(conv({ inbox_dismissed_at: 100 }))).toBe("dismissed");
+  });
+
+  test("killed is its own state", () => {
+    expect(classifyRetirement(conv({ inbox_killed_at: 100 }))).toBe("killed");
+  });
+
+  // The precedence that makes the two kill surfaces agree. applyHideTransition
+  // (cast kill, dismiss→kill) stamps BOTH fields; the killSession command stamps
+  // the marker alone. Without killed-first, one user-visible state would be
+  // reported under two different names depending on which surface did the kill.
+  test("cast kill's two stamps still classify as killed, not dismissed", () => {
+    expect(classifyRetirement(conv({ inbox_dismissed_at: 100, inbox_killed_at: 100 })))
+      .toBe("killed");
+  });
+
+  test("the killSession command's lone marker classifies the same way", () => {
+    expect(classifyRetirement(conv({ inbox_killed_at: 100 }))).toBe("killed");
+  });
+
+  test("killed outranks stashed too", () => {
+    expect(classifyRetirement(conv({ inbox_stashed_at: 100, inbox_killed_at: 100 })))
+      .toBe("killed");
+  });
+
+  // Dismiss outranks stash, matching isSessionStashed in the web's inboxStore
+  // ("Dismiss wins: a stashed session that later gets dismissed renders in the
+  // Dismissed bucket, never both"). The ordering is not arbitrary taste — a row
+  // reported as "stashed" here and "dismissed" there would be exactly the
+  // two-surfaces-disagree defect this classifier exists to remove. Dismiss is
+  // also the stronger claim: the agent was torn down, so a surviving stash stamp
+  // is stale history and "stashed" would assert a live agent there isn't one.
+  test("a stashed row that was later dismissed is dismissed, matching the web", () => {
+    expect(classifyRetirement(conv({ inbox_stashed_at: 100, inbox_dismissed_at: 200 })))
+      .toBe("dismissed");
+  });
+
+  // Exactly one bucket per row is what keeps the three counts from double-counting.
+  test("a row is never in two states at once", () => {
+    const both = conv({ inbox_dismissed_at: 100, inbox_stashed_at: 100, inbox_killed_at: 100 });
+    const state = classifyRetirement(both);
+    expect(["killed", "dismissed", "stashed"]).toContain(state!);
+    expect(state).toBe("killed");
+  });
+});
+
+// Enforces the scope of the web-agreement claim in classifyRetirement's comment
+// rather than leaving it asserted. Imports the REAL web helpers, so a change to
+// either side's rule breaks this instead of drifting silently.
+//
+// The two models differ by construction: the web carries a bucket
+// (active | dismissed | stashed) PLUS an orthogonal isSessionKilled flag, while
+// classifyRetirement is a single-axis partition because it feeds counts. They
+// agree on every UNKILLED combination — that is the part that must not drift —
+// and diverge on every killed one, which is intended and pinned below so a
+// future reader meets it as a documented design choice, not a surprise.
+describe("classifyRetirement vs the web's bucketing", () => {
+  // Every rule here comes from the web helpers — none is re-implemented, or the
+  // cross-check would silently stop covering whichever one was copied.
+  const webBucket = (c: any): "dismissed" | "stashed" | null =>
+    isSessionStashed(c) ? "stashed" : isSessionDismissed(c) ? "dismissed" : null;
+
+  const STAMPS = [
+    { inbox_dismissed_at: undefined, inbox_stashed_at: undefined },
+    { inbox_dismissed_at: 100, inbox_stashed_at: undefined },
+    { inbox_dismissed_at: undefined, inbox_stashed_at: 100 },
+    { inbox_dismissed_at: 100, inbox_stashed_at: 100 },
+  ];
+
+  test("agrees with the web bucket for every UNKILLED stamp combination", () => {
+    for (const stamps of STAMPS) {
+      const row = conv(stamps as any);
+      expect(isSessionKilled(row as any)).toBe(false);
+      expect(classifyRetirement(row)).toBe(webBucket(row) as any);
+    }
+  });
+
+  test("diverges on killed rows BY DESIGN — single axis here, two axes there", () => {
+    for (const stamps of STAMPS) {
+      const row = conv({ ...stamps, inbox_killed_at: 100 } as any);
+      // Here: one answer, killed wins.
+      expect(classifyRetirement(row)).toBe("killed");
+      // There: the kill flag is orthogonal, so the bucket survives underneath.
+      expect(isSessionKilled(row as any)).toBe(true);
+    }
+    // The concrete reachable case: stash a session, then kill it — killSession
+    // stamps the marker alone and never clears inbox_stashed_at.
+    const stashedThenKilled = conv({ inbox_stashed_at: 100, inbox_killed_at: 200 });
+    expect(classifyRetirement(stashedThenKilled)).toBe("killed");
+    expect(webBucket(stashedThenKilled)).toBe("stashed");
+  });
+});
+
 describe("shouldShowInInbox", () => {
   test("active session with messages → show", () => {
     expect(shouldShowInInbox(conv())).toBe(true);

--- a/packages/convex/convex/inboxFilters.ts
+++ b/packages/convex/convex/inboxFilters.ts
@@ -38,6 +38,47 @@ export function shouldShowInInbox(conv: ConversationDoc): boolean {
   return true;
 }
 
+// The three DISTINCT ways a session leaves the active inbox. They were reported
+// as a single "dismissed" figure back when kill was an event rather than a
+// state, which hid the one difference that matters operationally — whether the
+// agent is still running:
+//   stashed   — hidden from the inbox, agent still ALIVE
+//   dismissed — hidden from the inbox, agent TORN DOWN
+//   killed    — retired; the authoritative marker, and it outranks both
+// Killed takes precedence because the two kill surfaces write different fields:
+// applyHideTransition (cast kill, dismiss→kill) stamps inbox_dismissed_at
+// ALONGSIDE inbox_killed_at, while the killSession command stamps the marker
+// alone. Checking dismissed first would file one user-visible state under two
+// different names depending on which surface did the killing.
+//
+// Dismissed then outranks stashed, matching isSessionStashed in the web's
+// inboxStore ("Dismiss wins: a stashed session that later gets dismissed
+// renders in the Dismissed bucket, never both"). Dismiss is also the stronger
+// claim: it means the agent was torn down, so a stash stamp that survives it is
+// stale history, and calling such a row "stashed" would assert a live agent
+// there isn't one.
+//
+// SCOPE OF THAT AGREEMENT — it holds for UNKILLED rows only, and the difference
+// is deliberate. The web models this as two ORTHOGONAL axes: a bucket
+// (active | dismissed | stashed) plus an independent isSessionKilled flag, so a
+// killed row still carries whichever bucket its hide stamps imply. This is a
+// SINGLE-AXIS partition, because its job is counting: every row must land in
+// exactly one tally or the figures overlap. The two therefore agree on every
+// combination with no kill marker and diverge on every one with it — e.g. a
+// stashed-then-killed row (killSession stamps the marker alone and never clears
+// inbox_stashed_at) is "killed" here and bucket=stashed + killed=true there.
+// Same facts, different projection; neither is wrong, and inboxFilters.test.ts
+// cross-checks the unkilled rows against the real web helpers so this stays
+// true rather than merely asserted.
+export type RetirementState = "killed" | "dismissed" | "stashed";
+
+export function classifyRetirement(conv: ConversationDoc): RetirementState | null {
+  if (conv.inbox_killed_at) return "killed";
+  if (conv.inbox_dismissed_at) return "dismissed";
+  if (conv.inbox_stashed_at) return "stashed";
+  return null;
+}
+
 // Whether `parent` is a conversation an orchestration worker can safely be
 // nested under at spawn time. We only stamp a worker's parent_conversation_id
 // when this holds, because listInboxSessions surfaces a child *only* under a

--- a/packages/convex/convex/managedSessions.listActive.test.ts
+++ b/packages/convex/convex/managedSessions.listActive.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { makeFakeDb } from "./testDb";
+import { performListActiveSessions } from "./managedSessions";
+
+// The /sessions page is the PROCESS/TMUX view, not the inbox. It used to drop
+// every killed row, so killing a session from that page made it vanish
+// instantly — and a teardown that didn't take left the session invisible on the
+// one surface built to catch that, while its tmux and process kept heartbeating.
+// The investigation behind this page started at "why are there 41 tmux sessions
+// but only ~10 in my sidebar?", so hiding rows here defeats its purpose.
+
+const USER = "u".repeat(31) + "a";
+const OTHER = "u".repeat(31) + "b";
+
+function fixtures(convs: Array<Record<string, any>>) {
+  const now = Date.now();
+  return makeFakeDb({
+    managed_sessions: convs.map((c, i) => ({
+      _id: `ms${i}`,
+      session_id: `sess${i}`,
+      conversation_id: c._id,
+      user_id: USER,
+      pid: 100 + i,
+      started_at: now - 60_000,
+      last_heartbeat: now,
+    })),
+    conversations: convs,
+    session_metrics: [],
+    session_insights: [],
+  });
+}
+
+describe("listActiveSessions surfaces killed rows", () => {
+  test("a killed session is LISTED, not dropped", async () => {
+    const db = fixtures([
+      { _id: "conv_killed", user_id: USER, title: "Retired", inbox_killed_at: 111 },
+    ]);
+    const rows = await performListActiveSessions({ db } as any, USER as any);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].conversation_title).toBe("Retired");
+  });
+
+  // The page cannot get this from its listInboxSessions join: computeInbox
+  // Sessions applies shouldShowInInbox unconditionally, which drops a
+  // killed-and-unpinned row — precisely the rows revealed here. So the marker
+  // has to ride the projection or the badge can never render.
+  test("the row carries is_killed so the page needs no join", async () => {
+    const db = fixtures([
+      { _id: "conv_killed", user_id: USER, title: "Retired", inbox_killed_at: 111 },
+    ]);
+    const rows = await performListActiveSessions({ db } as any, USER as any);
+    expect(rows[0].is_killed).toBe(true);
+  });
+
+  test("a live session reports is_killed false, not undefined", async () => {
+    const db = fixtures([{ _id: "conv_live", user_id: USER, title: "Working" }]);
+    const rows = await performListActiveSessions({ db } as any, USER as any);
+    expect(rows[0].is_killed).toBe(false);
+  });
+
+  // Conversation-less tmux-only rows are listed too; they must not read as killed.
+  test("a session with no conversation reports is_killed false", async () => {
+    const db = makeFakeDb({
+      managed_sessions: [{
+        _id: "ms_bare", session_id: "sess_bare", user_id: USER,
+        pid: 1, started_at: Date.now(), last_heartbeat: Date.now(),
+      }],
+      conversations: [], session_metrics: [], session_insights: [],
+    });
+    const rows = await performListActiveSessions({ db } as any, USER as any);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].is_killed).toBe(false);
+  });
+
+  test("killed and live sessions are listed side by side", async () => {
+    const db = fixtures([
+      { _id: "conv_killed", user_id: USER, title: "Retired", inbox_killed_at: 111 },
+      { _id: "conv_live", user_id: USER, title: "Working" },
+    ]);
+    const rows = await performListActiveSessions({ db } as any, USER as any);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r: any) => r.is_killed).sort()).toEqual([false, true]);
+  });
+
+  // The 24h last_heartbeat cutoff stays the ONLY bound on the reveal: a session
+  // whose teardown succeeded stops beating and ages out on its own, so killed
+  // rows cannot accumulate indefinitely. (The fake db treats .gte as a no-op, so
+  // this pins the user scope rather than the cutoff arithmetic.)
+  test("the scan stays scoped to the calling user", async () => {
+    const db = fixtures([
+      { _id: "conv_killed", user_id: USER, title: "Retired", inbox_killed_at: 111 },
+    ]);
+    const rows = await performListActiveSessions({ db } as any, OTHER as any);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/convex/convex/managedSessions.ts
+++ b/packages/convex/convex/managedSessions.ts
@@ -1,4 +1,5 @@
 import { mutation, query, internalMutation } from "./functions";
+import type { QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { verifyApiToken } from "./apiTokens";
@@ -841,120 +842,140 @@ export const reportMetrics = mutation({
   },
 });
 
+// The row set behind the /sessions page. Split from the query wrapper (like
+// performRegisterManagedSession) so the projection is testable without auth.
+export async function performListActiveSessions(ctx: { db: QueryCtx["db"] }, userId: Id<"users">) {
+  const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+  const sessions = await ctx.db
+    .query("managed_sessions")
+    .withIndex("by_user_heartbeat", (q: any) =>
+      q.eq("user_id", userId).gte("last_heartbeat", cutoff)
+    )
+    .collect();
+
+  const results = [];
+  for (const session of sessions) {
+    let conversationTitle: string | undefined;
+    let projectPath: string | undefined;
+    let agentType: string | undefined;
+    let messageCount: number | undefined;
+    let conversationStatus: string | undefined;
+    let model: string | undefined;
+    let gitBranch: string | undefined;
+    let worktreeName: string | undefined;
+    let headline: string | undefined;
+    let isSubagent: boolean | undefined;
+    let conversationUpdatedAt: number | undefined;
+    let lastMessagePreview: string | undefined;
+    let lastMessageRole: string | undefined;
+    let isKilled = false;
+
+    if (session.conversation_id) {
+      const conv = await ctx.db.get(session.conversation_id);
+      if (conv) {
+        // Killed rows are LISTED, not skipped. This is the process/tmux view,
+        // not the inbox: hiding a retired row here means killing from
+        // /sessions makes it vanish instantly, so a teardown that didn't take
+        // leaves the session invisible on the one surface built to catch that
+        // — while its tmux and process may still be alive and heartbeating.
+        // The 24h last_heartbeat cutoff above is the bound: a session whose
+        // teardown succeeded stops beating and ages out on its own.
+        isKilled = !!conv.inbox_killed_at;
+        conversationTitle = conv.title;
+        projectPath = conv.project_path;
+        agentType = conv.agent_type;
+        messageCount = conv.message_count;
+        conversationStatus = conv.status;
+        model = conv.model;
+        gitBranch = conv.git_branch;
+        worktreeName = conv.worktree_name;
+        isSubagent = conv.is_subagent;
+        // updated_at moves on real conversation activity (messages, status) but
+        // NOT on idle heartbeats or metrics writes — the honest "last active"
+        // signal. The preview/role give every row something identifiable even
+        // when no insight headline exists (common for short/dead sessions).
+        conversationUpdatedAt = conv.updated_at;
+        lastMessagePreview = conv.last_message_preview;
+        lastMessageRole = conv.last_message_role;
+
+        const insight = await ctx.db
+          .query("session_insights")
+          .withIndex("by_conversation_id", (q: any) => q.eq("conversation_id", session.conversation_id))
+          .order("desc")
+          .first();
+        if (insight) {
+          headline = insight.headline || insight.summary?.slice(0, 120);
+        }
+      }
+    }
+
+    // The current_* copies on the registry doc are throttled to a ~5min write
+    // (SNAPSHOT_THROTTLE_MS in reportMetrics) to keep listInboxSessions' read
+    // set stable. That staleness is fine for the inbox but wrong for this
+    // monitoring view, which sorts and sums these numbers. Read the freshest
+    // time-series sample instead (≤30s old for active sessions, ≤3min for
+    // idle) and prefer it. This page is the ONLY consumer of
+    // listActiveSessions, so the extra per-session read never touches the hot
+    // inbox subscription the throttle exists to protect.
+    const latestMetric = await ctx.db
+      .query("session_metrics")
+      .withIndex("by_session_collected", (q: any) => q.eq("session_id", session.session_id))
+      .order("desc")
+      .first();
+
+    results.push({
+      _id: session._id,
+      session_id: session.session_id,
+      conversation_id: session.conversation_id,
+      pid: session.pid,
+      tmux_session: session.tmux_session,
+      started_at: session.started_at,
+      last_heartbeat: session.last_heartbeat,
+      agent_status: session.agent_status,
+      agent_status_updated_at: session.agent_status_updated_at,
+      permission_mode: session.permission_mode,
+      // Prefer the freshest sample; fall back to the throttled snapshot only
+      // when no time-series row survives the 2h retention (e.g. long-idle).
+      current_cpu: latestMetric?.cpu ?? session.current_cpu,
+      current_memory: latestMetric?.memory ?? session.current_memory,
+      current_pid_count: latestMetric?.pid_count ?? session.current_pid_count,
+      agent_pid: session.agent_pid,
+      awake_idle_ms: session.awake_idle_ms,
+      // Honest "as of" for the displayed metrics: the sample time, not the
+      // throttled snapshot time.
+      last_metrics_at: latestMetric?.collected_at ?? session.last_metrics_at,
+      conversation_title: conversationTitle,
+      project_path: projectPath,
+      agent_type: agentType,
+      message_count: messageCount,
+      conversation_status: conversationStatus,
+      model,
+      git_branch: gitBranch,
+      worktree_name: worktreeName,
+      headline,
+      is_subagent: isSubagent,
+      conversation_updated_at: conversationUpdatedAt,
+      last_message_preview: lastMessagePreview,
+      last_message_role: lastMessageRole,
+      // Authoritative killed state for the page, straight off the row. The
+      // page's triage join (listInboxSessions) CANNOT supply it: that query
+      // applies shouldShowInInbox unconditionally, which drops a killed-and-
+      // unpinned row — exactly the rows revealed here. Same reason it beats the
+      // join for the subagent/orphan rows that filter also drops. The
+      // conversation doc is already fetched above, so this costs no extra read.
+      is_killed: isKilled,
+    });
+  }
+
+  return results;
+}
+
 export const listActiveSessions = query({
   args: {},
   handler: async (ctx) => {
     const userId = await getAuthUserId(ctx as any);
     if (!userId) throw new Error("Not authenticated");
-
-    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
-    const sessions = await ctx.db
-      .query("managed_sessions")
-      .withIndex("by_user_heartbeat", (q: any) =>
-        q.eq("user_id", userId).gte("last_heartbeat", cutoff)
-      )
-      .collect();
-
-    const results = [];
-    for (const session of sessions) {
-      let conversationTitle: string | undefined;
-      let projectPath: string | undefined;
-      let agentType: string | undefined;
-      let messageCount: number | undefined;
-      let conversationStatus: string | undefined;
-      let model: string | undefined;
-      let gitBranch: string | undefined;
-      let worktreeName: string | undefined;
-      let headline: string | undefined;
-      let isSubagent: boolean | undefined;
-      let conversationUpdatedAt: number | undefined;
-      let lastMessagePreview: string | undefined;
-      let lastMessageRole: string | undefined;
-
-      if (session.conversation_id) {
-        const conv = await ctx.db.get(session.conversation_id);
-        if (conv) {
-          if (conv.inbox_killed_at) continue;
-          conversationTitle = conv.title;
-          projectPath = conv.project_path;
-          agentType = conv.agent_type;
-          messageCount = conv.message_count;
-          conversationStatus = conv.status;
-          model = conv.model;
-          gitBranch = conv.git_branch;
-          worktreeName = conv.worktree_name;
-          isSubagent = conv.is_subagent;
-          // updated_at moves on real conversation activity (messages, status) but
-          // NOT on idle heartbeats or metrics writes — the honest "last active"
-          // signal. The preview/role give every row something identifiable even
-          // when no insight headline exists (common for short/dead sessions).
-          conversationUpdatedAt = conv.updated_at;
-          lastMessagePreview = conv.last_message_preview;
-          lastMessageRole = conv.last_message_role;
-
-          const insight = await ctx.db
-            .query("session_insights")
-            .withIndex("by_conversation_id", (q: any) => q.eq("conversation_id", session.conversation_id))
-            .order("desc")
-            .first();
-          if (insight) {
-            headline = insight.headline || insight.summary?.slice(0, 120);
-          }
-        }
-      }
-
-      // The current_* copies on the registry doc are throttled to a ~5min write
-      // (SNAPSHOT_THROTTLE_MS in reportMetrics) to keep listInboxSessions' read
-      // set stable. That staleness is fine for the inbox but wrong for this
-      // monitoring view, which sorts and sums these numbers. Read the freshest
-      // time-series sample instead (≤30s old for active sessions, ≤3min for
-      // idle) and prefer it. This page is the ONLY consumer of
-      // listActiveSessions, so the extra per-session read never touches the hot
-      // inbox subscription the throttle exists to protect.
-      const latestMetric = await ctx.db
-        .query("session_metrics")
-        .withIndex("by_session_collected", (q: any) => q.eq("session_id", session.session_id))
-        .order("desc")
-        .first();
-
-      results.push({
-        _id: session._id,
-        session_id: session.session_id,
-        conversation_id: session.conversation_id,
-        pid: session.pid,
-        tmux_session: session.tmux_session,
-        started_at: session.started_at,
-        last_heartbeat: session.last_heartbeat,
-        agent_status: session.agent_status,
-        agent_status_updated_at: session.agent_status_updated_at,
-        permission_mode: session.permission_mode,
-        // Prefer the freshest sample; fall back to the throttled snapshot only
-        // when no time-series row survives the 2h retention (e.g. long-idle).
-        current_cpu: latestMetric?.cpu ?? session.current_cpu,
-        current_memory: latestMetric?.memory ?? session.current_memory,
-        current_pid_count: latestMetric?.pid_count ?? session.current_pid_count,
-        agent_pid: session.agent_pid,
-        awake_idle_ms: session.awake_idle_ms,
-        // Honest "as of" for the displayed metrics: the sample time, not the
-        // throttled snapshot time.
-        last_metrics_at: latestMetric?.collected_at ?? session.last_metrics_at,
-        conversation_title: conversationTitle,
-        project_path: projectPath,
-        agent_type: agentType,
-        message_count: messageCount,
-        conversation_status: conversationStatus,
-        model,
-        git_branch: gitBranch,
-        worktree_name: worktreeName,
-        headline,
-        is_subagent: isSubagent,
-        conversation_updated_at: conversationUpdatedAt,
-        last_message_preview: lastMessagePreview,
-        last_message_role: lastMessageRole,
-      });
-    }
-
-    return results;
+    return performListActiveSessions(ctx, userId);
   },
 });
 

--- a/packages/shared/contracts/agentStatus.test.ts
+++ b/packages/shared/contracts/agentStatus.test.ts
@@ -88,4 +88,32 @@ describe("isLivenessStale", () => {
     // statusless but fresh → trusted
     expect(isLivenessStale({ message_count: 5, updated_at: NOW - 10_000 }, NOW)).toBe(false);
   });
+
+  // A retired row's live-looking fields are never believable, and neither
+  // time-based arm catches the common case: killing a session mid-turn leaves an
+  // ACTIVE agent_status (isQuietSettled bails at once) and kill never touches
+  // updated_at (isStatusTrustStale needs the full hour). ct-41083.
+  it("is stale immediately for a KILLED session that was working when it died", () => {
+    const justKilled = {
+      agent_status: "working", is_idle: false, message_count: 5,
+      updated_at: NOW - 10_000, inbox_killed_at: NOW - 10_000,
+    };
+    expect(isLivenessStale(justKilled, NOW)).toBe(true);
+    // The same row alive is trusted — the kill marker is doing the work here,
+    // not the clock.
+    expect(isLivenessStale({ ...justKilled, inbox_killed_at: undefined }, NOW)).toBe(false);
+  });
+
+  it("needs no clock: a killed row is stale even with a brand-new updated_at", () => {
+    expect(isLivenessStale(
+      { agent_status: "thinking", is_idle: false, message_count: 5, updated_at: NOW, inbox_killed_at: NOW },
+      NOW,
+    )).toBe(true);
+  });
+
+  it("leaves the two time-based arms alone for unkilled rows", () => {
+    // Regression guard: the killed branch must not swallow the existing logic.
+    expect(isLivenessStale({ message_count: 5, updated_at: NOW - 10 * 60 * 1000, inbox_killed_at: null }, NOW)).toBe(true);
+    expect(isLivenessStale({ agent_status: "working", is_idle: false, message_count: 5, updated_at: NOW - 10 * 60 * 1000, inbox_killed_at: null }, NOW)).toBe(false);
+  });
 });

--- a/packages/shared/contracts/agentStatus.ts
+++ b/packages/shared/contracts/agentStatus.ts
@@ -101,6 +101,17 @@ export const AGENT_IDLE_GRACE_MS = 45 * 1000;
 // rows, unmanaged imports — see shouldShowInInbox) escape the WORKING bucket:
 // their liveness fields freeze at the last synced value, but updated_at stays
 // honestly quiet.
+//
+// Killed rows stay on that list, and the two arms divide by whether the client
+// ever RECEIVES the marker. shouldShowInInbox drops `inbox_killed_at &&
+// !inbox_pinned_at` from every query that projects the field, so an UNPINNED
+// killed row never arrives carrying it — the client holds a stale pre-kill copy
+// and these time-based arms remain its only compensation (see the overlay note
+// in convex/conversations.ts). A PINNED killed row does arrive with the marker,
+// and isLivenessStale short-circuits on it there — which this branch could not
+// do anyway: it returns early on any ACTIVE agent_status, and kill never
+// touches updated_at, so a session killed mid-turn would wait out the full
+// trust TTL here.
 export function isQuietSettled(
   s: {
     agent_status?: string | null;
@@ -121,8 +132,17 @@ export function isQuietSettled(
 // is_idle:false) must apply — the inbox bucket, the pulsing dot, the status
 // pill. One predicate so they can never disagree (a needs-input card with a
 // green "working" dot is the historical failure mode). True when the row's
-// liveness can no longer be believed: an active status gone quiet past the 1h
-// trust TTL, or a statusless row quiet past the 45s idle grace.
+// liveness can no longer be believed: the row was RETIRED, an active status has
+// gone quiet past the 1h trust TTL, or a statusless row is quiet past the 45s
+// idle grace.
+//
+// inbox_killed_at is checked first and needs no clock at all: the agent was torn
+// down, so whatever live-looking fields the row still carries are by definition
+// no longer believable. Neither time-based arm catches the common case on its
+// own — killing a session that was mid-turn leaves an ACTIVE agent_status
+// (isQuietSettled bails immediately) and kill never touches updated_at
+// (isStatusTrustStale needs a full hour) — so a torn-down session went on
+// pulsing green for up to an hour.
 export function isLivenessStale(
   s: {
     agent_status?: string | null;
@@ -130,8 +150,10 @@ export function isLivenessStale(
     has_pending?: boolean | null;
     message_count?: number;
     updated_at?: number;
+    inbox_killed_at?: number | null;
   },
   now: number,
 ): boolean {
+  if (s.inbox_killed_at) return true;
   return isStatusTrustStale(s, now) || isQuietSettled(s, now);
 }

--- a/packages/web/app/sessions/page.tsx
+++ b/packages/web/app/sessions/page.tsx
@@ -11,10 +11,9 @@ import { toast } from "sonner";
 import {
   isSessionWaitingForInput,
   isSessionEffectivelyIdle,
-  isSessionDismissed,
-  isSessionHidden,
   type InboxSession,
 } from "../../store/inboxStore";
+import { deriveTriageFlags } from "./triageFlags";
 import { isParkedDispatchError } from "../../store/mutativeMiddleware";
 
 type Session = FunctionReturnType<typeof api.managedSessions.listActiveSessions>[number];
@@ -36,8 +35,15 @@ type ClassifiedSession = Session & {
   lastActiveMs: number;
   // Triage state, joined from listInboxSessions (the same data the inbox uses).
   pinned: boolean;
-  // Hidden from the active inbox for either reason; `killed` narrows to the
-  // destructive flavor (inbox_dismissed_at — agent torn down).
+  // Out of the active inbox for ANY reason — stashed, dismissed, or killed
+  // (the server hides a killed row from listInboxSessions unless it is pinned,
+  // so all three belong to the same "not in the inbox" axis). `killed` narrows
+  // to the destructive flavor, read from the row's own is_killed — projected
+  // off inbox_killed_at, the retired marker every kill surface writes, and NOT
+  // from inbox_dismissed_at, which the killSession mutation behind this page's
+  // own kill button never sets. It comes off the ROW because the inbox join
+  // structurally cannot carry it for an unpinned killed session (see
+  // deriveTriageFlags).
   dismissed: boolean;
   killed: boolean;
   needsInput: boolean;
@@ -355,8 +361,7 @@ function SessionsView() {
 
       const inbox = s.conversation_id ? inboxById.get(String(s.conversation_id)) : undefined;
       const pinned = !!inbox?.is_pinned;
-      const dismissed = inbox ? isSessionHidden(inbox) : false;
-      const killed = inbox ? isSessionDismissed(inbox) : false;
+      const { killed, dismissed } = deriveTriageFlags(inbox, s.is_killed);
       let needsInput = false;
       let workState: WorkState | null = null;
       if (inbox) {
@@ -481,8 +486,14 @@ function SessionsView() {
     (s: ClassifiedSession) => {
       if (!s.conversation_id) return;
       markBusy(s.session_id);
+      // Restore clears the retired marker too, or a row killed by THIS page's
+      // kill button (convCommand("killSession"), the one surface that stamps
+      // inbox_killed_at without inbox_dismissed_at) would keep its "restore"
+      // button forever while shouldShowInInbox went on hiding it. Nulling all
+      // three is what `cast undismiss` does, and it is the un-kill SHAPE the
+      // dispatch rail requires before it will honor a kill-clear (dispatch.ts).
       patchConversation(s.conversation_id, s.dismissed
-        ? { inbox_dismissed_at: null, inbox_stashed_at: null }
+        ? { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_killed_at: null }
         : { inbox_stashed_at: Date.now() });
     },
     [patchConversation, markBusy]

--- a/packages/web/app/sessions/triageFlags.test.ts
+++ b/packages/web/app/sessions/triageFlags.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { deriveTriageFlags } from "./triageFlags";
+import type { InboxSession } from "../../store/inboxStore";
+
+// The defect ct-41083 is named for: /sessions derived `killed` from
+// inbox_dismissed_at, a field the killSession mutation behind this page's own
+// kill button never writes. (`cast kill` and the web inbox's kill action do
+// write it — they were never the gap.)
+type Row = Pick<InboxSession, "inbox_killed_at" | "inbox_dismissed_at" | "inbox_stashed_at">;
+
+const row = (extra: Partial<Row> = {}): Row => ({
+  inbox_killed_at: null,
+  inbox_dismissed_at: null,
+  inbox_stashed_at: null,
+  ...extra,
+});
+
+describe("deriveTriageFlags", () => {
+  it("reports a killed+pinned row (the only killed shape the inbox join delivers) as killed", () => {
+    expect(deriveTriageFlags(row({ inbox_killed_at: 1_000 }))).toEqual({ killed: true, dismissed: true });
+  });
+
+  it("reports killed from the managed-session row flag, with no inbox join at all", () => {
+    // The unpinned killed case: shouldShowInInbox drops it from the inbox
+    // query, so the row flag is the ONLY source that can report it.
+    expect(deriveTriageFlags(undefined, true)).toEqual({ killed: true, dismissed: true });
+  });
+
+  it("reports killed when the row flag is set even though the inbox join says nothing", () => {
+    expect(deriveTriageFlags(row(), true)).toEqual({ killed: true, dismissed: true });
+  });
+
+  it("does NOT call a dismissed-but-alive row killed", () => {
+    // The auto-tidy paths (agentTasks.ts) patch inbox_dismissed_at with no
+    // teardown at all — those agents are alive and must not read as killed.
+    expect(deriveTriageFlags(row({ inbox_dismissed_at: 1_000 }))).toEqual({ killed: false, dismissed: true });
+  });
+
+  it("does NOT call a stashed row killed — stash keeps the agent running", () => {
+    expect(deriveTriageFlags(row({ inbox_stashed_at: 1_000 }))).toEqual({ killed: false, dismissed: true });
+  });
+
+  it("leaves an ordinary live row untouched on both axes", () => {
+    expect(deriveTriageFlags(row())).toEqual({ killed: false, dismissed: false });
+    expect(deriveTriageFlags(undefined)).toEqual({ killed: false, dismissed: false });
+    expect(deriveTriageFlags(row(), false)).toEqual({ killed: false, dismissed: false });
+  });
+
+  it("keeps dismissed true whenever killed is true, so the badge always renders", () => {
+    // The badge is gated on `dismissed` and only then picks its killed/stashed
+    // label — a killed row with dismissed:false would render NO badge at all.
+    for (const input of [
+      deriveTriageFlags(row({ inbox_killed_at: 1 })),
+      deriveTriageFlags(undefined, true),
+      deriveTriageFlags(row({ inbox_killed_at: 1, inbox_stashed_at: 2 })),
+    ]) {
+      expect(input.killed).toBe(true);
+      expect(input.dismissed).toBe(true);
+    }
+  });
+});

--- a/packages/web/app/sessions/triageFlags.ts
+++ b/packages/web/app/sessions/triageFlags.ts
@@ -1,0 +1,32 @@
+import { isSessionHidden, isSessionKilled, type InboxSession } from "../../store/inboxStore";
+
+// The /sessions triage derivation, extracted from the page's classification
+// useMemo so it can be tested without mounting the component. ct-41083.
+//
+// `killed` has an AUTHORITATIVE source and a fallback:
+//
+//   - `rowKilled` — listActiveSessions projects `is_killed` as
+//     `!!conv.inbox_killed_at` straight off the conversation doc, before and
+//     independent of any inbox filtering. It therefore covers every killed row,
+//     pinned or not, and is the only source that can report an UNPINNED one.
+//   - the inbox join (`inbox_killed_at`) — a strict subset: shouldShowInInbox
+//     (convex/inboxFilters.ts) drops `inbox_killed_at && !inbox_pinned_at`
+//     unconditionally, above the `show_all` branch, so the join can only ever
+//     deliver a killed row that is PINNED.
+//
+// The join term is kept as belt-and-braces, not because it is load-bearing: it
+// costs nothing, is covered by the tests below, and keeps this correct if a
+// future projection change drops the row flag. `rowKilled` stays optional so
+// callers without a projected flag still get the fallback behavior.
+//
+// `dismissed` means "out of the active inbox" on ANY axis — stashed, dismissed,
+// or killed — because that is what the server means: shouldShowInInbox hides a
+// killed row just as the hide stamps hide the other two. The per-row badge then
+// uses `killed` to name which flavor it is.
+export function deriveTriageFlags(
+  inbox: Pick<InboxSession, "inbox_killed_at" | "inbox_dismissed_at" | "inbox_stashed_at"> | undefined,
+  rowKilled?: boolean,
+): { killed: boolean; dismissed: boolean } {
+  const killed = !!rowKilled || (!!inbox && isSessionKilled(inbox));
+  return { killed, dismissed: killed || (!!inbox && isSessionHidden(inbox)) };
+}

--- a/packages/web/components/CommandPalette.tsx
+++ b/packages/web/components/CommandPalette.tsx
@@ -1317,7 +1317,7 @@ function CommandPaletteImpl({ standalone = false }: { standalone?: boolean }) {
 
   const navigateToSession = useCallback(
     (
-      conv: { _id: string; session_id?: string; title?: string; updated_at?: number; project_path?: string; git_root?: string; agent_type?: string; message_count?: number; is_idle?: boolean; user_id?: string; authorName?: string | null; authorAvatar?: string | null },
+      conv: { _id: string; session_id?: string; title?: string; updated_at?: number; project_path?: string; git_root?: string; agent_type?: string; message_count?: number; is_idle?: boolean; user_id?: string; authorName?: string | null; authorAvatar?: string | null; inbox_killed_at?: number | null },
       opts?: { messageId?: string; highlight?: string }
     ) => {
       const hash = opts?.messageId ? `#msg-${opts.messageId}` : "";
@@ -1343,6 +1343,13 @@ function CommandPaletteImpl({ standalone = false }: { standalone?: boolean }) {
           message_count: conv.message_count || 0,
           is_idle: conv.is_idle ?? true,
           has_pending: false,
+          // Carry the retired marker or an injected killed row renders alive
+          // (working dot, needs-input bucket) until the next sync corrects it.
+          // Both palette sources supply it: favorites pass whole store rows,
+          // and performListRecentSessions projects the field off the
+          // conversation doc. Unlike is_idle just above, which that projection
+          // still omits — so `?? true` there is always the fallback.
+          inbox_killed_at: conv.inbox_killed_at ?? null,
           // Search/recent results null out author for own sessions, so a present
           // authorName means "not mine" — carry it so the card labels whose it is.
           user_id: conv.user_id,

--- a/packages/web/components/GlobalSessionPanel.tsx
+++ b/packages/web/components/GlobalSessionPanel.tsx
@@ -2987,7 +2987,8 @@ export function SessionListPanel({
 
   // Shared renderer for the two hidden buckets at the bottom of the list —
   // Stashed (set aside, agent alive) above Killed (retired, agent torn down;
-  // the persisted flag keeps its historical name inbox_dismissed_at).
+  // the persisted flag keeps its historical name inbox_dismissed_at, and the
+  // server's kill transition additionally stamps inbox_killed_at).
   // Identical chrome; they differ only in the destructive slot: a stashed card
   // kills (moves down a bucket), a killed card's X removes the row outright.
   // Both hide entirely when empty and render COLLAPSED by default — the
@@ -3651,6 +3652,19 @@ export function SessionListPanel({
           ),
         })}
         {renderHiddenBucket({
+          // "Killed" is honest for what dominates this bucket. It is keyed on
+          // inbox_dismissed_at, and both real kill surfaces write that stamp:
+          // the web's kill action optimistically (hideSessionInDraft mode
+          // "kill"), and `cast kill` durably (cliSetSessionVisibility, which
+          // patches inbox_dismissed_at and then stamps inbox_killed_at via
+          // applyHideTransition). The dismissed reconcile crawl
+          // (collectHiddenSessionsLite) has no shouldShowInInbox filter, so a
+          // `cast kill`ed row keeps arriving here. The non-kill dismissals that
+          // also land here (agentTasks' auto-tidy, dismissStaleInboxSessions)
+          // are the minority — and renaming this to "Dismissed" would mean
+          // pressing Kill, reading a "Killed" toast, and watching the row drop
+          // into "Dismissed". See inboxFilters.ts on why conflating the two
+          // loses the one difference that matters operationally.
           label: "Killed",
           items: filteredDismissed,
           expanded: s.clientState.show_dismissed === true,

--- a/packages/web/components/LivenessDot.tsx
+++ b/packages/web/components/LivenessDot.tsx
@@ -59,6 +59,11 @@ export function sessionLivenessState(session: {
   updated_at?: number;
   agent_status?: string | null;
   has_pending?: boolean;
+  // Declared because isLivenessStale reads it: a retired row's live-looking
+  // fields are never believable. Callers pass whole rows, so it already arrived
+  // at runtime — spelling it out keeps the dependency from resting on
+  // structural typing, and stops a hand-built literal from silently omitting it.
+  inbox_killed_at?: number | null;
 }): LivenessState {
   if (session.session_error) return "error";
   if (session.is_unresponsive) return "unresponsive";

--- a/packages/web/components/livenessDot.test.ts
+++ b/packages/web/components/livenessDot.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { sessionLivenessState } from "./LivenessDot";
+
+// sessionLivenessState defers its "active" decision to isLivenessStale, which
+// now short-circuits on the retired marker. These pin the end-to-end result:
+// killing a session that was mid-turn used to leave the dot pulsing green for
+// up to an hour (kill never touches updated_at, and the quiet-settled arm bails
+// on any ACTIVE agent_status). ct-41083.
+const working = {
+  is_idle: false,
+  message_count: 5,
+  agent_status: "working",
+  updated_at: Date.now(),
+};
+
+describe("sessionLivenessState — killed rows never read active", () => {
+  it("a session killed mid-turn stops pulsing immediately", () => {
+    expect(sessionLivenessState({ ...working, inbox_killed_at: Date.now() })).toBe("idle");
+    // Control: the same row alive is active — the marker is doing the work,
+    // not the clock.
+    expect(sessionLivenessState(working)).toBe("active");
+  });
+
+  it("holds for every ACTIVE status, not just 'working'", () => {
+    for (const agent_status of ["working", "thinking", "compacting", "connected", "starting", "resuming"]) {
+      expect(sessionLivenessState({ ...working, agent_status, inbox_killed_at: 1 })).toBe("idle");
+      expect(sessionLivenessState({ ...working, agent_status })).toBe("active");
+    }
+  });
+
+  it("leaves the error / unresponsive / pinned branches ahead of it alone", () => {
+    expect(sessionLivenessState({ ...working, inbox_killed_at: 1, session_error: "boom" })).toBe("error");
+    expect(sessionLivenessState({ ...working, inbox_killed_at: 1, is_unresponsive: true })).toBe("unresponsive");
+    expect(sessionLivenessState({ ...working, is_idle: true, is_pinned: true, inbox_killed_at: 1 })).toBe("pinned");
+  });
+
+  it("a killed row with no messages is still 'new', not 'idle'", () => {
+    expect(sessionLivenessState({ ...working, message_count: 0, inbox_killed_at: 1 })).toBe("new");
+  });
+});

--- a/packages/web/components/triggerTasks.test.ts
+++ b/packages/web/components/triggerTasks.test.ts
@@ -402,6 +402,26 @@ describe("loop and subagent pseudo rows", () => {
     expect(stashed.absorbedIds.has("home")).toBe(false);
   });
 
+  // The killSession mutation (the web's convCommand path) stamps
+  // inbox_killed_at WITHOUT inbox_dismissed_at, so a home killed that way kept
+  // a loop row for a harness that no longer exists. Stash must still keep its
+  // row — it is the standing-loop home, which is why this gate deliberately
+  // isn't isSessionHidden. ct-41083.
+  it("killing the home retires its loop row too, while stash still keeps it", () => {
+    const killed = partitionTriggerInbox(
+      undefined,
+      { home: session("home", { loop_state: loop(), inbox_killed_at: NOW }) },
+      { now: NOW },
+    );
+    expect(killed.rows).toHaveLength(0);
+    const stashed = partitionTriggerInbox(
+      undefined,
+      { home: session("home", { loop_state: loop(), inbox_stashed_at: NOW }) },
+      { now: NOW },
+    );
+    expect(stashed.rows).toHaveLength(1);
+  });
+
   it("the focused home is never absorbed", () => {
     const p = partitionTriggerInbox(undefined, { home: session("home", { loop_state: loop() }) }, { now: NOW, focusedId: "home" });
     expect(p.rows).toHaveLength(1);

--- a/packages/web/components/triggerTasks.ts
+++ b/packages/web/components/triggerTasks.ts
@@ -374,7 +374,12 @@ export function partitionTriggerInbox(
     if (!loop || !isLoopFresh(loop, now)) continue;
     // Dismiss/kill retires the session AND its loop (the harness dies with the
     // tmux); a stashed home keeps its row — stash is the standing-loop home.
-    if (sess.inbox_dismissed_at) continue;
+    // Deliberately NOT isSessionHidden: that folds in stashed, which this loop
+    // must keep. inbox_killed_at is the other half of "retired" — the
+    // killSession mutation (the web's convCommand path) stamps it WITHOUT
+    // inbox_dismissed_at, so a session killed that way kept a loop row for a
+    // harness that no longer exists.
+    if (sess.inbox_dismissed_at || sess.inbox_killed_at) continue;
     loopRowIds.add(sess._id);
     rows.push({ task: loopTaskRow(sess, loop), openId: sess._id, unread: false, kind: "loop" });
     if (loop.status === "armed" && (nextRunAt === undefined || loop.wakeup_at < nextRunAt)) {

--- a/packages/web/hooks/__tests__/forkTreeBuilder.test.ts
+++ b/packages/web/hooks/__tests__/forkTreeBuilder.test.ts
@@ -165,3 +165,36 @@ describe("buildForkFamily — labels & counts", () => {
     expect(branchDisplayCount(a)).toBe(12); // 50 - 38
   });
 });
+
+// A retired branch owes no attention. liveOf reads awaiting_input /
+// permission_blocked / pending_api_error RAW, so without a killed guard a
+// torn-down branch went on glowing amber for blockers that died with its agent.
+// Exercised through buildForkFamily (liveOf is private) — the real path. ct-41083.
+describe("buildForkFamily — killed branches never glow needs_input", () => {
+  const conv: ForkConversationLike = { _id: "root", forked_from: null, message_count: 10, started_at: 1 };
+
+  function liveFor(extra: Record<string, any>) {
+    const sessions = {
+      root: sess("root", null, { started_at: 1 }),
+      kid: sess("kid", "root", { started_at: 2, ...extra }),
+    };
+    return buildForkFamily(conv, sessions).find((n) => n.id === "kid")!.live;
+  }
+
+  test("a killed branch with a frozen open poll reads idle, not needs_input", () => {
+    expect(liveFor({ awaiting_input: true, inbox_killed_at: 1_000 })).toBe("idle");
+    expect(liveFor({ awaiting_input: true })).toBe("needs_input");
+  });
+
+  test("likewise for a frozen permission prompt and an auth banner", () => {
+    expect(liveFor({ agent_status: "permission_blocked", inbox_killed_at: 1_000 })).toBe("idle");
+    expect(liveFor({ pending_api_error: true, inbox_killed_at: 1_000 })).toBe("idle");
+    expect(liveFor({ agent_status: "permission_blocked" })).toBe("needs_input");
+    expect(liveFor({ pending_api_error: true })).toBe("needs_input");
+  });
+
+  test("a killed branch that still claims to be working reads idle", () => {
+    expect(liveFor({ is_idle: false, agent_status: "working", inbox_killed_at: 1_000 })).toBe("idle");
+    expect(liveFor({ is_idle: false, agent_status: "working" })).toBe("working");
+  });
+});

--- a/packages/web/hooks/__tests__/useSyncInboxSessions.test.ts
+++ b/packages/web/hooks/__tests__/useSyncInboxSessions.test.ts
@@ -56,4 +56,50 @@ describe("shouldPlayWaitingSound", () => {
     expect(result.play).toBe(false);
     expect(notified.get("conv1")).toBe("conv1:5:permission_blocked");
   });
+
+  // This sound and the server's needs-input push (convex/notifications.ts
+  // checkNeedsInput) are documented mirrors. The server stands down on a killed
+  // row via classifyWorkState's `killed` precedence; so must this. ct-41083.
+  it("stays silent for a KILLED session that would otherwise chime", () => {
+    const notified = new Map<string, string>();
+
+    let result = apply([{ ...baseSession, agent_status: "working", awaiting_input: false, inbox_killed_at: 900 }], null, notified);
+    result = apply([{ ...baseSession, agent_status: "working", awaiting_input: true, inbox_killed_at: 900 }], result.nextWaiting, notified);
+    expect(result.play).toBe(false);
+    expect(notified.has("conv1")).toBe(false);
+  });
+
+  it("still chimes for the equivalent LIVE session (the killed case isn't silencing everything)", () => {
+    const notified = new Map<string, string>();
+
+    let result = apply([{ ...baseSession, agent_status: "working", awaiting_input: false }], null, notified);
+    result = apply([{ ...baseSession, agent_status: "working", awaiting_input: true }], result.nextWaiting, notified);
+    expect(result.play).toBe(true);
+  });
+
+  // The server bails on `inbox_dismissed_at || inbox_stashed_at` outright
+  // (notifications.ts checkNeedsInput) and these two are documented mirrors, so
+  // a set-aside session must not chime either. Behavior change: stashed
+  // sessions used to chime here.
+  it("stays silent for a STASHED session, matching the server's stand-down", () => {
+    const notified = new Map<string, string>();
+
+    let result = apply([{ ...baseSession, agent_status: "working", awaiting_input: false, inbox_stashed_at: 900 }], null, notified);
+    result = apply([{ ...baseSession, agent_status: "working", awaiting_input: true, inbox_stashed_at: 900 }], result.nextWaiting, notified);
+    expect(result.play).toBe(false);
+    expect(notified.has("conv1")).toBe(false);
+  });
+
+  // Killed rows leave nextWaiting entirely (the `continue`), so a revival is
+  // re-observed from scratch — no chime for a waiting episode that began while
+  // the session was retired. Same shape as the dismiss path.
+  it("does not chime on the sync right after a killed-and-waiting session is revived", () => {
+    const notified = new Map<string, string>();
+
+    let result = apply([{ ...baseSession, agent_status: "working", awaiting_input: true, inbox_killed_at: 900 }], null, notified);
+    expect(result.nextWaiting.has("conv1")).toBe(false);
+
+    result = apply([{ ...baseSession, agent_status: "working", awaiting_input: true }], result.nextWaiting, notified);
+    expect(result.play).toBe(false);
+  });
 });

--- a/packages/web/hooks/useForkTree.ts
+++ b/packages/web/hooks/useForkTree.ts
@@ -119,6 +119,11 @@ function localBranchLabel(
 // session counts as needs_input, but a map where every done branch glows amber
 // says nothing. Amber here = the agent is actually blocked on you.
 function liveOf(s: InboxSession): BranchLive {
+  // A retired branch is done, whatever its frozen blockers still say. Without
+  // this the raw reads below light a killed branch amber for a poll or
+  // permission prompt that died with the agent — the map's whole job is to show
+  // where attention is owed, and a torn-down branch owes none.
+  if (s.inbox_killed_at) return "idle";
   if (!isSessionEffectivelyIdle(s)) return "working";
   if (s.awaiting_input || s.agent_status === "permission_blocked" || s.pending_api_error) {
     return "needs_input";

--- a/packages/web/hooks/useSyncInboxSessions.ts
+++ b/packages/web/hooks/useSyncInboxSessions.ts
@@ -65,7 +65,16 @@ export function shouldPlayWaitingSound(
   const nextWaiting = new Map<string, boolean>();
 
   for (const session of sessions) {
-    if (session.inbox_dismissed_at) continue;
+    // Stand down on every TRIAGED row — the full set the server stands down on.
+    // This sound and the needs-input push (convex/notifications.ts
+    // checkNeedsInput) are deliberate mirrors: the server bails on
+    // `inbox_dismissed_at || inbox_stashed_at` outright, and on a killed row via
+    // classifyWorkState's `killed` precedence. Setting a session aside is the
+    // user saying "not now" whichever gesture they used, so all three belong
+    // here. `continue` rather than a falsy key on purpose: leaving the id out of
+    // nextWaiting makes a later revival re-observe the session fresh, so no
+    // chime fires for a waiting episode that began while it was set aside.
+    if (session.inbox_dismissed_at || session.inbox_stashed_at || session.inbox_killed_at) continue;
     const id = session._id.toString();
     const key = isSub(session) ? null : waitingSoundKey(session, queued);
     nextWaiting.set(id, !!key);

--- a/packages/web/store/__tests__/killedState.test.ts
+++ b/packages/web/store/__tests__/killedState.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  isSessionDismissed,
+  isSessionHardBlocked,
+  isSessionHidden,
+  isSessionKilled,
+  isSessionEffectivelyIdle,
+  isSessionWaitingForInput,
+  useInboxStore,
+  type InboxSession,
+} from "../inboxStore";
+
+// inbox_killed_at is the authoritative "this session is retired" marker, and the
+// server's classifyWorkState (convex/inboxFilters.ts) gives it precedence over
+// every other signal. These cover the web's copies of that derivation, which
+// used to read inbox_dismissed_at (a DIFFERENT field — the command kill surfaces
+// never write it) or nothing at all, so the same session read "killed" to
+// `cast sessions` and "working" to the web. See ct-41083.
+
+const REAL_A = "a".repeat(32);
+
+function session(id: string, extra: Partial<InboxSession> = {}): InboxSession {
+  return {
+    _id: id,
+    session_id: `sess-${id}`,
+    updated_at: 1,
+    agent_type: "claude_code",
+    message_count: 3,
+    is_idle: true,
+    has_pending: false,
+    ...extra,
+  } as InboxSession;
+}
+
+// How a kill arrives from the killSession MUTATION — the web's
+// convCommand("killSession"): the /sessions kill button and the panel's
+// kill-and-complete. It stamps inbox_killed_at alone; nothing stamps
+// inbox_dismissed_at, which is why reading that field to answer "is this
+// killed?" silently missed every one of them. (`cast kill` and the web's own
+// kill action write BOTH stamps, so those rows were never the gap.)
+function killed(extra: Partial<InboxSession> = {}): InboxSession {
+  return session(REAL_A, { inbox_killed_at: 1_000, ...extra });
+}
+
+describe("isSessionKilled", () => {
+  it("reports a command-killed row killed — inbox_dismissed_at says nothing about it", () => {
+    const s = killed();
+    expect(isSessionKilled(s)).toBe(true);
+    // The predicate /sessions used to call for its `killed` column:
+    expect(isSessionDismissed(s)).toBe(false);
+    expect(isSessionHidden(s)).toBe(false);
+  });
+
+  it("does not call an ordinary stashed or dismissed row killed", () => {
+    expect(isSessionKilled(session(REAL_A, { inbox_stashed_at: 5 }))).toBe(false);
+    expect(isSessionKilled(session(REAL_A, { inbox_dismissed_at: 5 }))).toBe(false);
+  });
+});
+
+describe("killed precedence in the shared classifiers", () => {
+  it("a killed row is effectively idle even while its agent_status still says working", () => {
+    expect(isSessionEffectivelyIdle(killed({ agent_status: "working", is_idle: false }))).toBe(true);
+    // Control: the same row alive is not idle.
+    expect(isSessionEffectivelyIdle(session(REAL_A, { agent_status: "working", is_idle: false }))).toBe(false);
+  });
+
+  it("a killed row is effectively idle even while a server-queued message is pending", () => {
+    expect(isSessionEffectivelyIdle(killed({ has_pending: true, is_idle: false }))).toBe(true);
+  });
+
+  it("a killed row never waits for input — not on an open poll", () => {
+    expect(isSessionWaitingForInput(killed({ awaiting_input: true }))).toBe(false);
+    expect(isSessionWaitingForInput(session(REAL_A, { awaiting_input: true }))).toBe(true);
+  });
+
+  it("a killed row never waits for input — not on a permission block", () => {
+    expect(isSessionWaitingForInput(killed({ agent_status: "permission_blocked" }))).toBe(false);
+    expect(isSessionWaitingForInput(session(REAL_A, { agent_status: "permission_blocked" }))).toBe(true);
+  });
+
+  it("a killed row never waits for input — not on an unresolved auth banner", () => {
+    expect(isSessionWaitingForInput(killed({ pending_api_error: true }))).toBe(false);
+    expect(isSessionWaitingForInput(session(REAL_A, { pending_api_error: true }))).toBe(true);
+  });
+
+  it("a killed row never waits for input — not as a dead agent with output", () => {
+    expect(isSessionWaitingForInput(killed({ agent_status: "stopped" }))).toBe(false);
+    expect(isSessionWaitingForInput(session(REAL_A, { agent_status: "stopped" }))).toBe(true);
+  });
+
+  it("a killed row never waits for input — not as a plain finished turn", () => {
+    expect(isSessionWaitingForInput(killed({ is_idle: true }))).toBe(false);
+    expect(isSessionWaitingForInput(session(REAL_A, { is_idle: true }))).toBe(true);
+  });
+});
+
+// Pin is an ORDERING gesture, not a revival. The sanctioned revivals are an
+// explicit send, Restart, and undismiss; the server's dispatch rail now drops a
+// kill-clear that isn't itself an un-kill, so an optimistic clear here only
+// rendered a retired row alive until the round-trip put the marker back.
+describe("pin does not un-kill", () => {
+  beforeEach(() => {
+    useInboxStore.setState({
+      sessions: { [REAL_A]: session(REAL_A, { inbox_killed_at: 1_000 }) },
+      conversations: { [REAL_A]: { _id: REAL_A, inbox_killed_at: 1_000 } },
+      pending: {},
+      currentUser: null,
+    } as any);
+  });
+
+  it("pinSession leaves inbox_killed_at intact on the conversation twin", () => {
+    useInboxStore.getState().pinSession(REAL_A);
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].is_pinned).toBe(true);
+    expect((s.conversations[REAL_A] as any).inbox_killed_at).toBe(1_000);
+  });
+
+  it("the cross-window pin bridge likewise leaves inbox_killed_at intact", () => {
+    useInboxStore.getState().applyGestureBridge({
+      kind: "pin", id: REAL_A, pinned: true, pinnedAt: 500, ts: 500,
+    } as any);
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].is_pinned).toBe(true);
+    expect((s.conversations[REAL_A] as any).inbox_killed_at).toBe(1_000);
+  });
+});
+
+// Restore IS a sanctioned revival, and the only one that reaches a row killed
+// through a command (marker set, inbox_dismissed_at unset). The server's un-kill
+// mirror can't help there — it gates on `wasDismissed` — so the client has to
+// clear all three stamps itself or shouldShowInInbox goes on hiding the row.
+describe("restore un-kills", () => {
+  beforeEach(() => {
+    useInboxStore.setState({
+      sessions: {
+        [REAL_A]: session(REAL_A, { inbox_killed_at: 1_000, inbox_dismissed_at: null }),
+      },
+      conversations: {
+        [REAL_A]: { _id: REAL_A, inbox_killed_at: 1_000, inbox_dismissed_at: null },
+      },
+      messages: {},
+      pendingMessages: {},
+      pagination: {},
+      pendingSessionCreates: {},
+      pending: {},
+      currentSessionId: null,
+      viewingDismissedId: null,
+      currentUser: null,
+      clientState: {},
+    } as any);
+  });
+
+  it("restoreSession clears inbox_killed_at on both twins", () => {
+    useInboxStore.getState().restoreSession(REAL_A);
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].inbox_killed_at).toBeNull();
+    expect((s.conversations[REAL_A] as any).inbox_killed_at).toBeNull();
+    expect(isSessionKilled(s.sessions[REAL_A])).toBe(false);
+  });
+
+  it("the cross-window restore receiver clears it too", () => {
+    useInboxStore.getState().applyGestureBridge({
+      kind: "restore", ids: [REAL_A], ts: 9_000,
+    } as any);
+    const s = useInboxStore.getState();
+    expect(s.sessions[REAL_A].inbox_killed_at).toBeNull();
+    expect((s.conversations[REAL_A] as any).inbox_killed_at).toBeNull();
+  });
+});
+
+// isSessionHardBlocked is what pulls an ANCHOR out of its own space and into the
+// inbox (categorizeSessions' hiddenAnchor gate). A killed anchor keeps its
+// frozen awaiting_input / permission_blocked, so without a killed branch it
+// re-escalated forever after teardown.
+describe("isSessionHardBlocked killed precedence", () => {
+  it("a killed session is not hard-blocked by a frozen open poll", () => {
+    expect(isSessionHardBlocked(killed({ awaiting_input: true }))).toBe(false);
+    expect(isSessionHardBlocked(session(REAL_A, { awaiting_input: true }))).toBe(true);
+  });
+
+  it("a killed session is not hard-blocked by a frozen permission prompt", () => {
+    expect(isSessionHardBlocked(killed({ agent_status: "permission_blocked" }))).toBe(false);
+    expect(isSessionHardBlocked(session(REAL_A, { agent_status: "permission_blocked" }))).toBe(true);
+  });
+
+  it("a killed session is not hard-blocked by an auth banner or a dead agent", () => {
+    expect(isSessionHardBlocked(killed({ pending_api_error: true }))).toBe(false);
+    expect(isSessionHardBlocked(killed({ agent_status: "stopped" }))).toBe(false);
+    expect(isSessionHardBlocked(session(REAL_A, { pending_api_error: true }))).toBe(true);
+    expect(isSessionHardBlocked(session(REAL_A, { agent_status: "stopped" }))).toBe(true);
+  });
+
+  it("a killed ANCHOR stops escalating into the active inbox", () => {
+    // categorizeSessions: hiddenAnchor = is_anchor && !isSessionHardBlocked(s).
+    // True here means the anchor stays in its own space, which is the fix.
+    const anchor = killed({ is_anchor: true, awaiting_input: true } as Partial<InboxSession>);
+    expect(!!(anchor as any).is_anchor && !isSessionHardBlocked(anchor)).toBe(true);
+  });
+});

--- a/packages/web/store/inboxStore.ts
+++ b/packages/web/store/inboxStore.ts
@@ -274,6 +274,14 @@ export type InboxSession = {
   // buckets into the Stashed group (above Dismissed) while the agent keeps
   // running. Same absolute-flag semantics as dismiss; a dismiss clears it.
   inbox_stashed_at?: number | null;
+  // The RETIRED marker — the user tore this session down. Set by every kill
+  // surface (`cast kill`, the web killSession command, applyHideTransition's
+  // kill branch) and outranks every other state signal: a killed row is never
+  // "working" and never "waiting for input", however stale its has_pending /
+  // agent_status still are. Cleared only by a sanctioned revival (an explicit
+  // send, Restart, undismiss) — see classifyWorkState in convex/inboxFilters.ts,
+  // whose precedence the client predicates below mirror.
+  inbox_killed_at?: number | null;
   last_user_message?: string | null;
   session_error?: string;
   // True when the session's latest turn is an unresolved Claude Code auth/API
@@ -820,6 +828,19 @@ export function isSessionDismissed(s: Pick<InboxSession, "inbox_dismissed_at">):
   return !!s.inbox_dismissed_at;
 }
 
+// Retired: the agent was torn down. A distinct field from inbox_dismissed_at,
+// not a synonym. Most kills write both — a hide patch carries
+// inbox_dismissed_at and applyHideTransition stamps the marker on top, which
+// covers the web's kill action AND `cast kill` (cliSetSessionVisibility patches
+// inbox_dismissed_at, then forces the kill transition). The exception is the
+// killSession MUTATION (conversations.ts), which stamps inbox_killed_at ALONE:
+// that's the path behind the web's convCommand("killSession") — the /sessions
+// kill button and the panel's kill-and-complete. Anything asking "is this
+// killed?" must read this field or it silently misses those.
+export function isSessionKilled(s: Pick<InboxSession, "inbox_killed_at">): boolean {
+  return !!s.inbox_killed_at;
+}
+
 export function isSessionStashed(
   s: Pick<InboxSession, "inbox_dismissed_at" | "inbox_stashed_at">,
 ): boolean {
@@ -1146,8 +1167,15 @@ export function reconcilePendingSendForSession(
 }
 
 export function isSessionEffectivelyIdle(
-  session: Pick<InboxSession, "is_idle" | "agent_status">,
+  session: Pick<InboxSession, "is_idle" | "agent_status" | "inbox_killed_at">,
 ): boolean {
+  // A KILLED row is retired and outranks every signal below — same precedence
+  // classifyWorkState applies server-side (convex/inboxFilters.ts), which is
+  // what keeps this surface and `cast sessions` telling the same story. It has
+  // to win over the agent_status short-circuit too: a daemon that resurrected
+  // the worker (or simply never cleared its last "working") would otherwise
+  // render the retired row alive.
+  if (session.inbox_killed_at) return true;
   // Daemon-reported ACTIVE statuses are a definitive "working" signal —
   // short-circuit to non-idle for fast UI response when status flips.
   if (isAgentActive(session)) {
@@ -1160,9 +1188,14 @@ export function isSessionEffectivelyIdle(
 }
 
 export function isSessionWaitingForInput(
-  session: Pick<InboxSession, "_id" | "is_idle" | "agent_status" | "message_count" | "is_pinned" | "has_pending" | "awaiting_input" | "is_unresponsive" | "pending_api_error">,
+  session: Pick<InboxSession, "_id" | "is_idle" | "agent_status" | "message_count" | "is_pinned" | "has_pending" | "awaiting_input" | "is_unresponsive" | "pending_api_error" | "inbox_killed_at">,
   sessionsWithQueuedMessages?: Set<string>,
 ): boolean {
+  // Retired: the user already triaged this row, so nothing about it is a claim
+  // on their attention — not a poll left open when the agent was torn down, not
+  // a permission prompt, not a stale has_pending. First, exactly as
+  // classifyWorkState puts `killed` above every other branch.
+  if (session.inbox_killed_at) return false;
   const dead = !!session.agent_status && DEAD_AGENT_STATUSES.has(session.agent_status);
   const canDeliver = !session.is_unresponsive && !dead;
   // A message the user just sent/queued from the client (the durable
@@ -1219,10 +1252,16 @@ export function isSessionWaitingForInput(
 // count as blocked here. No pinned exemption either: placement of pinned rows
 // is the caller's concern (they never leave the Pinned group).
 export function isSessionHardBlocked(
-  session: Pick<InboxSession, "_id" | "agent_status" | "message_count" | "has_pending" | "awaiting_input" | "is_unresponsive" | "pending_api_error">,
+  session: Pick<InboxSession, "_id" | "agent_status" | "message_count" | "has_pending" | "awaiting_input" | "is_unresponsive" | "pending_api_error" | "inbox_killed_at">,
   sessionsWithQueuedMessages?: Set<string>,
 ): boolean {
   if (sessionsWithQueuedMessages?.has(session._id)) return false;
+  // Retired outranks every blocker below, same as in isSessionWaitingForInput
+  // and classifyWorkState. It matters most here because this predicate is what
+  // pulls an ANCHOR out of its own space and into the inbox (categorizeSessions'
+  // hiddenAnchor gate): a killed anchor keeps its frozen awaiting_input /
+  // permission_blocked, so without this it re-escalated forever after teardown.
+  if (session.inbox_killed_at) return false;
   if (session.awaiting_input) return true;
   if (session.pending_api_error && session.message_count > 0) return true;
   if (session.agent_status === "permission_blocked") return session.message_count > 0;
@@ -4048,13 +4087,16 @@ function applyGestureInDraft(draft: any, msg: GestureMessage) {
   }
 
   if (msg.kind === "restore") {
-    // Un-hiding is un-hiding: both flags clear, but only if this window's value
-    // is no newer than the restore (a re-kill here must survive).
+    // Un-hiding is un-hiding: all three flags clear, but only if this window's
+    // value is no newer than the restore (a re-kill here must survive).
+    // inbox_killed_at rides along for the same reason the sender clears it
+    // (restoreSession): a command-killed row carries the marker alone, and a
+    // sibling that cleared only the two hide stamps would go on hiding it.
     for (const sid of msg.ids) {
       // A no-op restore still carries a newer causal tombstone. Without these
-      // locks, a delayed older kill sees two visible nulls and re-applies.
-      acceptTransition(sid, ["inbox_dismissed_at", "inbox_stashed_at"], {
-        shared: { inbox_dismissed_at: null, inbox_stashed_at: null },
+      // locks, a delayed older kill sees visible nulls and re-applies.
+      acceptTransition(sid, ["inbox_dismissed_at", "inbox_stashed_at", "inbox_killed_at"], {
+        shared: { inbox_dismissed_at: null, inbox_stashed_at: null, inbox_killed_at: null },
       });
     }
     return;
@@ -4083,10 +4125,11 @@ function applyGestureInDraft(draft: any, msg: GestureMessage) {
   // undo restores the ORIGINAL pin time, so it cannot be re-derived from ts).
   // Repeated pin messages leave matching rows untouched; an unpin deliberately
   // plants a null tombstone even when the row already appears unpinned.
+  // Touches pin state ONLY: pin is not an un-kill on the sender (pinSession),
+  // so a sibling window must not become one either.
   acceptTransition(msg.id, ["inbox_pinned_at"], {
     shared: { inbox_pinned_at: msg.pinnedAt },
     sessions: { is_pinned: msg.pinned },
-    ...(msg.pinned ? { conversations: { inbox_killed_at: undefined } } : {}),
   });
 }
 
@@ -4378,7 +4421,9 @@ export const useInboxStore = create<InboxStoreState>(
   // transition (dispatch.applyPatches sees inbox_dismissed_at flip), so this
   // action only has to move the rows; every kill path gets the teardown
   // without remembering to ask for it. (The persisted field keeps its
-  // historical name inbox_dismissed_at; the UI calls the bucket "Killed".)
+  // historical name inbox_dismissed_at and the UI calls the bucket "Killed";
+  // the server's kill transition additionally stamps inbox_killed_at, which is
+  // what actually marks the row retired.)
   killSession: action(function (this: Draft, id: string) {
     soundKill();
     announceHide(this, "kill", hideSessionInDraft(this, id, "kill"));
@@ -4631,7 +4676,21 @@ export const useInboxStore = create<InboxStoreState>(
 
 
   // Bring a stashed/dismissed session (and its hidden children) back into the
-  // active inbox. Clears BOTH hide flags — un-hiding is un-hiding.
+  // active inbox. Clears ALL THREE hide flags — un-hiding is un-hiding.
+  //
+  // inbox_killed_at has to go with them. Restore is one of the three sanctioned
+  // revivals (with an explicit send and Restart), and it is the only one that
+  // reaches a row killed through the killSession MUTATION (the web's
+  // convCommand("killSession") — the /sessions kill button and the panel's
+  // kill-and-complete), which stamps the marker WITHOUT inbox_dismissed_at.
+  // (`cast kill` and the web's own kill action both write inbox_dismissed_at
+  // too, so those rows were already covered.) The server's un-kill mirror can't
+  // cover a marker-only row for us: it fires only when the patch clears
+  // inbox_dismissed_at on a row that already had it (dispatch.ts
+  // `wasDismissed`), so it would keep being hidden by shouldShowInInbox no
+  // matter how often the user pressed restore. Clearing all three is also
+  // exactly the un-kill SHAPE the dispatch guard demands before it will honor a
+  // kill-clear at all, and what `cast undismiss` writes.
   restoreSession: action(function (this: Draft, id: string) {
     const now = Date.now();
     const childIds = Object.values(this.sessions as Record<string, InboxSession>)
@@ -4642,11 +4701,13 @@ export const useInboxStore = create<InboxStoreState>(
       if (this.sessions[sid]) {
         this.sessions[sid].inbox_dismissed_at = null;
         this.sessions[sid].inbox_stashed_at = null;
+        this.sessions[sid].inbox_killed_at = null;
       }
       const conv = this.conversations[sid] as any;
       if (conv) {
         conv.inbox_dismissed_at = null;
         conv.inbox_stashed_at = null;
+        conv.inbox_killed_at = null;
       }
     }
     declareViewNav("gesture");
@@ -4678,9 +4739,17 @@ export const useInboxStore = create<InboxStoreState>(
       this.sessions[id].is_pinned = newPinned;
       this.sessions[id].inbox_pinned_at = pinnedAt;
     }
+    // Pin is a pure ORDERING gesture, never a revival: it leaves
+    // inbox_killed_at (as it already leaves inbox_dismissed_at/inbox_stashed_at)
+    // exactly where it is. The sanctioned revivals are an explicit send,
+    // Restart, and undismiss — and the server's dispatch rail now DROPS a
+    // kill-clear that isn't itself an un-kill, so clearing it optimistically
+    // only bought a flicker of a retired row rendering alive until the
+    // round-trip put it back. A killed row stays reachable while pinned:
+    // shouldShowInInbox keeps `inbox_killed_at && inbox_pinned_at` in the inbox
+    // precisely so pinning is how you hold onto one.
     if (this.conversations[id]) {
       (this.conversations[id] as any).inbox_pinned_at = pinnedAt;
-      if (newPinned) (this.conversations[id] as any).inbox_killed_at = undefined;
     }
     // Pin is a TOGGLE read off this window's row, so a sibling that never saw
     // the flip computes the opposite value from its stale row on the next

--- a/packages/web/store/syncProtocol.ts
+++ b/packages/web/store/syncProtocol.ts
@@ -10,12 +10,17 @@ export type PendingEntry = {
 
 // Convex omits optional conversation inbox timestamps when they are clear,
 // while optimistic bridge transitions retain the local `null` spelling.  That
-// is the same server acknowledgement for these three fields only; all other
-// fields keep strict null/undefined semantics.
+// is the same server acknowledgement for these four fields only; all other
+// fields keep strict null/undefined semantics.  inbox_killed_at belongs here
+// for the same reason as the rest: the /sessions restore gesture nulls it
+// (an un-kill patch clears all three stamps), and the server acknowledges by
+// dropping the field — without the equivalence that pending lock would never
+// retire and would keep re-asserting the clear.
 const OPTIONAL_INBOX_TIMESTAMPS = new Set([
   "inbox_dismissed_at",
   "inbox_stashed_at",
   "inbox_pinned_at",
+  "inbox_killed_at",
 ]);
 
 function fieldEchoesPending(field: string, incoming: unknown, pending: unknown): boolean {


### PR DESCRIPTION
Follow-ups to #25 (session-teardown lifecycle): the two defects deferred out of that effort, plus everything the adversarial reviews surfaced around them.

## fix(cli): stop reaping a codex subagent's borrowed parent process

A codex subagent thread runs inside its parent TUI's process, so process discovery resolved it to the parent's pid+tty — and killing **or dismissing** one nested card SIGKILLed the parent agent and every sibling thread (live, reachable from three gestures). Ownership is now a session-level property read from the rollout store directly and classified by structural shape (`thread_spawn` object = borrower; bare `"review"` = a `codex exec` child that owns its pid; unrecognized parent-carrying shapes fail **closed**). `planSessionTeardown` gates both destructive actions at both kill sites; injection deliberately still routes to the parent's pane. Metrics credit one session per pid, borrowers zeroed with idle carry-forward; log ids widen to 13 chars (8 is exactly the UUIDv7 ms prefix, so parent/subagent groups collided by construction).

## fix(web): make the killed marker authoritative on every client surface

`inbox_killed_at` wasn't even declared client-side. Killed now outranks every stale flag in the classifiers (mirroring `classifyWorkState`), the liveness dot, the waiting sound (which now also mirrors the server's stashed stand-down — behavior change: stashed sessions no longer chime), the fork map, and anchor escalation. Pin is a pure ordering gesture (no longer clears the marker); every restore path clears all three stamps — the un-kill shape the dispatch rail requires.

## fix(convex): surface killed sessions where a failed teardown is visible

`/sessions` no longer drops killed rows — killing from that page used to make the row vanish instantly, hiding a failed teardown on the one surface built to catch it. Rows carry `is_killed` off the conversation doc (zero extra reads). `cast sessions` renders killed+pinned rows with a `killed` tag and reports stashed / dismissed / killed as separate tallies (`classifyRetirement`, cross-checked against the real web helpers by test). Restoring a command-killed row re-arms its schedules.

## Verification

- 6 adversarial review rounds (maker ≠ checker throughout); final round: nothing ship-blocking. 9-mutation matrix on the kill-path guards, all caught; ownership classifier at 0/221 misclassifications on the local rollout corpus.
- web 1926/0 · convex 1195/0 · cli 1946 pass with 3 failures, all on the documented known-flaky set (per-name comparison against a pristine-baseline list, not counts).
- Follow-ups filed rather than absorbed: ct-41115, ct-41116, ct-41120, ct-41121, ct-41123, ct-41124, ct-41177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
