### PR TITLE
fix(cli): bound imports and preserve terminal Unicode

### DIFF
--- a/packages/cli/src/codexImportContext.e2e.test.ts
+++ b/packages/cli/src/codexImportContext.e2e.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { closeSync, mkdtempSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateCodexJsonl, type ExportResult } from "./jsonlGenerator";
+import { buildCodexImportContext } from "./codexImportContext";
+
+const binary = process.env.CODEX_IMPORT_NATIVE_BINARY;
+const sourceRollout = process.env.CODEX_IMPORT_SOURCE_ROLLOUT;
+
+test.skipIf(!binary)("native Codex imports the full archive but sends only bounded context to the provider", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "codex-import-native-"));
+  const requests: Array<{ path: string; input: unknown[] }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1", port: 0,
+    async fetch(request) {
+      const body = await request.json() as { input: unknown[] };
+      requests.push({ path: new URL(request.url).pathname, input: body.input });
+      if (body.input.length > 16_384) return Response.json({ error: { message: "Invalid 'input': array too long", type: "invalid_request_error", param: "input", code: "array_above_max_length" } }, { status: 400 });
+      const answer = { type: "message", role: "assistant", id: "answer", status: "completed", content: [{ type: "output_text", text: "IMPORT_OK", annotations: [] }] };
+      const events = [
+        { type: "response.created", response: { id: "response", status: "in_progress", output: [] } },
+        { type: "response.output_item.added", output_index: 0, item: { ...answer, status: "in_progress", content: [] } },
+        { type: "response.output_text.delta", item_id: "answer", output_index: 0, content_index: 0, delta: "IMPORT_OK" },
+        { type: "response.output_item.done", output_index: 0, item: answer },
+        { type: "response.completed", response: { id: "response", status: "completed", output: [answer], usage: { input_tokens: 100, output_tokens: 10, total_tokens: 110 } } },
+      ];
+      return new Response(events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""), { headers: { "content-type": "text/event-stream" } });
+    },
+  });
+  try {
+    const timestamp = "2026-09-05T00:00:00.000Z";
+    const data: ExportResult = {
+      conversation: { id: "jx7b88a", title: "Long import", session_id: crypto.randomUUID(), agent_type: "claude", project_path: dir, model: null, message_count: 20_002, started_at: timestamp, updated_at: timestamp },
+      messages: [
+        { role: "user", content: "Original mandate", timestamp },
+        ...Array.from({ length: 20_000 }, (_, i) => ({ role: "assistant", content: `historical step ${i}`, timestamp })),
+        { role: "user", content: "Hold until the gate is green", timestamp },
+      ],
+    };
+    let { jsonl } = generateCodexJsonl(data);
+    if (sourceRollout) {
+      const archived = readFileSync(sourceRollout, "utf8");
+      const rows = archived.trim().split("\n").map(line => JSON.parse(line));
+      const replacement = buildCodexImportContext(rows.filter(row => row.type === "response_item").map(row => row.payload), "jx7b88a");
+      jsonl = archived.trimEnd() + "\n" + JSON.stringify({ timestamp, type: "compacted", payload: { message: "", replacement_history: replacement } }) + "\n";
+    }
+    for (const bounded of [false, true]) {
+      const home = join(dir, bounded ? "bounded" : "control");
+      mkdirSync(home);
+      const path = join(home, "input.jsonl");
+      writeFileSync(path, bounded ? jsonl : jsonl.split("\n").filter(line => !line || JSON.parse(line).type !== "compacted").join("\n"));
+      writeFileSync(join(home, "config.toml"), `model = "gpt-6-astra"\nmodel_provider = "import_test"\nmodel_auto_compact_token_limit = 10000000\n[model_providers.import_test]\nname = "Local import test"\nbase_url = "http://127.0.0.1:${server.port}/v1"\nwire_api = "responses"\nrequires_openai_auth = false\nsupports_websockets = false\n`);
+      const startIndex = requests.length;
+      const outputPath = join(home, "native.out");
+      const errorPath = join(home, "native.err");
+      const outputFd = openSync(outputPath, "w");
+      const errorFd = openSync(errorPath, "w");
+      const child = spawn("node", [fileURLToPath(new URL("./test-helpers/codexImportNative.mjs", import.meta.url)), binary!, home, path, dir], {
+        cwd: dir, env: { PATH: process.env.PATH, HOME: process.env.HOME }, stdio: ["ignore", outputFd, errorFd],
+      });
+      closeSync(outputFd);
+      closeSync(errorFd);
+      try {
+        const code = await new Promise<number | null>((resolve, reject) => {
+          child.once("error", reject);
+          child.once("close", resolve);
+        });
+        if (code !== 0) throw new Error(readFileSync(errorPath, "utf8"));
+        const output = readFileSync(join(home, "result.json"), "utf8");
+        const completion = JSON.parse(output);
+        const sent = requests.slice(startIndex);
+        expect(sent.length).toBeGreaterThan(0);
+        expect(sent.every(request => request.path === "/v1/responses")).toBe(true);
+        if (bounded) {
+          expect(completion.status).toBe("completed");
+          expect(sent.every(request => request.input.length < 16_384)).toBe(true);
+          const input = JSON.stringify(sent[0].input);
+          expect(input).toContain("Hold until the gate is green");
+          if (!sourceRollout) {
+            expect(input).toContain("Original mandate");
+            expect(input).toContain("historical step 19999");
+          }
+        } else {
+          expect(completion.status).toBe("failed");
+          expect(sent[0].input.length).toBeGreaterThan(16_384);
+        }
+        process.stdout.write(JSON.stringify({ case: bounded ? "bounded" : "control", inputItems: sent[0].input.length, status: completion.status }) + "\n");
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) {
+          const exited = new Promise<void>(resolve => child.once("exit", () => resolve()));
+          child.kill();
+          await exited;
+        }
+      }
+    }
+  } finally {
+    server.stop(true);
+    rmSync(dir, { recursive: true, force: true });
+  }
+}, 90_000);

