### PR TITLE
fix: finish cloud fork imports and compact location labels

### DIFF
--- a/packages/cli/src/daemon.codex-fork-import.test.ts
+++ b/packages/cli/src/daemon.codex-fork-import.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./daemon.ts", import.meta.url), "utf8");
+const start = source.indexOf('if (resumeAgentType === "codex" && (parsed.fork === true || forceReconstitute) && conversationId)');
+const end = source.indexOf("} catch (forkErr)", start);
+const importer = source.slice(start, end);
+
+describe("Codex fork import identity", () => {
+  test("uses a native UUID for temporary metadata, not the virtual conversation session id", () => {
+    expect(start).toBeGreaterThan(0);
+    expect(end).toBeGreaterThan(start);
+    expect(importer).toContain("generateCodexJsonl(exportData, { sessionId: randomUUID() })");
+    expect(importer).toContain('writeCodexSession(jsonl, importSessionId, "codecast-fork")');
+    expect(importer).not.toContain("generateCodexJsonl(exportData, { sessionId })");
+  });
+
+  test("keeps temporary import provenance separate from the final conversation binding", () => {
+    expect(importer).toContain("pendingAppServerForkParents.add(importSessionId)");
+    expect(importer).toContain("pendingForkParentId = importSessionId");
+    expect(importer).toContain("path: importPath");
+    expect(importer).toContain("const realThreadId = forked.thread.id");
+    expect(importer).toContain("remapConversationSession(sessionId, realThreadId, conversationId)");
+    expect(importer).toContain("pushSessionIdBinding(conversationId, realThreadId, cwd");
+  });
+});

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -5477,7 +5477,7 @@ async function executeRemoteCommand(
               result = JSON.stringify({ forked: false, reason: "no_local_checkout" });
               break;
             }
-            const { jsonl, sessionId: importSessionId } = generateCodexJsonl(exportData, { sessionId });
+            const { jsonl, sessionId: importSessionId } = generateCodexJsonl(exportData, { sessionId: randomUUID() });
             const { filePath: importPath } = writeCodexSession(jsonl, importSessionId, "codecast-fork");
             const importBytes = fs.statSync(importPath).size;
             setPosition(importPath, importBytes);

--- a/packages/cli/src/daemonBuildId.ts
+++ b/packages/cli/src/daemonBuildId.ts
@@ -10,4 +10,4 @@
 //
 // This file is excluded from its own hash, and it imports nothing on purpose:
 // the CLI fast path reads it, so it must never pull in a module graph.
-export const DAEMON_BUILD_ID = "c3c7ec8ecc68";
+export const DAEMON_BUILD_ID = "bd5728d96cf6";

