### PR TITLE
fix: preserve Codex permissions and imported worker sessions

### DIFF
--- a/packages/cli/src/codexAppServer.test.ts
+++ b/packages/cli/src/codexAppServer.test.ts
@@ -132,7 +132,7 @@ describe("CodexAppServer sandbox restatement", () => {
 
     // Invalidated BEFORE the write, and disk must not claim the old broader one.
     expect(invalidated).toEqual(["thread"]);
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   test("timeout after a narrowing leaves the policy unspecified, not the old one", async () => {
@@ -145,7 +145,7 @@ describe("CodexAppServer sandbox restatement", () => {
 
     expect(server.hasPendingPolicyChange("thread")).toBe(false);
     expect(server.policyForThread("thread")).toBeUndefined();
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   test("a dropped connection is ambiguous too, and does not restore the old policy", async () => {
@@ -155,7 +155,7 @@ describe("CodexAppServer sandbox restatement", () => {
     await expect(server.turnStart({
       threadId: "thread", input: [{ type: "text", text: "a" }], sandboxPolicy: READONLY,
     })).rejects.toThrow("terminated");
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   test("an EXPLICIT refusal is authoritative, so the old policy remains valid", async () => {
@@ -190,7 +190,7 @@ describe("CodexAppServer sandbox restatement", () => {
 
     // The second call finished; the first is still in flight and still owns the mark.
     expect(server.hasPendingPolicyChange("thread")).toBe(true);
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
 
     releaseFirst({ turn: { id: "t", items: [], status: "inProgress" } });
     await first;
@@ -198,7 +198,7 @@ describe("CodexAppServer sandbox restatement", () => {
     // for this thread, so an older response may not resolve the uncertainty. The
     // policy stays unknown and a resume sends none, which is restrictive.
     expect(server.hasPendingPolicyChange("thread")).toBe(false);
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   // A=FULL and B=READONLY both in flight. A is accepted while B is still
@@ -223,7 +223,7 @@ describe("CodexAppServer sandbox restatement", () => {
     await a;
     // A settled, but B is newer and still unresolved.
     expect(server.hasPendingPolicyChange("thread")).toBe(true);
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
 
     failB(new Error("Request turn/start timed out after 1ms"));
     await expect(b).rejects.toThrow("timed out");
@@ -232,7 +232,7 @@ describe("CodexAppServer sandbox restatement", () => {
     // come back from A's earlier acceptance or from the record.
     expect(server.hasPendingPolicyChange("thread")).toBe(false);
     expect(server.policyForThread("thread")).toBeUndefined();
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   // Same stale-response guard at the other entry point. A resume knows its
@@ -271,7 +271,7 @@ describe("CodexAppServer sandbox restatement", () => {
     void server.threadResume({ threadId: "thread", cwd: "/p" });
     await Promise.resolve();
     expect(invalidated).toEqual(["thread"]);
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   test("a failed resume leaves the policy unknown rather than reverting", async () => {
@@ -280,7 +280,7 @@ describe("CodexAppServer sandbox restatement", () => {
     (server as any).sendRequest = async () => { throw new Error("Request thread/resume timed out after 1ms"); };
     await expect(server.threadResume({ threadId: "thread", cwd: "/p" })).rejects.toThrow("timed out");
     expect(server.policyForThread("thread")).toBeUndefined();
-    expect(disk(server, "thread", FULL)).toBeUndefined();
+    expect(disk(server, "thread", FULL)).toBeNull();
   });
 
   test("an implicit turn never touches an override's pending mark", async () => {

--- a/packages/cli/src/codexAppServer.ts
+++ b/packages/cli/src/codexAppServer.ts
@@ -227,6 +227,7 @@ export interface CodexAppServerOptions {
   log: (msg: string) => void;
   onApproval?: (threadId: string, approval: ApprovalRequest) => Promise<boolean>;
   codexBinary?: string;
+  defaultPermissions?: () => Pick<ThreadStartParams, "sandbox" | "approvalPolicy">;
 }
 
 interface PendingRequest {
@@ -335,12 +336,14 @@ export class CodexAppServer extends EventEmitter {
   private log: (msg: string) => void;
   private onApproval?: (threadId: string, approval: ApprovalRequest) => Promise<boolean>;
   private codexBinary: string;
+  private defaultPermissions?: CodexAppServerOptions["defaultPermissions"];
 
   constructor(opts: CodexAppServerOptions) {
     super();
     this.log = opts.log;
     this.onApproval = opts.onApproval;
     this.codexBinary = opts.codexBinary || "codex";
+    this.defaultPermissions = opts.defaultPermissions;
   }
 
   start(): void {
@@ -378,10 +381,20 @@ export class CodexAppServer extends EventEmitter {
   }
 
   async threadStart(params: ThreadStartParams): Promise<ThreadStartResponse> {
-    const response = await this.sendRequest("thread/start", withWorktreeConfig(params), THREAD_START_TIMEOUT_MS) as ThreadStartResponse;
+    const response = await this.sendRequest("thread/start", withWorktreeConfig(this.withDefaultPermissions(params)), THREAD_START_TIMEOUT_MS) as ThreadStartResponse;
     this.threadModels.set(response.thread.id, response.model);
     this.rememberPolicy(response.thread.id, response.sandbox, this.nextPolicyGeneration(response.thread.id));
     return response;
+  }
+
+  private withDefaultPermissions<T extends ThreadStartParams>(params: T): T {
+    const defaults = this.defaultPermissions?.();
+    if (!defaults) return params;
+    return {
+      ...params,
+      sandbox: params.sandbox ?? defaults.sandbox,
+      approvalPolicy: params.approvalPolicy ?? defaults.approvalPolicy,
+    };
   }
 
   async turnStart(params: TurnStartParams): Promise<TurnStartResponse> {
@@ -511,6 +524,14 @@ export class CodexAppServer extends EventEmitter {
   }
 
   async threadResume(params: ThreadResumeParams): Promise<ThreadResumeResponse> {
+    const knownPolicy = this.policyForThread(params.threadId);
+    if (!params.sandbox && knownPolicy) {
+      const known = sandboxResumeParams(knownPolicy);
+      params = { ...params, sandbox: known.sandbox ?? "read-only", config: { ...known.config, ...params.config } };
+    }
+    params = this.withDefaultPermissions(this.isPolicyInvalidated(params.threadId) && !params.sandbox
+      ? { ...params, sandbox: "read-only" }
+      : params);
     // Unlike start and fork, a resume already knows its thread id, so its
     // generation must be taken BEFORE the request goes out. Taking it after the
     // await would make a slow response the newest by definition, letting it
@@ -539,7 +560,7 @@ export class CodexAppServer extends EventEmitter {
   }
 
   async threadFork(params: ThreadForkParams, timeoutMs = THREAD_START_TIMEOUT_MS): Promise<ThreadForkResponse> {
-    const response = await this.sendRequest("thread/fork", withWorktreeConfig(params), timeoutMs) as ThreadForkResponse;
+    const response = await this.sendRequest("thread/fork", withWorktreeConfig(this.withDefaultPermissions(params)), timeoutMs) as ThreadForkResponse;
     this.threadModels.set(response.thread.id, response.model);
     this.rememberPolicy(response.thread.id, response.sandbox, this.nextPolicyGeneration(response.thread.id));
     return response;

--- a/packages/cli/src/codexPermissions.e2e.test.ts
+++ b/packages/cli/src/codexPermissions.e2e.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CodexAppServer, type SandboxPolicy } from "./codexAppServer.js";
+import { codexResumeParams, type PersistedCodexThread } from "./codexTurnRecovery.js";
+
+const binary = process.env.CODEX_PERMISSIONS_NATIVE_BINARY;
+const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+
+test.skipIf(!binary)("native Codex defaults survive turns and cold restart while explicit restrictions remain enforced", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "codex-permissions-native-"));
+  const home = join(dir, "codex");
+  const cwd = join(dir, "project");
+  mkdirSync(home);
+  mkdirSync(cwd);
+  const requests: unknown[] = [];
+  const provider = Bun.serve({
+    hostname: "127.0.0.1", port: 0,
+    async fetch(request) {
+      if (new URL(request.url).pathname === "/health") return new Response("NETWORK_OK");
+      requests.push(await request.json());
+      const answer = { type: "message", role: "assistant", id: "answer", status: "completed", content: [{ type: "output_text", text: "PERMISSIONS_OK", annotations: [] }] };
+      const events = [
+        { type: "response.created", response: { id: "response", status: "in_progress", output: [] } },
+        { type: "response.output_item.added", output_index: 0, item: { ...answer, status: "in_progress", content: [] } },
+        { type: "response.output_text.delta", item_id: "answer", output_index: 0, content_index: 0, delta: "PERMISSIONS_OK" },
+        { type: "response.output_item.done", output_index: 0, item: answer },
+        { type: "response.completed", response: { id: "response", status: "completed", output: [answer], usage: { input_tokens: 100, output_tokens: 10, total_tokens: 110 } } },
+      ];
+      return new Response(events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""), { headers: { "content-type": "text/event-stream" } });
+    },
+  });
+  const wrapper = join(dir, "codex-wrapper");
+  writeFileSync(wrapper, `#!/bin/sh\nunset OPENAI_API_KEY\nexport CODEX_HOME=${quote(home)}\nexec ${quote(binary!)} "$@"\n`, { mode: 0o755 });
+  writeFileSync(join(home, "config.toml"), `model = "gpt-6-astra"\nmodel_provider = "permissions_test"\n[model_providers.permissions_test]\nname = "Local permissions test"\nbase_url = "http://127.0.0.1:${provider.port}/v1"\nwire_api = "responses"\nrequires_openai_auth = false\nsupports_websockets = false\n`);
+  let server: CodexAppServer | undefined;
+  const log: string[] = [];
+  const boot = async () => {
+    server = new CodexAppServer({ codexBinary: wrapper, log: line => log.push(line), defaultPermissions: () => ({ sandbox: "danger-full-access", approvalPolicy: "never" }) });
+    server.on("error", () => {});
+    const ready = once(server, "ready");
+    server.start();
+    await ready;
+    return server;
+  };
+  const stop = async () => {
+    if (!server) return;
+    if (!server.running) { server.stop(); return; }
+    const exited = once(server, "exited");
+    server.stop();
+    await exited;
+  };
+  const turn = async (threadId: string) => {
+    const done = once(server!, "turnCompleted");
+    await server!.turnStart({ threadId, input: [{ type: "text", text: "Reply PERMISSIONS_OK." }] });
+    const result = await done;
+    expect(result[3]).toBe("completed");
+  };
+  const checkAccess = async (policy: SandboxPolicy, allowed: boolean) => {
+    const write = await (server as any).sendRequest("command/exec", {
+      cwd, sandboxPolicy: policy, command: ["/bin/sh", "-c", `printf WRITE_OK > ${quote(join(dir, "outside-project"))}`], timeoutMs: 5000,
+    }, 10_000);
+    expect(write.exitCode === 0).toBe(allowed);
+    const network = await (server as any).sendRequest("command/exec", {
+      cwd, sandboxPolicy: policy, command: ["/usr/bin/curl", "--max-time", "3", "-fsS", `http://127.0.0.1:${provider.port}/health`], timeoutMs: 5000,
+    }, 10_000);
+    expect(network.exitCode === 0).toBe(allowed);
+    if (allowed) expect(network.stdout).toBe("NETWORK_OK");
+    process.stdout.write(JSON.stringify({ policy: policy.type, write: write.exitCode, network: network.exitCode }) + "\n");
+  };
+  try {
+    await boot();
+    const started = await server!.threadStart({ cwd });
+    expect(started.sandbox).toEqual({ type: "dangerFullAccess" });
+    await turn(started.thread.id);
+    const saved: PersistedCodexThread = JSON.parse(JSON.stringify({ threadId: started.thread.id, cwd, updatedAt: 1, sandboxPolicy: started.sandbox }));
+    await checkAccess(started.sandbox, true);
+    await stop();
+
+    await boot();
+    const resumed = await server!.threadResume(codexResumeParams(saved, "never"));
+    expect(resumed.sandbox).toEqual(started.sandbox);
+    await turn(saved.threadId);
+    await checkAccess(resumed.sandbox, true);
+    const contexts = readFileSync(resumed.thread.path!, "utf8").trim().split("\n").map(line => JSON.parse(line)).filter(row => row.type === "turn_context");
+    expect(contexts.length).toBeGreaterThanOrEqual(2);
+    for (const context of contexts) expect(context.payload.sandbox_policy.type).toBe("danger-full-access");
+    await stop();
+
+    await boot();
+    const legacy = await server!.threadResume(codexResumeParams({ threadId: saved.threadId, cwd, updatedAt: 1 }, "never"));
+    expect(legacy.sandbox.type).toBe("readOnly");
+    await checkAccess(legacy.sandbox, false);
+    await stop();
+
+    await boot();
+    const invalidated = await server!.threadResume(codexResumeParams({ ...saved, sandboxPolicy: null }, "never"));
+    expect(invalidated.sandbox.type).toBe("readOnly");
+    await checkAccess(invalidated.sandbox, false);
+    const forked = await server!.threadFork({ threadId: saved.threadId, cwd });
+    expect(forked.sandbox).toEqual(started.sandbox);
+    const safe = await server!.threadStart({ cwd, sandbox: "read-only", approvalPolicy: "never" });
+    expect(safe.sandbox.type).toBe("readOnly");
+    await turn(safe.thread.id);
+    await checkAccess(safe.sandbox, false);
+    expect(requests.length).toBeGreaterThanOrEqual(3);
+    process.stdout.write(JSON.stringify({ cases: ["default-start", "turn-restatement", "cold-resume", "old-absent-invalidation", "invalidated-resume", "default-fork", "explicit-read-only"], status: "passed" }) + "\n");
+  } finally {
+    await stop();
+    provider.stop(true);
+    if (process.env.CODEX_PERMISSIONS_EVIDENCE) writeFileSync(process.env.CODEX_PERMISSIONS_EVIDENCE, log.join("\n"));
+    if (!process.env.CODEX_PERMISSIONS_EVIDENCE) rmSync(dir, { recursive: true, force: true });
+  }
+}, 90_000);

--- a/packages/cli/src/codexPermissions.test.ts
+++ b/packages/cli/src/codexPermissions.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CodexAppServer, type ThreadStartParams } from "./codexAppServer";
+import { applyPolicyInPlace, codexResumeParams, persistedPolicyFor, registerPolicyPersistenceHandlers, type PersistedCodexThread } from "./codexTurnRecovery";
+import { buildLaunchArgs, buildPrintArgs, codexPermissionsFromArgs, getPermissionFlags, permissionFlagsForMode } from "./launchCommand";
+import { getAgentArgs } from "./config/types.js";
+
+const full = { sandbox: "danger-full-access", approvalPolicy: "never" } as const;
+const readonly = { type: "readOnly", networkAccess: false } as const;
+
+function client(defaults: Pick<ThreadStartParams, "sandbox" | "approvalPolicy"> = full) {
+  const requests: Array<{ method: string; params: any }> = [];
+  const server = new CodexAppServer({ log: () => {}, defaultPermissions: () => defaults });
+  (server as any).sendRequest = async (method: string, params: any) => {
+    requests.push({ method, params });
+    if (method === "turn/start") return { turn: { id: "turn", items: [], status: "inProgress" } };
+    return { thread: { id: params.threadId ?? "thread" }, model: "test", sandbox: params.sandbox === "danger-full-access" ? { type: "dangerFullAccess" } : readonly };
+  };
+  return { server, requests };
+}
+
+describe("configured Codex permissions", () => {
+  test("all production resumes pass through the persisted-policy boundary", () => {
+    const calls: string[] = [];
+    for (const file of new Bun.Glob("**/*.ts").scanSync(import.meta.dir)) {
+      if (/\.(test|spec)\.ts$/.test(file) || file.includes("__fixtures__") || file.includes("test-helpers")) continue;
+      const source = readFileSync(join(import.meta.dir, file), "utf8");
+      for (const call of source.matchAll(/\.threadResume\s*\(([^\n]*)/g)) calls.push(`${file}:${call[1]}`);
+    }
+    expect(calls).toEqual(['daemon.ts:codexResumeParams(record, policy));']);
+  });
+
+  test("ordinary configured launches default to full access independently of approval policy", () => {
+    const flags = getPermissionFlags("codex", null)!.split(" ");
+    expect(codexPermissionsFromArgs(flags)).toEqual(full);
+    expect(codexPermissionsFromArgs(["--ask-for-approval", "never"])).toEqual({ sandbox: "workspace-write", approvalPolicy: "never" });
+    expect(codexPermissionsFromArgs(["--full-auto"])).toEqual({ sandbox: "workspace-write", approvalPolicy: "on-request" });
+  });
+
+  test.each(["--sandbox read-only -a never", "-s read-only --ask-for-approval=never", "--sandbox=read-only -a=never", "-sread-only -anever", "-s=read-only -a=never"])("explicit sandbox arguments suppress the bypass default: %s", args => {
+    expect(getPermissionFlags("codex", { agent_args: { codex: args } } as any)).toBeNull();
+    expect(permissionFlagsForMode("codex", "bypass", args)).toBeNull();
+    expect(codexPermissionsFromArgs(args.split(" "))).toEqual({ sandbox: "read-only", approvalPolicy: "never" });
+  });
+
+  test("attached approval intent remains independent from sandbox intent", () => {
+    expect(getPermissionFlags("codex", { agent_args: { codex: "-anever" } } as any)).toBeNull();
+    expect(codexPermissionsFromArgs(["-anever"])).toEqual({ sandbox: "workspace-write", approvalPolicy: "never" });
+  });
+
+  test.each(["-sread-only", "-anever", "--sandbox read-only", "--yolo"])("permission-looking prompt text after -- is ignored: %s", prompt => {
+    const args = `-- ${prompt}`;
+    expect(getPermissionFlags("codex", { agent_args: { codex: args } } as any)).toBe("--dangerously-bypass-approvals-and-sandbox");
+    expect(permissionFlagsForMode("codex", "bypass", args)).toBe("--dangerously-bypass-approvals-and-sandbox");
+    expect(codexPermissionsFromArgs(["--yolo", ...args.split(" ")])).toEqual(full);
+    expect(codexPermissionsFromArgs(["-sread-only", "--", "--yolo"])).toEqual({ sandbox: "read-only", approvalPolicy: "on-request" });
+  });
+
+  test.each(["-- -sread-only", "-sread-only -- --yolo"])("actual launch, print and daemon defaults preserve the option boundary: %s", configuredArgs => {
+    const config = { agent_args: { codex: configuredArgs } } as any;
+    const input = { agentType: "codex" as const, configuredArgs, permFlags: getPermissionFlags("codex", config), defaultFlags: null, modelAlias: "test-model" };
+    const launch = buildLaunchArgs(input).binaryArgs;
+    const print = buildPrintArgs({ ...input, prompt: "" }).binaryArgs;
+    const expected = configuredArgs.startsWith("--") ? full : { sandbox: "read-only", approvalPolicy: "on-request" } as const;
+    for (const args of [launch, print]) {
+      expect(args.slice(args.indexOf("--"))).toEqual(configuredArgs.split(" ").slice(configuredArgs.split(" ").indexOf("--")));
+      expect(args.slice(0, args.indexOf("--"))).toContain("-m");
+      expect(args.slice(0, args.indexOf("--"))).toContain("test-model");
+      expect(codexPermissionsFromArgs(args)).toEqual(expected);
+    }
+    const source = readFileSync(join(import.meta.dir, "daemon.ts"), "utf8");
+    const start = source.indexOf("function resolveCodexPermissionDefaults(");
+    expect(start).toBeGreaterThan(-1);
+    const body = source.slice(start, source.indexOf("\ninterface ConversationCache", start));
+    const resolve = new Function("buildLaunchArgs", "getAgentArgs", "getPermissionFlags", "codexPermissionsFromArgs", new Bun.Transpiler().transformSync(body, "ts") + "; return resolveCodexPermissionDefaults;")(buildLaunchArgs, getAgentArgs, getPermissionFlags, codexPermissionsFromArgs);
+    expect(resolve(config)).toEqual(expected);
+  });
+
+  test("ordinary start, resume and fork explicitly request full access without approvals", async () => {
+    const { server, requests } = client();
+    await server.threadStart({ cwd: "/project" });
+    await server.threadResume({ threadId: "legacy", cwd: "/project" });
+    await server.threadFork({ threadId: "source", cwd: "/project" });
+    for (const request of requests) expect(request.params).toMatchObject(full);
+  });
+
+  test("explicit restrictions override the configured default on all thread requests", async () => {
+    const { server, requests } = client();
+    const restricted = { sandbox: "read-only", approvalPolicy: "on-request" } as const;
+    await server.threadStart({ cwd: "/project", ...restricted });
+    await server.threadResume({ threadId: "legacy", ...restricted });
+    await server.threadFork({ threadId: "source", ...restricted });
+    for (const request of requests) expect(request.params).toMatchObject(restricted);
+  });
+
+  test("an absent persisted policy may be an older invalidation and remains restricted", async () => {
+    const { server, requests } = client();
+    await server.threadResume(codexResumeParams({ threadId: "legacy", updatedAt: 1 }, "never"));
+    await server.turnStart({ threadId: "legacy", input: [{ type: "text", text: "continue" }] });
+    expect(requests[0].params.sandbox).toBe("read-only");
+    expect(requests[1].params.sandboxPolicy).toEqual(readonly);
+  });
+
+  test("an explicit turn restriction remains in force despite full-access defaults", async () => {
+    const { server, requests } = client();
+    await server.threadStart({ cwd: "/project" });
+    await server.turnStart({ threadId: "thread", input: [], sandboxPolicy: readonly });
+    await server.turnStart({ threadId: "thread", input: [] });
+    expect(requests.at(-1)!.params.sandboxPolicy).toEqual(readonly);
+  });
+
+  test("defaults never fill an unknown turn policy", async () => {
+    const { server, requests } = client();
+    await server.turnStart({ threadId: "unknown", input: [] });
+    expect(requests[0].params.sandboxPolicy).toBeUndefined();
+  });
+
+  test("recorded restrictions survive cold resume", async () => {
+    const { server, requests } = client();
+    await server.threadResume(codexResumeParams({ threadId: "safe", updatedAt: 1, sandboxPolicy: readonly }, "never"));
+    expect(requests[0].params.sandbox).toBe("read-only");
+  });
+
+  test("legacy coarse restrictions survive cold resume until a server policy supersedes them", async () => {
+    const record: PersistedCodexThread = { threadId: "safe", updatedAt: 1, sandbox: "read-only" };
+    const { server, requests } = client();
+    const response = await server.threadResume(codexResumeParams(JSON.parse(JSON.stringify(record)), "never"));
+    expect(requests[0].params.sandbox).toBe("read-only");
+    applyPolicyInPlace(record, "safe", response.sandbox);
+    expect(record.sandbox).toBeUndefined();
+    expect(record.sandboxPolicy).toEqual(readonly);
+  });
+
+  test("a live restricted thread retains its known policy on an implicit resume", async () => {
+    const { server, requests } = client();
+    await server.threadStart({ cwd: "/project", sandbox: "read-only" });
+    await server.threadResume({ threadId: "thread", cwd: "/project" });
+    expect(requests.at(-1)!.params.sandbox).toBe("read-only");
+  });
+
+  test("durable invalidation survives JSON and does not acquire the legacy default", async () => {
+    const record: PersistedCodexThread = { threadId: "thread", updatedAt: 1, sandbox: "danger-full-access", sandboxPolicy: { type: "dangerFullAccess" } };
+    const identity = record;
+    const policy = persistedPolicyFor({ pending: true, previous: record.sandboxPolicy });
+    applyPolicyInPlace(record, "thread", policy);
+    expect(record).toBe(identity);
+    expect(record.sandboxPolicy).toBeNull();
+    expect(record.sandbox).toBeUndefined();
+    const { server, requests } = client();
+    await server.threadResume(codexResumeParams(JSON.parse(JSON.stringify(record)), "never"));
+    expect(requests[0].params.sandbox).toBe("read-only");
+  });
+
+  test("an ambiguous narrowing persists invalidation before the request and stays restricted on restart", async () => {
+    const { server } = client();
+    const record: PersistedCodexThread = { threadId: "thread", updatedAt: 1 };
+    await server.threadStart({ cwd: "/project" });
+    registerPolicyPersistenceHandlers({
+      client: server,
+      conversationForThread: () => "conversation",
+      persist: () => {
+        applyPolicyInPlace(record, "thread", persistedPolicyFor({
+          pending: server.hasPendingPolicyChange("thread"), invalidated: server.isPolicyInvalidated("thread"),
+          live: server.policyForThread("thread"), previous: record.sandboxPolicy,
+        }));
+        return true;
+      },
+    });
+    (server as any).sendRequest = async () => {
+      expect(JSON.parse(JSON.stringify(record)).sandboxPolicy).toBeNull();
+      throw new Error("response lost");
+    };
+    await expect(server.turnStart({ threadId: "thread", input: [], sandboxPolicy: readonly })).rejects.toThrow("response lost");
+    const restarted = client();
+    await restarted.server.threadResume(codexResumeParams(JSON.parse(JSON.stringify(record)), "never"));
+    expect(restarted.requests[0].params.sandbox).toBe("read-only");
+  });
+
+  test("configured defaults are read again for each request", async () => {
+    const defaults: Pick<ThreadStartParams, "sandbox" | "approvalPolicy"> = { ...full };
+    const { server, requests } = client(defaults);
+    await server.threadStart({ cwd: "/project" });
+    defaults.sandbox = "read-only";
+    defaults.approvalPolicy = "on-request";
+    await server.threadStart({ cwd: "/project" });
+    expect(requests[0].params).toMatchObject(full);
+    expect(requests[1].params).toMatchObject(defaults);
+  });
+});

--- a/packages/cli/src/codexTurnRecovery.test.ts
+++ b/packages/cli/src/codexTurnRecovery.test.ts
@@ -125,12 +125,12 @@ describe("Codex restart policy preservation", () => {
   // NEGATIVE CONTROL for the old behaviour: a record with no recorded policy
   // must not acquire one. The previous code derived a full-access sandbox from
   // approvalPolicy "never", which widened any thread that was really restricted.
-  test("an unknown prior sandbox stays unspecified rather than guessed", () => {
+  test("an unknown prior sandbox cannot acquire configured full access", () => {
     expect(sandboxResumeParams(undefined)).toEqual({});
     expect(sandboxResumeParams(null)).toEqual({});
     const legacy: PersistedCodexThread = { threadId: "t", updatedAt: 1, cwd: "/p", approvalPolicy: "never" };
     const params = codexResumeParams(legacy, "never");
-    expect(params.sandbox).toBeUndefined();
+    expect(params.sandbox).toBe("read-only");
     expect((params as { config?: unknown }).config).toBeUndefined();
   });
 

--- a/packages/cli/src/codexTurnRecovery.ts
+++ b/packages/cli/src/codexTurnRecovery.ts
@@ -1,35 +1,41 @@
-import { sandboxResumeParams, type ApprovalPolicy, type SandboxPolicy, type ThreadResumeParams, type ThreadResumeResponse, type Turn } from "./codexAppServer.js";
+import { sandboxResumeParams, type ApprovalPolicy, type SandboxMode, type SandboxPolicy, type ThreadResumeParams, type ThreadResumeResponse, type Turn } from "./codexAppServer.js";
 
 export type PersistedCodexThread = {
   threadId: string;
   updatedAt: number;
   cwd?: string;
   approvalPolicy?: ApprovalPolicy;
+  sandbox?: SandboxMode;
   /** The policy the server reported for this thread, recorded so a restart can
-   *  reproduce it exactly. A coarse mode cannot carry workspace roots or
-   *  network access, so the policy is what gets persisted. */
-  sandboxPolicy?: SandboxPolicy;
+   *  reproduce it exactly. Preferred over `sandbox`, which is a coarse mode and
+   *  cannot carry workspace roots or network access. */
+  sandboxPolicy?: SandboxPolicy | null;
   activeTurnId?: string;
   recoveryAttempts?: number;
 };
 
 /**
  * Params to bring a saved thread back, reproducing the policy it actually ran
- * under. A record with no recorded policy sends no sandbox at all: an unknown
- * prior sandbox stays unspecified rather than guessed, because naming a mode we
- * cannot justify would widen a thread that was deliberately restricted. Losing
- * access is recoverable; granting it silently is not.
+ * under. A recorded `sandboxPolicy` is authoritative and restores writable roots
+ * and network access; a legacy record carrying only the coarse `sandbox` mode
+ * replays that mode, which is the most the protocol can express for it.
+ *
+ * A record with NEITHER may be an invalidation from an older version and resumes read-only.
+ * A null policy records invalidation and must resume read-only, even when a
+ * stale coarse mode or the configured default grants broader access.
  */
 export function codexResumeParams(
   record: PersistedCodexThread,
   approvalPolicy: ApprovalPolicy,
 ): ThreadResumeParams {
   const fromPolicy = sandboxResumeParams(record.sandboxPolicy);
+  const sandbox = record.sandboxPolicy === null ? "read-only" : fromPolicy.sandbox
+    ?? (record.sandboxPolicy ? "read-only" : record.sandbox ?? "read-only");
   return {
     threadId: record.threadId,
     ...(record.cwd ? { cwd: record.cwd } : {}),
     approvalPolicy,
-    ...(fromPolicy.sandbox ? { sandbox: fromPolicy.sandbox } : {}),
+    ...(sandbox ? { sandbox } : {}),
     ...(fromPolicy.config ? { config: fromPolicy.config } : {}),
   };
 }
@@ -38,18 +44,18 @@ export function codexResumeParams(
  * What to write to disk as a thread's policy. This is the production decision,
  * shared by every persist site in the daemon.
  *
- * While an override is in flight the answer is `undefined`, never the previous
+ * While an override is in flight the answer is `null`, never the previous
  * value. The previous value is the BROADER one, so reusing it would let a crash
  * or a lost response restore access the thread may no longer have. A record with
- * no policy resumes with no sandbox, which is restrictive: the safe direction.
+ * a null policy resumes read-only. Older versions also used absence for invalidation.
  */
 export function persistedPolicyFor(input: {
   pending: boolean;
   invalidated?: boolean;
   live?: SandboxPolicy;
-  previous?: SandboxPolicy;
-}): SandboxPolicy | undefined {
-  if (input.pending || input.invalidated) return undefined;
+  previous?: SandboxPolicy | null;
+}): SandboxPolicy | null | undefined {
+  if (input.pending || input.invalidated) return null;
   return input.live ?? input.previous;
 }
 
@@ -69,10 +75,11 @@ export function persistedPolicyFor(input: {
 export function applyPolicyInPlace(
   record: PersistedCodexThread | undefined,
   threadId: string,
-  policy: SandboxPolicy | undefined,
+  policy: SandboxPolicy | null | undefined,
 ): boolean {
   if (!record || record.threadId !== threadId) return false;
-  record.sandboxPolicy = policy;
+  record.sandboxPolicy = policy ?? null;
+  delete record.sandbox;
   return true;
 }
 

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { TmuxSpawnRegistry } from "./tmuxSpawns.js";
+import { registerAppServerSpawnTracking, TmuxSpawnRegistry } from "./tmuxSpawns.js";
 import * as fs from "fs";
 import * as path from "path";
 import { randomUUID, createHash, randomBytes } from "node:crypto";
@@ -23860,6 +23860,13 @@ async function main(): Promise<void> {
       markAppServerConversationResumable(entry.conversationId, threadId);
     }
   });
+
+  registerAppServerSpawnTracking(
+    codexAppServerInstance,
+    threadId => appServerThreads.get(threadId)?.conversationId,
+    (messages, parent) => trackTmuxSpawns(messages, parent, syncService, conversationCache),
+    err => logError("[codex-app-server] could not track spawned session", err instanceof Error ? err : new Error(String(err))),
+  );
 
   codexAppServerInstance.on("itemStarted", (threadId: string, turnId: string, item: ThreadItem) => {
     const entry = appServerThreads.get(threadId);

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -102,7 +102,6 @@ import {
   threadItemsToMessages,
   type ApprovalPolicy,
   type SandboxPolicy,
-  type SandboxMode,
   type ApprovalRequest,
   type ThreadItem,
 } from "./codexAppServer.js";
@@ -218,7 +217,7 @@ import {
   upgradedLegacyResumeTmuxName,
 } from "./resumeCommand.js";
 import { conventionSeed, resolveLocalProjectPath, resolveLocalRepoPath, resolveResumeCwd, pickProjectPath, claudeProjectDirName, chooseSessionTranscript, type TranscriptCandidate } from "./projectPathResolver.js";
-import { buildLaunchArgs, getConfiguredAgentArgs, getDefaultParamFlags, getPermissionFlags, launchBinary } from "./launchCommand.js";
+import { buildLaunchArgs, getConfiguredAgentArgs, getDefaultParamFlags, getPermissionFlags, codexPermissionsFromArgs, launchBinary } from "./launchCommand.js";
 import type { AgentStatus, DeviceSnippetSettings, AgentClientId, StableLaunchPrefs, OpenTaskKind, OpenTaskReport } from "@codecast/shared/contracts";
 import { planGatedSnippets } from "./gatedSnippets";
 import { findModelOption, CLAUDE_EFFORT_LEVELS, CODEX_EFFORT_LEVELS, SNIPPET_CATALOG, snippetBySlug, AGENT_CLIENTS, fromConvexAgentType, isValidPaneTarget, STABLE_ENV_MODE, STABLE_ENV_GLOBAL, STABLE_ENV_EXCLUDE, STABLE_ENV_CONVERSATION_ID, classifyApiErrorBanner, isUsageLimitDialog, ACTIVE_AGENT_STATUSES, DECLARED_VERDICT_STATUSES, MID_TURN_AGENT_STATUSES } from "@codecast/shared/contracts";
@@ -934,24 +933,14 @@ export function buildBlankLaunchArgs(
   return [];
 }
 
-/**
- * The sandbox a Codex thread should run under. Codex 0.153+ applies a
- * restrictive managed permission profile to any request that names no sandbox,
- * so "unset" is never safe to send. Deriving it from the approval policy keeps
- * the two from drifting apart, which is what silently stripped live sessions of
- * file and network access on 2026-09-04.
- */
-function sandboxForApprovalPolicy(policy: ApprovalPolicy): SandboxMode {
-  return policy === "never" ? "danger-full-access" : "workspace-write";
-}
-
-function resolveCodexApprovalPolicy(config?: Config | null): ApprovalPolicy {
-  const flags = getPermissionFlags("codex", config);
-  const codexArgs = getAgentArgs(config, "codex") || "";
-  if (flags?.includes("--dangerously-bypass") || codexArgs.includes("--dangerously-bypass") || flags?.includes("--full-auto") || codexArgs.includes("--full-auto")) {
-    return "never";
-  }
-  return "on-request";
+function resolveCodexPermissionDefaults(config?: Config | null) {
+  const { binaryArgs } = buildLaunchArgs({
+    agentType: "codex",
+    configuredArgs: getAgentArgs(config, "codex") || "",
+    permFlags: getPermissionFlags("codex", config),
+    defaultFlags: null,
+  });
+  return codexPermissionsFromArgs(binaryArgs);
 }
 
 interface ConversationCache {
@@ -4599,14 +4588,14 @@ async function executeRemoteCommand(
         let cmdText = `${accountPrefix}${keyPrefix}${disclaimPrefix()}${envPrefix} ${[binary, ...binaryArgs].join(" ")}`;
 
         let codexThreadId: string | null = null;
-        const codexSkipApprovals = binaryArgs.includes("--full-auto") || binaryArgs.includes("--dangerously-bypass-approvals-and-sandbox");
-        const codexApprovalPolicy: ApprovalPolicy = codexSkipApprovals ? "never" : "on-request";
+        const codexPermissions = codexPermissionsFromArgs(binaryArgs);
+        const codexApprovalPolicy = codexPermissions.approvalPolicy;
         const activeCodexAppServer = codexAppServerInstance?.running
           ? codexAppServerInstance
           : null;
         if (agentType === "codex" && activeCodexAppServer) {
           try {
-            const sandbox = sandboxForApprovalPolicy(codexApprovalPolicy);
+            const sandbox = codexPermissions.sandbox;
             const builtContext = await buildCodexStableContext(config, cwd, stablePrefs);
             const resp = await startCodexThreadThenRecordStableContext(
               () => activeCodexAppServer.threadStart({
@@ -5481,7 +5470,7 @@ async function executeRemoteCommand(
             const { filePath: importPath } = writeCodexSession(jsonl, importSessionId, "codecast-fork");
             const importBytes = fs.statSync(importPath).size;
             setPosition(importPath, importBytes);
-            const approvalPolicy = resolveCodexApprovalPolicy(config);
+            const { approvalPolicy, sandbox } = resolveCodexPermissionDefaults(config);
             pendingAppServerForkParents.add(importSessionId);
             pendingForkParentId = importSessionId;
             const forkTimeoutMs = threadForkTimeoutMsForBytes(importBytes);
@@ -5499,7 +5488,7 @@ async function executeRemoteCommand(
                 ? { config: { model_reasoning_effort: resumeOptions.effort } }
                 : {}),
               approvalPolicy,
-              sandbox: sandboxForApprovalPolicy(approvalPolicy),
+              sandbox,
             }, forkTimeoutMs);
             const realThreadId = forked.thread.id;
             remapConversationSession(sessionId, realThreadId, conversationId);
@@ -15364,7 +15353,7 @@ function persistAppServerThreadRegistrations(): boolean {
 function policyForPersist(
   threadId: string,
   previous?: PersistedCodexThread,
-): SandboxPolicy | undefined {
+): SandboxPolicy | null | undefined {
   return persistedPolicyFor({
     pending: !!codexAppServerInstance?.hasPendingPolicyChange(threadId),
     invalidated: !!codexAppServerInstance?.isPolicyInvalidated(threadId),
@@ -15391,10 +15380,13 @@ function registerAppServerConversation(
     persistedAppServerThreads.delete(existingConversation);
   }
   const previous = persistedAppServerThreads.get(conversationId);
+  const carried = previous?.threadId === threadId ? previous : undefined;
+  const sandboxPolicy = policyForPersist(threadId, carried);
   persistedAppServerThreads.set(conversationId, {
-    ...(previous?.threadId === threadId ? previous : {}),
+    ...(carried ?? {}),
     threadId, updatedAt, cwd: opts.cwd, approvalPolicy: opts.approvalPolicy,
-    sandboxPolicy: policyForPersist(threadId, previous?.threadId === threadId ? previous : undefined),
+    sandbox: sandboxPolicy === undefined ? carried?.sandbox : undefined,
+    sandboxPolicy,
   });
   persistAppServerThreadRegistrations();
 }
@@ -15430,13 +15422,15 @@ function markAppServerConversationResumable(
   // policy worth keeping: erasing them here is what left records that later
   // resumed under whatever default Codex chose.
   const carried = previous?.threadId === resolvedThreadId ? previous : undefined;
+  const sandboxPolicy = policyForPersist(resolvedThreadId, carried);
   persistedAppServerThreads.set(conversationId, {
     ...(carried ?? {}),
     threadId: resolvedThreadId,
     updatedAt,
     cwd: liveEntry?.cwd ?? carried?.cwd,
     approvalPolicy: liveEntry?.approvalPolicy ?? carried?.approvalPolicy,
-    sandboxPolicy: policyForPersist(resolvedThreadId, carried),
+    sandbox: sandboxPolicy === undefined ? carried?.sandbox : undefined,
+    sandboxPolicy,
   });
   return persistAppServerThreadRegistrations();
 }
@@ -15470,7 +15464,7 @@ async function rehydratePersistedAppServerThreads(): Promise<void> {
         }
         if (lifecycle.hasPendingMessages && appServerConversations.has(conversationId)) continue;
       }
-      const policy = record.approvalPolicy ?? resolveCodexApprovalPolicy(activeConfig);
+      const policy = record.approvalPolicy ?? resolveCodexPermissionDefaults(activeConfig).approvalPolicy;
       const response = await server.threadResume(codexResumeParams(record, policy));
       if (appServerShuttingDown || !server.running || persistedAppServerThreads.get(conversationId) !== record || pendingAgentSwitches.has(conversationId)) continue;
       registerAppServerConversation(conversationId, record.threadId, {
@@ -15544,6 +15538,7 @@ function loadPersistedAppServerThreadRegistrations(): void {
         updatedAt,
         cwd: record.cwd,
         approvalPolicy: record.approvalPolicy,
+        sandbox: record.sandbox,
         sandboxPolicy: record.sandboxPolicy,
         activeTurnId: record.activeTurnId,
         recoveryAttempts: record.recoveryAttempts,
@@ -23745,6 +23740,7 @@ async function main(): Promise<void> {
 
   codexAppServerInstance = new CodexAppServer({
     log,
+    defaultPermissions: () => resolveCodexPermissionDefaults(activeConfig),
     onApproval: async (threadId: string, approval: ApprovalRequest) => {
       const entry = appServerThreads.get(threadId);
       if (!entry) return true;
@@ -24052,6 +24048,7 @@ async function main(): Promise<void> {
           }));
           if (codexAppServerInstance) {
             registry.register(new CodexAppServerRuntimeDriver({
+              defaultPermissions: () => resolveCodexPermissionDefaults(activeConfig),
               io: {
                 client: codexAppServerInstance,
                 registerThread({ conversationId, threadId, cwd, approvalPolicy }) {

--- a/packages/cli/src/daemonBuildId.ts
+++ b/packages/cli/src/daemonBuildId.ts
@@ -10,4 +10,4 @@
 //
 // This file is excluded from its own hash, and it imports nothing on purpose:
 // the CLI fast path reads it, so it must never pull in a module graph.
-export const DAEMON_BUILD_ID = "210ee0dc1df5";
+export const DAEMON_BUILD_ID = "591800bbe102";

--- a/packages/cli/src/execution/drivers/codexAppServer.test.ts
+++ b/packages/cli/src/execution/drivers/codexAppServer.test.ts
@@ -42,6 +42,35 @@ function fakeIo(): CodexAppServerIo {
 }
 
 describe("CodexAppServerRuntimeDriver", () => {
+  test("an ordinary launch starts and registers full access without approvals", async () => {
+    const io = fakeIo();
+    const permissions: unknown[] = [];
+    io.client.threadStart = async input => { permissions.push(input); return { thread: { id: "thread-1" } }; };
+    io.registerThread = input => { permissions.push(input); };
+    expect((await new CodexAppServerRuntimeDriver({ io }).start(startRequest())).state).toBe("started");
+    expect(permissions).toHaveLength(2);
+    for (const permission of permissions) expect(permission).toMatchObject({ sandbox: "danger-full-access", approvalPolicy: "never" });
+  });
+
+  test("configured restrictions apply when no per-session isolation was supplied", async () => {
+    const io = fakeIo();
+    let permission: unknown;
+    io.client.threadStart = async input => { permission = input; return { thread: { id: "thread-1" } }; };
+    const defaultPermissions = () => ({ sandbox: "read-only", approvalPolicy: "on-request" }) as const;
+    expect((await new CodexAppServerRuntimeDriver({ io, defaultPermissions }).start(startRequest())).state).toBe("started");
+    expect(permission).toMatchObject(defaultPermissions());
+  });
+
+  test("registers the sandbox used to start the thread for later recovery", async () => {
+    const io = fakeIo();
+    let registration: Parameters<NonNullable<CodexAppServerIo["registerThread"]>>[0] | undefined;
+    io.registerThread = input => { registration = input; };
+    const request = startRequest();
+    request.target.isolation = { sandbox: "read-only", approvalPolicy: "never" };
+    expect((await new CodexAppServerRuntimeDriver({ io }).start(request)).state).toBe("started");
+    expect(registration).toMatchObject({ threadId: "thread-1", sandbox: "read-only", approvalPolicy: "never" });
+  });
+
   test("a thread/start error is ambiguous, never a signal to choose another agent", async () => {
     const io = fakeIo();
     io.client.threadStart = async () => { throw new Error("rpc timeout"); };

--- a/packages/cli/src/execution/drivers/codexAppServer.ts
+++ b/packages/cli/src/execution/drivers/codexAppServer.ts
@@ -43,6 +43,7 @@ export interface CodexAppServerIo {
     conversationId: string;
     threadId: string;
     cwd: string;
+    sandbox?: "read-only" | "workspace-write" | "danger-full-access";
     approvalPolicy?: "untrusted" | "on-failure" | "on-request" | "never";
   }): void;
   inspectThread(threadId: string): Promise<"alive" | "missing" | "unknown">;
@@ -53,6 +54,7 @@ export interface CodexAppServerIo {
 export interface CodexAppServerRuntimeDriverOptions {
   io: CodexAppServerIo;
   capabilities?: readonly RuntimeCapability[];
+  defaultPermissions?: () => { sandbox: "read-only" | "workspace-write" | "danger-full-access"; approvalPolicy: "untrusted" | "on-failure" | "on-request" | "never" };
 }
 
 export class CodexAppServerRuntimeDriver implements RuntimeDriver {
@@ -62,9 +64,11 @@ export class CodexAppServerRuntimeDriver implements RuntimeDriver {
   readonly capabilities: readonly RuntimeCapability[];
 
   private readonly io: CodexAppServerIo;
+  private readonly defaultPermissions?: CodexAppServerRuntimeDriverOptions["defaultPermissions"];
 
   constructor(options: CodexAppServerRuntimeDriverOptions) {
     this.io = options.io;
+    this.defaultPermissions = options.defaultPermissions;
     this.capabilities = options.capabilities ?? [...FENCED_RUNTIME_CAPABILITIES];
   }
 
@@ -79,10 +83,13 @@ export class CodexAppServerRuntimeDriver implements RuntimeDriver {
       };
     }
     try {
+      const defaults = this.defaultPermissions?.();
+      const sandbox = request.target.isolation?.sandbox ?? defaults?.sandbox ?? "danger-full-access";
+      const approvalPolicy = request.target.isolation?.approvalPolicy ?? defaults?.approvalPolicy ?? "never";
       const response = await this.io.client.threadStart({
         cwd: request.target.projectPath,
-        sandbox: request.target.isolation?.sandbox,
-        approvalPolicy: request.target.isolation?.approvalPolicy,
+        sandbox,
+        approvalPolicy,
         model: request.configuration.model,
         ...(request.configuration.effort
           ? { config: { model_reasoning_effort: request.configuration.effort } }
@@ -96,7 +103,8 @@ export class CodexAppServerRuntimeDriver implements RuntimeDriver {
         conversationId: request.target.conversationId,
         threadId,
         cwd: request.target.projectPath,
-        approvalPolicy: request.target.isolation?.approvalPolicy,
+        sandbox,
+        approvalPolicy,
       });
       return {
         state: "started",

--- a/packages/cli/src/jsonlGenerator.callIds.test.ts
+++ b/packages/cli/src/jsonlGenerator.callIds.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { generateCodexJsonl, type ExportResult } from "./jsonlGenerator";
+
+const timestamp = "2026-09-04T21:39:00.000Z";
+const importedId = "interactive-prompt-724d7618-2899-484e-a2ef-c5092c34fdc2-f52c1423b993f5fd";
+
+function generate(ids: string[], restore: boolean) {
+  const data: ExportResult = {
+    conversation: {
+      id: "conversation", title: "Imported workflow", session_id: "session",
+      agent_type: "claude", model: null, project_path: "/tmp/project",
+      message_count: ids.length * 2, started_at: timestamp, updated_at: timestamp,
+    },
+    messages: ids.flatMap((id, index) => [
+      { role: "assistant", content: "", timestamp,
+        tool_calls: [{ id, name: "AskUserQuestion", input: '{"question":"Continue?"}' }] },
+      { role: index % 2 ? "assistant" : "user", content: "", timestamp,
+        tool_results: [{ tool_use_id: id, content: "Continue", is_error: Boolean(index % 2) }] },
+    ]),
+  };
+  return generateCodexJsonl(data, restore ? { sessionId: "session" } : {}).jsonl
+    .trim().split("\n").map(line => JSON.parse(line))
+    .filter(entry => entry.type === "response_item" && entry.payload.call_id)
+    .map(entry => entry.payload);
+}
+
+describe("Codex import tool-call IDs", () => {
+  for (const restore of [false, true]) {
+    test(`${restore ? "restoring" : "importing"} bounds IDs and preserves call/result pairing`, () => {
+      const ids = [importedId, importedId.slice(0, -1) + "e", "toolu_valid", "x".repeat(64)];
+      const rows = generate(ids, restore);
+      expect(rows).toHaveLength(8);
+      expect(rows.every(row => row.call_id.length <= 64)).toBe(true);
+      expect(new Set(rows.filter(row => row.type === "function_call").map(row => row.call_id)).size).toBe(4);
+      ids.forEach((id, index) => {
+        const call = rows[index * 2];
+        const result = rows[index * 2 + 1];
+        expect(call.type).toBe("function_call");
+        expect(result.type).toBe("function_call_output");
+        expect(result.call_id).toBe(call.call_id);
+        expect(result.output).toContain("Continue");
+        if (id.length <= 64) expect(call.call_id).toBe(id);
+      });
+      expect(generate(ids, restore)).toEqual(rows);
+    });
+  }
+});

--- a/packages/cli/src/jsonlGenerator.ts
+++ b/packages/cli/src/jsonlGenerator.ts
@@ -701,6 +701,22 @@ function mapToolName(name: string): string {
   return "shell_command";
 }
 
+/**
+ * Codex's API rejects any function call id longer than 64 characters
+ * (`string_above_max_length` on `input[N].call_id`). Codecast mints ids that are
+ * structurally over: an interactive prompt card is
+ * `interactive-prompt-<uuid>-<digest>`, 72 characters, so every transcript
+ * carrying one poisons the import.
+ *
+ * Hashing is deterministic, so a call and its matching output normalize to the
+ * same value independently and the pairing survives. Ids already within the
+ * limit are returned untouched, which keeps native Codex ids (29-30 chars)
+ * readable and stable.
+ */
+export function normalizeCodexCallId(id: string): string {
+  return id.length <= 64 ? id : crypto.createHash("sha256").update(id).digest("hex");
+}
+
 export interface GenerateCodexJsonlOptions {
   sessionId?: string;
 }
@@ -751,7 +767,7 @@ export function generateCodexJsonl(
         for (const tr of msg.tool_results) {
           lines.push(JSON.stringify({
             timestamp: ts, type: "response_item",
-            payload: { type: "function_call_output", call_id: tr.tool_use_id, output: tr.is_error ? `Error:\n${tr.content}` : `Exit code: 0\nOutput:\n${tr.content}` },
+            payload: { type: "function_call_output", call_id: normalizeCodexCallId(tr.tool_use_id), output: tr.is_error ? `Error:\n${tr.content}` : `Exit code: 0\nOutput:\n${tr.content}` },
           }));
         }
       } else {
@@ -780,7 +796,7 @@ export function generateCodexJsonl(
         for (const tc of msg.tool_calls) {
           lines.push(JSON.stringify({
             timestamp: ts, type: "response_item",
-            payload: { type: "function_call", name: mapToolName(tc.name), arguments: tc.input, call_id: tc.id },
+            payload: { type: "function_call", name: mapToolName(tc.name), arguments: tc.input, call_id: normalizeCodexCallId(tc.id) },
           }));
         }
       }
@@ -793,7 +809,7 @@ export function generateCodexJsonl(
         for (const tr of msg.tool_results) {
           lines.push(JSON.stringify({
             timestamp: ts, type: "response_item",
-            payload: { type: "function_call_output", call_id: tr.tool_use_id, output: tr.is_error ? `Error:\n${tr.content}` : `Exit code: 0\nOutput:\n${tr.content}` },
+            payload: { type: "function_call_output", call_id: normalizeCodexCallId(tr.tool_use_id), output: tr.is_error ? `Error:\n${tr.content}` : `Exit code: 0\nOutput:\n${tr.content}` },
           }));
         }
       }

--- a/packages/cli/src/launchCommand.ts
+++ b/packages/cli/src/launchCommand.ts
@@ -19,6 +19,47 @@ import {
 } from "@codecast/shared/contracts";
 import { getAgentArgs, type Config } from "./config/types.js";
 import { stableClaudeBinary } from "./stableClaudeBinary.js";
+import type { ApprovalPolicy, SandboxMode } from "./codexAppServer.js";
+
+function codexPermissionArgs(args: readonly string[]): Array<[string, string | undefined]> {
+  const options: Array<[string, string | undefined]> = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--") break;
+    const parts = arg.split("=", 2);
+    let flag = parts[0]!;
+    let inline: string | undefined = parts[1];
+    if (/^-[sa]/.test(arg)) {
+      flag = arg.slice(0, 2);
+      inline = arg.length > 2 ? arg.slice(2).replace(/^=/, "") : undefined;
+    }
+    if (flag === "--sandbox" || flag === "-s" || flag === "--ask-for-approval" || flag === "-a") {
+      options.push([flag, inline ?? (args[i + 1] === "--" ? undefined : args[++i])]);
+    } else if (arg === "--dangerously-bypass-approvals-and-sandbox" || arg === "--yolo" || arg === "--full-auto") {
+      options.push([arg, undefined]);
+    }
+  }
+  return options;
+}
+
+export function codexPermissionsFromArgs(args: readonly string[]): { sandbox: SandboxMode; approvalPolicy: ApprovalPolicy } {
+  let sandbox: SandboxMode = "workspace-write";
+  let approvalPolicy: ApprovalPolicy = "on-request";
+  for (const [flag, value] of codexPermissionArgs(args)) {
+    if (flag === "--dangerously-bypass-approvals-and-sandbox" || flag === "--yolo") {
+      sandbox = "danger-full-access";
+      approvalPolicy = "never";
+    } else if (flag === "--full-auto") {
+      sandbox = "workspace-write";
+      approvalPolicy = "on-request";
+    } else if (flag === "--sandbox" || flag === "-s") {
+      if (value === "read-only" || value === "workspace-write" || value === "danger-full-access") sandbox = value;
+    } else if (flag === "--ask-for-approval" || flag === "-a") {
+      if (value === "untrusted" || value === "on-failure" || value === "on-request" || value === "never") approvalPolicy = value;
+    }
+  }
+  return { sandbox, approvalPolicy };
+}
 
 /**
  * The single seam for reading a client's user-configured base launch args.
@@ -59,7 +100,7 @@ export function getPermissionFlags(agentType: AgentClientId, config?: Config | n
     return "--permission-mode bypassPermissions";
   } else if (agentType === "codex") {
     const existing = getAgentArgs(config, "codex") || "";
-    if (existing.includes("--full-auto") || existing.includes("--ask-for-approval") || existing.includes("--dangerously-bypass")) return null;
+    if (codexPermissionArgs(splitFlags(existing)).length) return null;
     if (modes?.codex === "full_auto") return "--full-auto";
     if (modes?.codex === "default") return null;
     return "--dangerously-bypass-approvals-and-sandbox";
@@ -100,7 +141,7 @@ export function permissionFlagsForMode(
     return `--permission-mode ${m}`;
   }
   if (agentType === "codex") {
-    if (configuredArgs.includes("--full-auto") || configuredArgs.includes("--ask-for-approval") || configuredArgs.includes("--dangerously-bypass")) return null;
+    if (codexPermissionArgs(splitFlags(configuredArgs)).length) return null;
     if (m === "bypass") return "--dangerously-bypass-approvals-and-sandbox";
     if (m === "full_auto") return "--full-auto";
     if (m === "default") return null;
@@ -158,10 +199,14 @@ export interface LaunchArgsResult {
 export function buildLaunchArgs(input: LaunchArgsInput): LaunchArgsResult {
   const { agentType, configuredArgs, permFlags, defaultFlags } = input;
   const args: string[] = [];
+  const codexPromptArgs: string[] = [];
   let notifyCodexBypass = false;
 
   if (agentType === "codex") {
-    if (configuredArgs) args.push(...configuredArgs.split(/\s+/).filter(Boolean));
+    const configured = splitFlags(configuredArgs);
+    const end = configured.indexOf("--");
+    if (end !== -1) codexPromptArgs.push(...configured.splice(end));
+    args.push(...configured);
     if (permFlags) {
       args.push(...permFlags.split(/\s+/).filter(Boolean));
       if (!configuredArgs && !input.hasCodexPermissionMode) notifyCodexBypass = true;
@@ -201,6 +246,7 @@ export function buildLaunchArgs(input: LaunchArgsInput): LaunchArgsResult {
   if (defaultFlags) args.push(...defaultFlags.split(/\s+/).filter(Boolean));
 
   appendModelEffortFlags(args, input);
+  args.push(...codexPromptArgs);
 
   return { binaryArgs: args, notifyCodexBypass };
 }
@@ -306,6 +352,7 @@ export function buildPrintArgs(input: PrintArgsInput): PrintArgsResult {
   const print = AGENT_CLIENTS[agentType].printMode;
   const ignored: string[] = [];
   const args: string[] = [];
+  const codexPromptArgs: string[] = [];
 
   if (print.kind === "subcommand") args.push(print.token);
 
@@ -329,7 +376,10 @@ export function buildPrintArgs(input: PrintArgsInput): PrintArgsResult {
     else if (input.continueLast) args.push("--continue");
   }
 
-  if (input.configuredArgs) args.push(...splitFlags(input.configuredArgs));
+  const configured = splitFlags(input.configuredArgs);
+  const end = configured.indexOf("--");
+  if (agentType === "codex" && end !== -1) codexPromptArgs.push(...configured.splice(end));
+  args.push(...configured);
 
   if (agentType === "opencode" && !input.configuredArgs.includes("--auto")) {
     args.push("--auto");
@@ -395,6 +445,7 @@ export function buildPrintArgs(input: PrintArgsInput): PrintArgsResult {
     }
   }
 
+  args.push(...codexPromptArgs);
   if (print.kind === "flag") {
     if (print.promptAsValue) args.push(print.token, prompt);
     else {

--- a/packages/cli/src/test-helpers/tmuxSpawnFixture.ts
+++ b/packages/cli/src/test-helpers/tmuxSpawnFixture.ts
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
 import { resolveSpawnerConversation } from "../daemon.js";
-import { TmuxSpawnRegistry } from "../tmuxSpawns.js";
+import { registerAppServerSpawnTracking, TmuxSpawnRegistry } from "../tmuxSpawns.js";
 import { tmuxRunAsync } from "../tmux.js";
 
 async function verify() {
@@ -12,21 +13,29 @@ async function verify() {
   const transcript = join(dir, "rollout.jsonl");
   const script = join(dir, "writer.js");
   const registryFile = join(dir, "registry.json");
-  const launchTime = Date.now();
   const quote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
   writeFileSync(script, `const fs = require("node:fs"); const fd = fs.openSync(process.argv[2], "w"); fs.writeSync(fd, JSON.stringify({timestamp: new Date().toISOString(), type: "session_meta", payload: {id: "child"}})+"\\n"); setInterval(() => fs.fsyncSync(fd), 1000);`);
   const registry = new TmuxSpawnRegistry(registryFile);
-  registry.record([{ role: "assistant", content: "", timestamp: launchTime, toolCalls: [{ id: "launch", name: "exec_command", input: { cmd: `tmux new-session -d -s ${name} 'writer'` } }] }], "parent-conversation");
+  const server = new EventEmitter();
+  registerAppServerSpawnTracking(server, threadId => threadId === "parent-thread" ? "parent-conversation" : undefined, async (messages, parent) => {
+    registry.record(messages, parent);
+  }, err => { throw err; });
+  const command = `tmux new-session -d -s ${name} ${quote(`${quote(process.execPath)} ${quote(script)} ${quote(transcript)}`)}`;
+  server.emit("itemStarted", "parent-thread", "turn", { type: "commandExecution", id: "launch", status: "inProgress", command: `/bin/bash -lc ${quote(command)}`, cwd: dir });
   try {
     assert.equal((await tmuxRunAsync(["new-session", "-d", "-s", name, `${quote(process.execPath)} ${quote(script)} ${quote(transcript)}`])).status, 0);
     for (let i = 0; i < 40 && !existsSync(transcript); i++) await Bun.sleep(50);
     assert.ok(existsSync(transcript));
+    assert.equal(registry.parent(name, Date.now()), "parent-conversation");
     const restored = new TmuxSpawnRegistry(registryFile);
-    assert.equal(await resolveSpawnerConversation(transcript, "child", "codex", {}, restored), "parent-conversation");
+    const parent = await resolveSpawnerConversation(transcript, "child", "codex", {}, restored);
+    assert.equal(parent, "parent-conversation");
+    return parent;
   } finally {
     await tmuxRunAsync(["kill-session", "-t", `=${name}`]);
   }
 }
-await verify();
+const parent = await verify();
+writeFileSync(join(process.argv[2], "result.json"), JSON.stringify({ parent }));
 console.log("parent recovered after restart");
 process.exit(0);

--- a/packages/cli/src/tmuxSpawns.e2e.test.ts
+++ b/packages/cli/src/tmuxSpawns.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
@@ -11,8 +11,8 @@ test.skipIf(process.platform === "win32")("detached tmux transcript writer resol
   const env: NodeJS.ProcessEnv = { ...process.env, TMUX_TMPDIR: dir, NODE_ENV: "test" };
   delete env.TMUX;
   try {
-    const result = await run(process.execPath, [join(import.meta.dir, "test-helpers/tmuxSpawnFixture.ts"), dir], { env, timeout: 20_000, killSignal: "SIGKILL" });
-    expect(result.stdout.trim()).toBe("parent recovered after restart");
+    await run(process.execPath, [join(import.meta.dir, "test-helpers/tmuxSpawnFixture.ts"), dir], { env, timeout: 20_000, killSignal: "SIGKILL" });
+    expect(JSON.parse(readFileSync(join(dir, "result.json"), "utf8"))).toEqual({ parent: "parent-conversation" });
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/cli/src/tmuxSpawns.test.ts
+++ b/packages/cli/src/tmuxSpawns.test.ts
@@ -2,8 +2,9 @@ import { expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { EventEmitter } from "node:events";
 import { parseCodexSessionFile, parseSessionFile, type ParsedMessage } from "./parser";
-import { tmuxSpawns, TmuxSpawnRegistry } from "./tmuxSpawns";
+import { registerAppServerSpawnTracking, tmuxSpawns, TmuxSpawnRegistry } from "./tmuxSpawns";
 
 const timestamp = "2026-09-05T00:54:59.202Z";
 const startedAt = Date.parse(timestamp);
@@ -25,6 +26,74 @@ test("quoted examples, comments, user text and dynamic names are not launches", 
   expect(tmuxSpawns(shell("echo 'tmux new-session -s fake'\n# tmux new -s comment\ntmux new -s \"$DYNAMIC\""))).toEqual([]);
   expect(tmuxSpawns([{ ...shell("tmux new -s fake")[0], role: "user" }])).toEqual([]);
   expect(tmuxSpawns(shell("tmux new -s `whoami`"))).toEqual([]);
+});
+
+test("Codex commandExecution unwraps login shells and skips the brief heredoc", () => {
+  const command = "/bin/bash -lc \"cat > /tmp/brief.md <<'EOF'\ntmux new -s example\nEOF\ntmux new-session -d -s growth-conversion-check -c /repo\ntmux send-keys -t growth-conversion-check -- 'codex exec - < /tmp/brief.md' Enter\"";
+  const messages = shell(command);
+  messages[0].toolCalls![0].name = "commandExecution";
+  expect(tmuxSpawns(messages)).toEqual([{ name: "growth-conversion-check", timestamp: startedAt }]);
+  expect(tmuxSpawns(shell("/bin/zsh -lc 'bash -c \"tmux new -s nested\"'")).map(s => s.name)).toEqual(["nested"]);
+  expect(tmuxSpawns(shell("echo '/bin/bash -lc \"tmux new -s example\"'"))).toEqual([]);
+  expect(tmuxSpawns(shell("bash /tmp/script.sh -c 'tmux new -s example'"))).toEqual([]);
+});
+
+test("agent-spawn runtime and model options preserve the actual tmux session name", () => {
+  for (const options of ["--codex", "--claude", "--runtime codex --model model", "--runtime=codex --model=model", "--"]) {
+    expect(tmuxSpawns(shell(`/bin/bash -lc '/home/me/agent-spawn.sh ${options} reviewer growth-conversion-audit /repo brief'`)).map(s => s.name)).toEqual(["growth-conversion-audit"]);
+  }
+  for (const options of ["--dry-run", "--help", "-h", "--unknown", "--runtime --codex", "--model --codex"]) {
+    expect(tmuxSpawns(shell(`agent-spawn.sh ${options} reviewer not-launched /repo`))).toEqual([]);
+  }
+});
+
+test("syntax-only shells cannot replace the real launch parent", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cast-tmux-noexec-"));
+  try {
+    const registry = new TmuxSpawnRegistry(join(dir, "spawns.json"));
+    registry.record(shell("/bin/bash -elc 'tmux new -s worker'"), "real-parent");
+    for (const command of [
+      "bash -nc 'tmux new -s worker'",
+      "bash -n -c 'tmux new -s worker'",
+      "bash -lcn 'tmux new -s worker'",
+      "/bin/bash -lc 'bash -nc \"tmux new -s worker\"'",
+      "bash -o noexec -c 'tmux new -s worker'",
+      "bash -o -c 'tmux new -s worker'",
+      "zsh --noexec -c 'tmux new -s worker'",
+    ]) {
+      const messages = shell(command);
+      messages[0].timestamp++;
+      expect(tmuxSpawns(messages)).toEqual([]);
+      expect(registry.record(messages, "syntax-check-parent")).toEqual([]);
+      expect(registry.parentForPanes("worker 100", [101, 100], startedAt + 2)).toBe("real-parent");
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("app-server records a launch at item start, before the command completes", async () => {
+  const server = new EventEmitter();
+  const launches: string[] = [];
+  const errors: unknown[] = [];
+  registerAppServerSpawnTracking(server, id => id === "parent-thread" ? "parent-conversation" : undefined, async (messages, parent) => {
+    expect(parent).toBe("parent-conversation");
+    launches.push(...tmuxSpawns(messages).map(s => s.name));
+  }, err => errors.push(err));
+  const item = { type: "commandExecution", id: "launch", status: "inProgress", command: "/bin/bash -lc 'tmux new -s worker'", cwd: "/repo" };
+  server.emit("itemStarted", "unrelated", "turn", item);
+  expect(launches).toEqual([]);
+  server.emit("itemStarted", "parent-thread", "turn", item);
+  expect(launches).toEqual(["worker"]);
+  server.emit("itemCompleted", "parent-thread", "turn", { ...item, status: "completed" });
+  expect(launches).toEqual(["worker"]);
+  expect(errors).toEqual([]);
+
+  const failedServer = new EventEmitter();
+  registerAppServerSpawnTracking(failedServer, () => "parent", async () => { throw new Error("write failed"); }, err => errors.push(err));
+  failedServer.emit("itemStarted", "parent-thread", "turn", item);
+  await Promise.resolve();
+  expect(errors).toHaveLength(1);
 });
 
 test("launch survives restart and resolves through the child pane ancestry", () => {

--- a/packages/cli/src/tmuxSpawns.ts
+++ b/packages/cli/src/tmuxSpawns.ts
@@ -2,8 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { extractNestedActions, isShellTool } from "@codecast/shared/render";
 import { atomicWriteFile } from "./atomicWrite.js";
 import type { ParsedMessage } from "./parser.js";
+import type { EventEmitter } from "node:events";
+import { threadItemToMessage, type ThreadItem } from "./codexAppServer.js";
 
-function shellCommands(source: string): string[][] {
+function shellCommands(source: string, depth = 0): string[][] {
   const commands: string[][] = [];
   let words: string[] = [];
   let word = "";
@@ -58,7 +60,45 @@ function shellCommands(source: string): string[][] {
   }
   flushWord();
   if (words.length) commands.push(words);
-  return commands;
+  return commands.flatMap(words => {
+    if (depth >= 4 || !/^(?:.*\/)?(?:ba|z|da|k)?sh$/.test(words[0])) return [words];
+    for (let at = 1; at < words.length; at++) {
+      if (/^-[ceiluvx]+$/.test(words[at]) && words[at].includes("c")) {
+        return words[at + 1] ? shellCommands(words[at + 1], depth + 1) : [words];
+      }
+      if (!/^-[eiluvx]+$|^--(?:noprofile|norc|login)$/.test(words[at])) break;
+    }
+    return [words];
+  });
+}
+
+function agentSpawnName(words: string[]): string | undefined {
+  let at = 1;
+  for (; at < words.length && words[at].startsWith("-"); at++) {
+    const option = words[at];
+    if (option === "--") { at++; break; }
+    if (option === "--codex" || option === "--claude" || /^--(?:runtime|model)=.+/.test(option)) continue;
+    if (option === "--runtime" || option === "--model") {
+      if (!words[++at] || words[at].startsWith("--")) return undefined;
+      continue;
+    }
+    return undefined;
+  }
+  return words[at + 1];
+}
+
+export function registerAppServerSpawnTracking(
+  server: EventEmitter,
+  parentForThread: (threadId: string) => string | undefined,
+  track: (messages: ParsedMessage[], parent: string) => Promise<void>,
+  onError: (err: unknown) => void,
+): void {
+  server.on("itemStarted", (threadId: string, _turnId: string, item: ThreadItem) => {
+    const parent = parentForThread(threadId);
+    if (!parent) return;
+    const message = threadItemToMessage(item);
+    if (message) void track([message], parent).catch(onError);
+  });
 }
 
 export function tmuxSpawns(messages: readonly ParsedMessage[]): Array<{ name: string; timestamp: number }> {
@@ -75,7 +115,7 @@ export function tmuxSpawns(messages: readonly ParsedMessage[]): Array<{ name: st
         if (typeof source !== "string") continue;
         for (const words of shellCommands(source)) {
           let name: string | undefined;
-          if (/^(?:.*\/)?agent-spawn(?:\.sh)?$/.test(words[0])) name = words[2];
+          if (/^(?:.*\/)?agent-spawn(?:\.sh)?$/.test(words[0])) name = agentSpawnName(words);
           if (words[0] === "tmux" && (words[1] === "new-session" || words[1] === "new")) {
             const at = words.indexOf("-s", 2);
             if (at >= 0) name = words[at + 1];

--- a/packages/web/store/__tests__/subagentNesting.test.ts
+++ b/packages/web/store/__tests__/subagentNesting.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import type { InboxSession } from "../inboxStore";
+import { sessionStructuralSig } from "../inboxStore";
+import { placeSections } from "./placeTestHarness";
+
+const now = Date.now();
+const row = (id: string, over: Partial<InboxSession> = {}): InboxSession => ({
+  _id: id,
+  session_id: id,
+  title: id,
+  agent_type: "codex",
+  agent_status: "working",
+  is_idle: false,
+  message_count: 5,
+  updated_at: now,
+  ...over,
+});
+const parent = row("parent");
+const child = row("child", { parent_conversation_id: "parent", is_subagent: true, inbox_dismissed_at: now });
+const ids = (rows: InboxSession[]) => rows.map(row => row._id);
+const place = (rows: InboxSession[]) => placeSections(Object.fromEntries(rows.map(row => [row._id, row])), new Set(), undefined, { now });
+
+describe("linked subagent nesting", () => {
+  it("nests an automatically dismissed child without adding an inbox card or count", () => {
+    const placed = place([parent, child]);
+    expect(ids(placed.subsByParent.get("parent") ?? [])).toEqual(["child"]);
+    expect(ids(placed.working)).toEqual(["parent"]);
+    expect(placed.tally.shown.working).toBe(1);
+    expect(placed.dismissed).toEqual([]);
+  });
+
+  it("supports legacy parent-linked children without the subagent flag", () => {
+    const placed = place([parent, { ...child, is_subagent: undefined }]);
+    expect(ids(placed.subsByParent.get("parent") ?? [])).toEqual(["child"]);
+  });
+
+  it("honors explicit stash and kill on a child", () => {
+    for (const stamp of [{ inbox_stashed_at: now }, { inbox_killed_at: now }]) {
+      expect(sessionStructuralSig({ ...child, ...stamp })).not.toBe(sessionStructuralSig(child));
+      const placed = place([parent, { ...child, ...stamp }]);
+      expect(placed.subsByParent.get("parent") ?? []).toEqual([]);
+      expect(ids(placed.working)).toEqual(["parent"]);
+    }
+  });
+
+  it("never exposes children under an absent or hidden parent", () => {
+    for (const rows of [[child], [child, { ...parent, inbox_dismissed_at: now }], [child, { ...parent, inbox_stashed_at: now }]]) {
+      const placed = place(rows);
+      expect(placed.subsByParent.size).toBe(0);
+      expect(placed.working).toEqual([]);
+      expect(placed.sorted).toEqual([]);
+    }
+  });
+
+  it("keeps a dismissed plan handoff dismissed", () => {
+    const placed = place([parent, { ...child, is_subagent: false, parent_message_uuid: "plan-handoff" }]);
+    expect(placed.subsByParent.size).toBe(0);
+    expect(ids(placed.dismissed)).toEqual(["child"]);
+  });
+
+});

--- a/packages/web/store/inboxStore.ts
+++ b/packages/web/store/inboxStore.ts
@@ -2346,7 +2346,8 @@ export function sessionStructuralSig(s: InboxSession): string {
     sessionSortRank(s).join(","),
     isSessionHidden(s) ? 1 : 0,
     isSessionDismissed(s) ? 1 : 0,
-    isSessionStashed(s) ? 1 : 0,
+    s.inbox_stashed_at ? 1 : 0,
+    isSessionKilled(s) ? 1 : 0,
     nestParentIdOf(s) || "",
     s.forked_from || "",
     orchestrationGroupLabelOf(s) || "",
@@ -2900,10 +2901,12 @@ export function placeInboxRows(
     // A placed row files by its placement; a stub or child row by its own
     // stamps. An anchor's standing thread lives in its own space unless hard
     // blocked — the shared `hidden` bucket, never rendered here.
-    const setAside = p ? p.bucket === "dismissed" || p.bucket === "stashed" || p.bucket === "hidden" : isSessionHidden(s);
+    const subagent = isOrphanOrSubagent(s);
+    const hidden = subagent ? !!s.inbox_killed_at || !!s.inbox_stashed_at : isSessionHidden(s);
+    const setAside = p ? p.bucket === "dismissed" || p.bucket === "stashed" || p.bucket === "hidden" : hidden;
     // The rank reads the SAME verdict the section files under (rankVerdictOf).
     if (!setAside) activeKeyed.push({ s, rank: sessionSortRank(s, p) });
-    if (p ? p.bucket === "dismissed" : isSessionDismissed(s)) dismissed.push(s);
+    if (p ? p.bucket === "dismissed" : !subagent && isSessionDismissed(s)) dismissed.push(s);
     if (p ? p.bucket === "stashed" : isSessionStashed(s)) stashed.push(s);
   }
   activeKeyed.sort(compareRankedSessions);
@@ -3074,7 +3077,7 @@ export function placeInboxRows(
     tally: tallyOut,
     truncated: reuseArray(prev?.truncated, membership?.truncated ?? EMPTY_TRUNCATED),
     set_digest,
-    sorted: reuseArray(prev?.sorted, sorted),
+    sorted: reuseArray(prev?.sorted, sorted.filter(s => !isOrphanSubagent(s))),
     questions: reuseArray(prev?.questions, questions),
     pinned: reuseArray(prev?.pinned, pinned),
     newSessions: reuseArray(prev?.newSessions, newSessions),


### PR DESCRIPTION
Codex launches can lose intended access, imported tool IDs can exceed the provider limit, and detached workers can appear outside their parent. This update restores configured launch defaults while preserving explicit restrictions, bounds imported IDs without breaking call/result pairing, and tracks and displays linked workers under their parent.

Old records with no trustworthy saved permission policy remain restricted. A separate reviewed activation procedure restores only the specifically reported session; no blanket permission migration is included.

Validation: combined focused tests, real Codex app-server controls with credential-free local providers, all repository typechecks and lint passed. Parenting has detached tmux and browser verification; linked-worker nesting has candidate browser proof. Full CI is required before release.