--- a/packages/cli/src/codexImportContext.test.ts
+++ b/packages/cli/src/codexImportContext.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { buildCodexImportContext, CODEX_IMPORT_MAX_BYTES, CODEX_IMPORT_MAX_ITEMS, type CodexImportItem } from "./codexImportContext";
+import { generateCodexJsonl, type ExportResult } from "./jsonlGenerator";
+import { parseCodexSessionFile } from "./parser";
+
+const msg = (role: string, text: string): CodexImportItem => ({ type: "message", role, content: [{ type: role === "assistant" ? "output_text" : "input_text", text }] });
+const setup = [msg("developer", "permissions"), msg("user", "project"), msg("user", "environment")];
+const bytes = (items: CodexImportItem[]) => Buffer.byteLength(JSON.stringify(items));
+
+function bounded(items: CodexImportItem[]) {
+  const result = buildCodexImportContext(items, "jx7b88a")!;
+  expect(result).toBeDefined();
+  expect(result.length).toBeLessThanOrEqual(CODEX_IMPORT_MAX_ITEMS);
+  expect(bytes(result)).toBeLessThanOrEqual(CODEX_IMPORT_MAX_BYTES);
+  expect(result.every(item => item.type === "message")).toBe(true);
+  expect(JSON.stringify(result)).toContain("cast read jx7b88a");
+  return result;
+}
+
+describe("bounded Codex import context", () => {
+  test("small imports retain their exact native history", () => {
+    expect(buildCodexImportContext([...setup, msg("user", "Help"), msg("assistant", "Done")], "thread")).toBeUndefined();
+  });
+
+  test("28,000 tiny items stay within the API item cap and retain instructions in order", () => {
+    const request = msg("user", "Original mandate");
+    const constraint = msg("user", "Never deploy without the green gate");
+    const decision = msg("user", "Hold until the gate is green");
+    const items = [...setup, request, ...Array.from({ length: 28_000 }, (_, i) => msg("assistant", `step ${i}`))];
+    items.splice(100, 0, constraint);
+    items.push(decision);
+    const result = bounded(items);
+    expect(result).toContainEqual(request);
+    expect(result).toContainEqual(constraint);
+    expect(result.at(-1)).toEqual(decision);
+    expect(result.indexOf(request)).toBeLessThan(result.indexOf(constraint));
+  });
+
+  test("large tool history is retained as quoted activity without dangling tool calls", () => {
+    const items = [...setup, msg("user", "Original mandate"), ...Array.from({ length: 1000 }, (_, i) => [
+      { type: "function_call", call_id: `call-${i}`, name: "exec", arguments: '{"cmd":"check"}' },
+      { type: "function_call_output", call_id: `call-${i}`, output: "evidence ".repeat(500) },
+    ]).flat(), msg("user", "Hold until the gate is green")];
+    const result = bounded(items);
+    expect(JSON.stringify(result)).toContain("call-999");
+    expect(JSON.stringify(result)).toContain("Historical function_call_output");
+    expect(result.at(-1)).toEqual(items.at(-1)!);
+  });
+
+  test("oversized Unicode instructions and trailing outputs cannot exceed the byte budget", () => {
+    const items = [...setup, msg("user", "BEGIN " + "界\"\\".repeat(100_000) + " ORIGINAL END"),
+      msg("user", "LATEST START " + "界".repeat(100_000) + " HOLD DEPLOY"),
+      { type: "function_call_output", call_id: "missing", output: "界".repeat(200_000) }];
+    const result = bounded(items);
+    const text = JSON.stringify(result);
+    for (const marker of ["BEGIN", "ORIGINAL END", "LATEST START", "HOLD DEPLOY", "Truncated for model context"]) expect(text).toContain(marker);
+    expect(items[3]).toEqual(msg("user", "BEGIN " + "界\"\\".repeat(100_000) + " ORIGINAL END"));
+  });
+
+  test("many earlier user messages cannot overflow the reserved instruction budget", () => {
+    bounded([...setup, ...Array.from({ length: 20_000 }, (_, i) => msg("user", `instruction ${i}`))]);
+  });
+
+  test("generated checkpoint preserves every archival row and never duplicates restored messages", () => {
+    const timestamp = "2026-09-05T00:00:00.000Z";
+    const data: ExportResult = {
+      conversation: { id: "jx7b88a", title: "Mandate", session_id: "session", agent_type: "claude", project_path: "/tmp/project", model: null, message_count: 20_002, started_at: timestamp, updated_at: timestamp },
+      messages: [
+        { role: "user", content: "Original mandate", timestamp },
+        ...Array.from({ length: 20_000 }, (_, i) => ({ role: "assistant", content: `historical step ${i}`, timestamp })),
+        { role: "user", content: "Hold until the gate is green", timestamp },
+      ],
+    };
+    for (const restore of [false, true]) {
+      const { jsonl } = generateCodexJsonl(data, restore ? { sessionId: "session" } : {});
+      const rows = jsonl.trim().split("\n").map(line => JSON.parse(line));
+      expect(rows.filter(row => row.type === "response_item")).toHaveLength(data.messages.length + 3);
+      expect(rows.at(-1).type).toBe("compacted");
+      const context = rows.at(-1).payload.replacement_history;
+      expect(context.length).toBeLessThanOrEqual(CODEX_IMPORT_MAX_ITEMS);
+      expect(bytes(context)).toBeLessThanOrEqual(CODEX_IMPORT_MAX_BYTES);
+      expect(JSON.stringify(context.at(-1))).toContain("Hold until the gate is green");
+      const archive = rows.slice(0, -1).map(row => JSON.stringify(row)).join("\n");
+      expect(parseCodexSessionFile(jsonl)).toEqual(parseCodexSessionFile(archive));
+    }
+  });
+});