--- a/packages/web/components/GlobalSessionPanel.tsx
+++ b/packages/web/components/GlobalSessionPanel.tsx
@@ -39,7 +39,8 @@ import { fmtClock, fmtDuration, describeTaskCadence, isTaskOverdue, taskStateLab
 import { isWatchHostDead, liveWatchRowsFor } from "./monitorRows";
 import { partitionTriggerInbox, groupSessionsByTrigger, taskDisplayTitle, latestLoadedTriggerMessage, type TriggerRow, type TaskRow } from "./triggerTasks";
 import { useTriggers, fetchTriggerRuns } from "../hooks/useSyncTriggers";
-import { DeviceIcon, useRosterDevice, deviceWakesOnUse } from "./DeviceBadge";
+import { DeviceIcon, useRosterDevice, deviceWakesOnUse, deviceDisplayName } from "./DeviceBadge";
+import { SessionWorktreeChip } from "./SessionWorktreeChip";
 import { TriggerRunList, useTriggerRuns, openRunInStore, type TriggerRun } from "./TriggerRunHistory";
 import { cleanUserMessage } from "./sessionMessage";
 import { AgentTypeIcon, formatAgentType } from "./AgentTypeIcon";
@@ -2426,6 +2427,16 @@ export const SessionCard = memo(function SessionCard({
   }, [session._id, displayTitle, project]);
   const handleCardDragEnd = useCallback(() => setIsDraggingCard(false), []);
 
+  const worktreeChip = (session.worktree_name || session.cloud_placement === "pending") ? (
+    <SessionWorktreeChip
+      name={session.worktree_name}
+      branch={session.worktree_branch}
+      preparing={session.cloud_placement === "pending"}
+      hostName={runHost ? deviceDisplayName(runHost) : undefined}
+      hostIcon={runHost ? <DeviceIcon d={runHost} className="w-2.5 h-2.5 shrink-0" /> : undefined}
+    />
+  ) : null;
+
   if (isSubagent) {
     return (
       <div
@@ -2511,6 +2522,7 @@ export const SessionCard = memo(function SessionCard({
               </span>
             </div>
           </div>
+          {worktreeChip && <div className="flex min-w-0 pl-[18px] mt-0.5">{worktreeChip}</div>}
           {stateView && (
             <div className="mt-0.5 flex items-start gap-1" title={stateView.text}>
               <Pin
@@ -2807,22 +2819,7 @@ export const SessionCard = memo(function SessionCard({
               <span className="truncate">{sessionLabel ?? project}</span>
             </span>
           )}
-          {(session.worktree_name || session.cloud_placement === "pending") && (
-            <span
-              data-simple-hide
-              className={`inline-flex items-center gap-1 text-[9px] font-mono truncate max-w-[130px] ${session.cloud_placement === "pending" ? "text-sol-violet animate-pulse" : "text-sol-cyan"}`}
-              title={session.cloud_placement === "pending"
-                ? "Preparing the cloud host — its worktree is being made now."
-                : (session.worktree_branch || session.worktree_name || "")}
-            >
-              {/* The machine only appears when it is a host you would not
-                  otherwise expect — a worktree on your own laptop needs no icon. */}
-              {runHost && <DeviceIcon d={runHost} className="w-2.5 h-2.5 shrink-0" />}
-              <span className="truncate">
-                {session.cloud_placement === "pending" ? "preparing" : session.worktree_name}
-              </span>
-            </span>
-          )}
+          {worktreeChip}
           {showModelBadge && session.model && (
             <span data-simple-hide className="text-[9px] text-sol-text-dim/70 font-mono truncate max-w-[90px] flex-shrink-0" title={session.model}>
               {formatModel(session.model)}

--- a/packages/web/components/SessionWorktreeChip.test.tsx
+++ b/packages/web/components/SessionWorktreeChip.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
+import { SessionWorktreeChip } from "./SessionWorktreeChip";
+
+test("cloud worktree exposes host and branch without adding a nested control", () => {
+  const html = renderToStaticMarkup(<div role="button"><SessionWorktreeChip name="cloud-bc9163" branch="codecast/cloud-bc9163" hostName="Cloud Linux" hostIcon={<svg />} /></div>);
+  expect(html).toContain("Runs on Cloud Linux");
+  expect(html).toContain("Worktree cloud-bc9163 (codecast/cloud-bc9163)");
+  expect(html).toContain(">cloud-bc9163</span>");
+  expect(html).toContain("<svg");
+  expect(html).toContain('<span class="sr-only">Runs on Cloud Linux\nWorktree cloud-bc9163 (codecast/cloud-bc9163)</span>');
+  expect(html).toContain('aria-hidden="true"');
+  expect(html).not.toContain("<button");
+  expect(html).not.toContain("data-simple-hide");
+});
+
+test("local worktree and pending placement remain truthful", () => {
+  const local = renderToStaticMarkup(<SessionWorktreeChip name="local-a" />);
+  expect(local).toContain("Worktree local-a");
+  expect(local).not.toContain("Runs on");
+  const pending = renderToStaticMarkup(<SessionWorktreeChip preparing hostName="Cloud Linux" />);
+  expect(pending).toContain("Preparing the cloud host");
+  expect(pending).toContain(">preparing</span>");
+  expect(renderToStaticMarkup(<SessionWorktreeChip />)).toBe("");
+});
+
+test("both compact worktree rows and full cards render the same location chip", () => {
+  const source = readFileSync(new URL("./GlobalSessionPanel.tsx", import.meta.url), "utf8");
+  const compact = source.indexOf("if (isSubagent) {");
+  expect(compact).toBeGreaterThan(0);
+  expect(source.slice(0, compact)).toContain('const worktreeChip = (session.worktree_name || session.cloud_placement === "pending")');
+  expect(source.slice(compact).match(/\{worktreeChip\}/g)).toHaveLength(2);
+  expect(source.slice(compact)).toContain('<div className="flex min-w-0 pl-[18px] mt-0.5">{worktreeChip}</div>');
+  expect(source.slice(compact).indexOf("{worktreeChip}")).toBeGreaterThan(source.slice(compact).indexOf("{showBlockedBadge"));
+});

--- a/packages/web/components/SessionWorktreeChip.tsx
+++ b/packages/web/components/SessionWorktreeChip.tsx
@@ -1,0 +1,27 @@
+import React, { type ReactNode } from "react";
+
+export function SessionWorktreeChip({ name, branch, preparing, hostName, hostIcon }: {
+  name?: string | null;
+  branch?: string | null;
+  preparing?: boolean;
+  hostName?: string;
+  hostIcon?: ReactNode;
+}) {
+  if (!name && !preparing) return null;
+  const title = [
+    hostName && `Runs on ${hostName}`,
+    preparing ? "Preparing the cloud host — its worktree is being made now." : `Worktree ${name}${branch ? ` (${branch})` : ""}`,
+  ].filter(Boolean).join("\n");
+  return (
+    <span
+      className={`inline-flex min-w-0 text-[9px] font-mono max-w-[130px] ${preparing ? "text-sol-violet animate-pulse" : "text-sol-cyan"}`}
+      title={title}
+    >
+      <span className="sr-only">{title}</span>
+      <span aria-hidden="true" className="inline-flex items-center gap-1 min-w-0">
+        {hostIcon}
+        <span className="truncate">{preparing ? "preparing" : name}</span>
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
Cloud forks imported history with a synthetic metadata ID that native Codex rejects. Use a UUID for the temporary rollout while preserving the final conversation binding. Compact cloud-session rows also show the same host/worktree location as full cards.

Validation: real native old/UUID import control, a successful cloud fork response in its private workspace, focused CLI and location-chip regressions, CLI typecheck, and compact-card browser checks. Full CI is required before release.