--- a/packages/cli/src/codexImportContext.ts
+++ b/packages/cli/src/codexImportContext.ts
@@ -1,0 +1,81 @@
+export interface CodexImportItem {
+  type: string;
+  role?: string;
+  [key: string]: unknown;
+}
+
+export const CODEX_IMPORT_MAX_ITEMS = 4_096;
+export const CODEX_IMPORT_MAX_BYTES = 240_000;
+
+const size = (item: CodexImportItem) => Buffer.byteLength(JSON.stringify(item)) + 1;
+
+function message(role: string, text: string): CodexImportItem {
+  return { type: "message", role, content: [{ type: role === "assistant" ? "output_text" : "input_text", text }] };
+}
+
+function asContext(item: CodexImportItem): CodexImportItem {
+  if (item.type === "message") return item;
+  return message("assistant", `[Historical ${item.type}]\n${JSON.stringify(item)}`);
+}
+
+function fit(item: CodexImportItem, budget: number): CodexImportItem {
+  const context = asContext(item);
+  if (size(context) <= budget) return context;
+  const text = JSON.stringify(context);
+  const notice = "\n[Truncated for model context; read the full original in the conversation transcript.]\n";
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const clipped = message(context.role || "assistant", text.slice(0, Math.ceil(mid / 2)) + notice + text.slice(-Math.floor(mid / 2) || text.length));
+    if (size(clipped) <= budget) low = mid;
+    else high = mid - 1;
+  }
+  return message(context.role || "assistant", text.slice(0, Math.ceil(low / 2)) + notice + text.slice(-Math.floor(low / 2) || text.length));
+}
+
+export function buildCodexImportContext(items: CodexImportItem[], conversationId: string): CodexImportItem[] | undefined {
+  if (items.length <= CODEX_IMPORT_MAX_ITEMS && items.reduce((sum, item) => sum + size(item), 0) <= CODEX_IMPORT_MAX_BYTES) return;
+
+  const notice = message("developer", `[Codecast import] The full conversation is preserved in the transcript. ` +
+    "Only a bounded selection is in model context: the original request, earlier user messages that fit, and recent activity. " +
+    "Historical tool activity is quoted as text and is not a pending tool call. Some large entries may be shortened. " +
+    `Read omitted history before relying on past decisions: cast read ${conversationId} <from>:<to>.`);
+  const selected = new Map<number, CodexImportItem>();
+  let remaining = CODEX_IMPORT_MAX_BYTES - 1 - size(notice);
+  const add = (index: number, budget: number) => {
+    const item = fit(items[index], budget);
+    selected.set(index, item);
+    const bytes = size(item);
+    remaining -= bytes;
+    return bytes;
+  };
+
+  for (let i = 0; i < Math.min(3, items.length); i++) add(i, Math.min(8_000, remaining));
+  const firstUser = items.findIndex((item, index) => index >= 3 && item.type === "message" && item.role === "user");
+  if (firstUser >= 0) add(firstUser, 24_000);
+  for (let i = items.length - 1; i > firstUser && i >= 3; i--) {
+    if (items[i].type !== "message" || items[i].role !== "user") continue;
+    add(i, 24_000);
+    break;
+  }
+
+  let tailBudget = Math.floor(remaining * 0.75);
+  let tailStart = items.length;
+  for (let i = items.length - 1; i >= 3 && selected.size < CODEX_IMPORT_MAX_ITEMS - 513; i--) {
+    if (selected.has(i)) continue;
+    const bytes = size(asContext(items[i]));
+    if (bytes > tailBudget && tailStart < items.length) break;
+    tailBudget -= add(i, tailBudget);
+    tailStart = i;
+  }
+
+  for (let i = tailStart - 1; i >= 3 && selected.size < CODEX_IMPORT_MAX_ITEMS - 1; i--) {
+    if (selected.has(i) || items[i].type !== "message" || items[i].role !== "user") continue;
+    const bytes = size(items[i]);
+    if (bytes > remaining) continue;
+    add(i, remaining);
+  }
+
+  return [notice, ...[...selected.entries()].sort(([a], [b]) => a - b).map(([, item]) => item)];
+}

--- a/packages/cli/src/daemonBuildId.ts
+++ b/packages/cli/src/daemonBuildId.ts
@@ -10,4 +10,4 @@
 //
 // This file is excluded from its own hash, and it imports nothing on purpose:
 // the CLI fast path reads it, so it must never pull in a module graph.
-export const DAEMON_BUILD_ID = "bd5728d96cf6";
+export const DAEMON_BUILD_ID = "210ee0dc1df5";

--- a/packages/cli/src/jsonlGenerator.ts
+++ b/packages/cli/src/jsonlGenerator.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 import * as crypto from "crypto";
 import { CODECAST_IMPORT_NOTICE_PREFIX } from "./parser";
 import { claudeProjectDirName } from "./projectPathResolver.js";
+import { buildCodexImportContext, type CodexImportItem } from "./codexImportContext.js";
 
 const uuidv4 = () => crypto.randomUUID();
 
@@ -802,6 +803,16 @@ export function generateCodexJsonl(
       }));
     }
   }
+
+  const responseItems = lines.flatMap(line => {
+    const entry = JSON.parse(line);
+    return entry.type === "response_item" ? [entry.payload as CodexImportItem] : [];
+  });
+  const replacementHistory = buildCodexImportContext(responseItems, data.conversation.id);
+  if (replacementHistory) lines.push(JSON.stringify({
+    timestamp: data.conversation.updated_at, type: "compacted",
+    payload: { message: "", replacement_history: replacementHistory },
+  }));
 
   return { jsonl: lines.join("\n") + "\n", sessionId };
 }

--- a/packages/cli/src/terminal/controlProtocol.test.ts
+++ b/packages/cli/src/terminal/controlProtocol.test.ts
@@ -26,6 +26,17 @@ describe("unescapeControlData", () => {
     expect(unescapeControlData("caf\\303\\251").toString("utf8")).toBe("café");
   });
 
+  test("preserves unescaped Unicode and the ANSI sequences following it", () => {
+    for (const text of ["▐▛███▜▌", "─".repeat(80), "╭─╮ café 🚀", "日本語 e\u0301"]) {
+      expect(unescapeControlData(`${text}\\033[0m`)).toEqual(Buffer.from(`${text}\x1b[0m`));
+    }
+  });
+
+  test("preserves raw UTF-8 bytes mixed with octal escapes", () => {
+    const input = Buffer.concat([Buffer.from("▐\\033[2m"), Buffer.from([0xf0, 0x9f])]);
+    expect(unescapeControlData(input)).toEqual(Buffer.concat([Buffer.from("▐\x1b[2m"), Buffer.from([0xf0, 0x9f])]));
+  });
+
   test("leaves non-octal backslash sequences alone", () => {
     expect(unescapeControlData("a\\9b").toString()).toBe("a\\9b");
   });
@@ -84,6 +95,34 @@ describe("ControlModeParser", () => {
     parser.feed(bytes.subarray(0, splitAt), (ev) => events.push(ev));
     parser.feed(bytes.subarray(splitAt), (ev) => events.push(ev));
     expect(events).toEqual([{ type: "reply", ok: true, lines: ["café line"] }]);
+  });
+
+  test("preserves Unicode output at every transport chunk boundary", () => {
+    for (const prefix of ["%output %5 ", "%extended-output %5 0 : "]) {
+      const output = Buffer.from("▐▛███▜▌ ── café 🚀\x1b[0m");
+      const protocol = Buffer.from(`${prefix}▐▛███▜▌ ── café 🚀\\033[0m\n`);
+      for (let at = 1; at < protocol.length; at++) {
+        const parser = new ControlModeParser();
+        const events: ControlEvent[] = [];
+        parser.feed(protocol.subarray(0, at), (ev) => events.push(ev));
+        parser.feed(protocol.subarray(at), (ev) => events.push(ev));
+        expect(events).toEqual([{ type: "output", paneId: "%5", data: output }]);
+      }
+    }
+  });
+
+  test("preserves UTF-8 sequences split between output messages", () => {
+    const output = Buffer.from("▐▛███▜▌ ── café 🚀\x1b[0m");
+    for (let at = 1; at < output.length; at++) {
+      const parser = new ControlModeParser();
+      const events: ControlEvent[] = [];
+      const protocol = Buffer.concat([
+        Buffer.from("%output %5 "), output.subarray(0, at), Buffer.from("\n%extended-output %5 0 : "),
+        output.subarray(at), Buffer.from("\n"),
+      ]);
+      for (const byte of protocol) parser.feed(Buffer.from([byte]), (ev) => events.push(ev));
+      expect(Buffer.concat(events.flatMap((ev) => ev.type === "output" ? [ev.data] : []))).toEqual(output);
+    }
   });
 
   test("parses exit with reason, pause and continue", () => {

--- a/packages/cli/src/terminal/controlProtocol.ts
+++ b/packages/cli/src/terminal/controlProtocol.ts
@@ -3,34 +3,28 @@
 // Control mode is a line-based text protocol over the client's stdio: command
 // replies arrive framed by `%begin`/`%end` (or `%error`) lines, and
 // notifications (`%output`, `%exit`, `%pause`, ...) arrive between blocks.
-// Pane output in `%output` lines is octal-escaped per BYTE (`\015`, `\033`,
-// UTF-8 multibyte sequences become one escape per byte), so unescaping must
-// produce a Buffer — decoding to a string first would mangle multibyte text.
+// Pane output mixes raw UTF-8 with octal-escaped bytes (`\015`, `\033`), so
+// unescaping must produce a Buffer — decoding to a string first would mangle
+// characters split between output messages.
 
 /** Unescape tmux control-mode `%output` data (`\ooo` octal escapes) into raw bytes. */
-export function unescapeControlData(data: string): Buffer {
-  const out = Buffer.alloc(data.length);
+export function unescapeControlData(data: string | Buffer): Buffer {
+  const bytes = typeof data === "string" ? Buffer.from(data, "utf8") : data;
+  const out = Buffer.alloc(bytes.length);
   let w = 0;
-  for (let i = 0; i < data.length; i++) {
-    const ch = data.charCodeAt(i);
-    if (ch === 0x5c /* \ */ && i + 3 < data.length) {
-      const o1 = data.charCodeAt(i + 1) - 0x30;
-      const o2 = data.charCodeAt(i + 2) - 0x30;
-      const o3 = data.charCodeAt(i + 3) - 0x30;
+  for (let i = 0; i < bytes.length; i++) {
+    const ch = bytes[i]!;
+    if (ch === 0x5c /* \ */ && i + 3 < bytes.length) {
+      const o1 = bytes[i + 1]! - 0x30;
+      const o2 = bytes[i + 2]! - 0x30;
+      const o3 = bytes[i + 3]! - 0x30;
       if (o1 >= 0 && o1 <= 7 && o2 >= 0 && o2 <= 7 && o3 >= 0 && o3 <= 7) {
         out[w++] = (o1 << 6) | (o2 << 3) | o3;
         i += 3;
         continue;
       }
     }
-    // Non-ASCII chars can't appear unescaped in %output, but be lossless anyway.
-    if (ch < 0x80) {
-      out[w++] = ch;
-    } else {
-      const bytes = Buffer.from(data[i]!, "utf8");
-      bytes.copy(out, w);
-      w += bytes.length;
-    }
+    out[w++] = ch;
   }
   return out.subarray(0, w);
 }
@@ -72,13 +66,14 @@ export class ControlModeParser {
     while ((idx = this.buf.indexOf(0x0a)) >= 0) {
       let end = idx;
       if (end > 0 && this.buf[end - 1] === 0x0d) end--;
-      const line = this.buf.subarray(0, end).toString("utf8");
+      const line = this.buf.subarray(0, end);
       this.buf = this.buf.subarray(idx + 1);
       this.handleLine(line, emit);
     }
   }
 
-  private handleLine(line: string, emit: (ev: ControlEvent) => void): void {
+  private handleLine(bytes: Buffer, emit: (ev: ControlEvent) => void): void {
+    const line = bytes.toString("utf8");
     if (this.inBlock) {
       if (line.startsWith("%end ")) {
         this.inBlock = false;
@@ -102,7 +97,7 @@ export class ControlModeParser {
     if (line.startsWith("%output ")) {
       const sp = line.indexOf(" ", 8);
       if (sp > 0) {
-        emit({ type: "output", paneId: line.slice(8, sp), data: unescapeControlData(line.slice(sp + 1)) });
+        emit({ type: "output", paneId: line.slice(8, sp), data: unescapeControlData(bytes.subarray(sp + 1)) });
       }
       return;
     }
@@ -111,7 +106,7 @@ export class ControlModeParser {
       const colon = line.indexOf(" : ");
       const sp = line.indexOf(" ", 17);
       if (colon > 0 && sp > 0) {
-        emit({ type: "output", paneId: line.slice(17, sp), data: unescapeControlData(line.slice(colon + 3)) });
+        emit({ type: "output", paneId: line.slice(17, sp), data: unescapeControlData(bytes.subarray(colon + 3)) });
       }
       return;
     }

--- a/packages/cli/src/test-helpers/codexImportNative.mjs
+++ b/packages/cli/src/test-helpers/codexImportNative.mjs
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [binary, home, path, cwd] = process.argv.slice(2);
+const child = spawn(binary, ["app-server"], {
+  cwd,
+  env: { PATH: process.env.PATH, HOME: process.env.HOME, CODEX_HOME: home },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+const lines = createInterface({ input: child.stdout });
+let stderr = "";
+child.stderr.on("data", chunk => { stderr += String(chunk); });
+process.on("SIGTERM", () => child.kill());
+let sequence = 0;
+function wait(matches) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => { clearTimeout(timer); lines.off("line", onLine); child.off("exit", onExit); };
+    const onExit = () => { cleanup(); reject(new Error(`Native import exited (${child.exitCode}, ${child.signalCode}): ${stderr.slice(-2000)}`)); };
+    const timer = setTimeout(() => { cleanup(); reject(new Error(`Native import timeout: ${stderr.slice(-2000)}`)); }, 30_000);
+    const onLine = line => {
+      const row = JSON.parse(line);
+      if (matches(row)) { cleanup(); resolve(row); }
+    };
+    lines.on("line", onLine);
+    child.once("exit", onExit);
+  });
+}
+async function rpc(method, params) {
+  const id = ++sequence;
+  const response = wait(row => row.id === id);
+  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+  const row = await response;
+  if (row.error) throw new Error(JSON.stringify(row.error));
+  return row.result;
+}
+try {
+  await rpc("initialize", { clientInfo: { name: "import_test", version: "1.0.0" }, capabilities: { experimentalApi: true } });
+  const fork = await rpc("thread/fork", { threadId: "", path, cwd, approvalPolicy: "never", sandbox: "read-only" });
+  const done = wait(row => row.method === "turn/completed");
+  await rpc("turn/start", { threadId: fork.thread.id, input: [{ type: "text", text: "Report import readiness only." }] });
+  const completion = await done;
+  writeFileSync(join(home, "result.json"), JSON.stringify(completion.params.turn));
+} finally {
+  lines.close();
+  if (child.exitCode === null && child.signalCode === null) {
+    const exited = new Promise(resolve => child.once("exit", resolve));
+    child.kill();
+    await exited;
+  }
+}


### PR DESCRIPTION
Long Claude-to-Codex imports exceeded the provider's input-item limit, and terminal output containing Unicode could corrupt characters and truncate trailing ANSI resets. Preserve the full imported transcript while adding a bounded native context checkpoint, and decode tmux output as bytes through the complete transport path.

Candidate verification: 49 focused tests / 331 assertions, full CLI typecheck, root lint (0 errors), and daemon stamp check. Real Codex 0.153.4 with a local test provider rejects the original 20,012-item import and completes the bounded 1,733-item import. The Unicode defect reproduces against the released daemon; matched native terminal-service harnesses fail before and pass after, including light/dark OSC replies. Independent terminal review adds 27 passing adversarial/regression tests. Full CI must pass before the signed CLI release.

No backend, desktop, or mobile changes. Live held conversations remain unchanged.
