### PR TITLE
fix(integrations): fence concurrent Linear token refreshes

### DIFF
--- a/docs/architecture/issue-sync.md
+++ b/docs/architecture/issue-sync.md
@@ -178,8 +178,24 @@ Both write `external.synced_at`, `external.field_ts`, and `last_error` on
 failure. Failures are logged, never retried in a loop: the 15 minute reconcile
 (S6) is the retry.
 
-Tokens: Linear via `oauthConnectors.getAccessTokenForTeam`; GitHub via
-`githubApp.getInstallationToken` for the installation covering the repo.
+Tokens: Linear via `oauthConnectors.getFreshAccessTokenForTeam`, which
+refreshes the 24 hour access token ahead of `access_expires_at` and stores
+the rotated refresh token in the same write; a refused refresh lands on the
+connection's `last_error` and parks the source with a "reconnect" message.
+The refresh is single flight: a caller claims a lease (`refresh_lease_id`
+plus `refresh_lease_until`, the agent task lease shape; the claim itself is
+a compare and swap on the access ciphertext) before talking to the provider,
+and concurrent callers wait for the row to change instead of spending the
+same refresh token twice. Every outcome write, success or failure, is
+fenced by exact lease ownership and by the credentials the writer read, and
+the one write that passes releases the lease. Response arrival order says
+nothing about whose pair is newer, so an expired claimant's late success is
+refused like its late failure. A refused write never hands out the pair it
+fetched: the caller waits for the current owner's write and returns what the
+row holds then, and a disconnected connection yields no credentials at all.
+GitHub via `githubApp.getInstallationToken` for the installation covering
+the repo. The reconcile retries parked sources every tick, and a successful
+sync flips a parked source back to active.
 
 ## S6. Inbound
 

--- a/packages/convex/convex/issueSync.test.ts
+++ b/packages/convex/convex/issueSync.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { GITHUB_EVENT_KINDS, linearEventKind } from "./issueSync";
 import { linearDeliveryId, verifyLinearSignature } from "./linearWebhooks";
+import { markSourceSynced } from "./issueSync";
+import { makeFakeDb } from "./testDb";
 import {
   normalizeGithubComment,
   normalizeGithubIssue,
@@ -247,5 +249,26 @@ describe("github webhook payloads", () => {
       body: "On it.",
       author_login: "ada",
     });
+  });
+});
+
+describe("markSourceSynced status transitions", () => {
+  const run = (status: string, args: Record<string, any>) => {
+    const t = { issue_sync_sources: [{ _id: "src_1", status, updated_at: 1 }] as any[] };
+    return (markSourceSynced as any)._handler({ db: makeFakeDb(t) }, { source_id: "src_1", ...args }).then(() => t.issue_sync_sources[0]);
+  };
+  test("a parked source heals on a clean sync; a paused one stays paused", async () => {
+    expect((await run("error", {})).status).toBe("active");
+    expect((await run("paused", {})).status).toBe("paused");
+    expect((await run("active", {})).status).toBe("active");
+  });
+  test("only an auth failure parks; a transient error leaves the status alone", async () => {
+    expect((await run("active", { error: "Linear API 401", auth_failed: true })).status).toBe("error");
+    const transient = await run("active", { error: "Linear API 502" });
+    expect(transient.status).toBe("active");
+    expect(transient.last_error).toBe("Linear API 502");
+    const pausedLate = await run("paused", { error: "Linear API 401", auth_failed: true });
+    expect(pausedLate.status).toBe("paused");          // the user's pause outlives a late failure
+    expect(pausedLate.last_error).toBe("Linear API 401");
   });
 });

--- a/packages/convex/convex/issueSync.ts
+++ b/packages/convex/convex/issueSync.ts
@@ -780,11 +780,16 @@ async function tokenFor(
 ): Promise<string | null> {
   if (provider === "linear") {
     if (!teamId) return null;
-    const res = await ctx.runQuery(internal.oauthConnectors.getAccessTokenForTeam, {
+    // Refreshes an expiring or unknown-age token first (Linear rotates 24h
+    // tokens). A missing connection is null like GitHub's; a refresh refusal
+    // is thrown so the source's last_error says "reconnect", not "401".
+    const res = await ctx.runAction(internal.oauthConnectors.getFreshAccessTokenForTeam, {
       provider: "linear",
       team_id: teamId,
     });
-    return res?.token ?? null;
+    if (res.ok && res.token) return res.token;
+    if (res.error?.startsWith("no_connection")) return null;
+    throw new Error(res.error ?? "Linear token refresh failed");
   }
   if (!repo) return null;
   const installation = teamId
@@ -1074,7 +1079,12 @@ export const getSource = internalQuery({
 export const listActiveSources = internalQuery({
   args: {},
   handler: async (ctx) =>
-    await ctx.db.query("issue_sync_sources").withIndex("by_status", (q: any) => q.eq("status", "active")).collect(),
+    [
+      ...(await ctx.db.query("issue_sync_sources").withIndex("by_status", (q: any) => q.eq("status", "active")).collect()),
+      // Parked on an auth failure: still worth one call per tick, because the
+      // token refresh or a reconnect heals it without anyone pressing Resume.
+      ...(await ctx.db.query("issue_sync_sources").withIndex("by_status", (q: any) => q.eq("status", "error")).collect()),
+    ],
 });
 
 export const markSourceSynced = internalMutation({
@@ -1085,17 +1095,26 @@ export const markSourceSynced = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = Date.now();
+    const source = await ctx.db.get(args.source_id);
+    if (!source) return;
     const patch: Record<string, any> = { updated_at: now, last_error: args.error };
-    if (!args.error) patch.last_synced_at = now;
+    if (!args.error) {
+      patch.last_synced_at = now;
+      // A parked source that syncs again is healthy again (a refreshed token,
+      // a reconnect): flip it back without a manual resume.
+      if (source.status === "error") patch.status = "active";
+    }
     // Only an auth failure parks the source: a transient 500 must not stop the
-    // next reconcile from trying again.
-    if (args.auth_failed) patch.status = "error";
+    // next reconcile from trying again. A pause is the user's word and wins
+    // over a failure that lands late from a sync already running: the error
+    // is recorded, the status stays paused.
+    if (args.auth_failed && source.status !== "paused") patch.status = "error";
     await ctx.db.patch(args.source_id, patch);
   },
 });
 
 function isAuthFailure(message: string): boolean {
-  return /\b(401|403)\b|no_connection|unauthorized|authentication/i.test(message);
+  return /\b(401|403)\b|no_connection|unauthorized|authentication|invalid_grant|reconnect/i.test(message);
 }
 
 /**

--- a/packages/convex/convex/oauthConnectors.test.ts
+++ b/packages/convex/convex/oauthConnectors.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { getFunctionName } from "convex/server";
 import { makeFakeDb } from "./testDb";
-import { PROVIDERS, storeConnection, finishConfirm, deleteConnection, getConnectUrl } from "./oauthConnectors";
-import { signStateWith, verifyStateWith } from "./googleOAuth";
+import {
+  PROVIDERS, storeConnection, finishConfirm, deleteConnection, getConnectUrl, accessExpiresAt, needsRefresh, REFRESH_MARGIN_MS,
+  getConnectionForTeam, updateStoredTokens, getFreshAccessTokenForTeam, claimRefresh, REFRESH_LEASE_MS,
+} from "./oauthConnectors";
+import { signStateWith, verifyStateWith, encryptRefreshToken, decryptRefreshToken } from "./googleOAuth";
 
 // The generic connector shares Google's security design; these tests pin the
 // PROVIDER TABLE (a new connector must be a config, not a fork) and the
@@ -144,5 +148,364 @@ describe("storeConnection + finishConfirm", () => {
     const member = await (deleteConnection as any)._handler(c, { user_id: "u_member", installation_id: "ai_1" });
     expect(member.ok).toBe(true);
     expect(t.app_installations).toHaveLength(0);
+  });
+});
+
+describe("token refresh policy", () => {
+  const now = 1_800_000_000_000;
+
+  test("expires_in becomes an absolute expiry; a provider without one records none", () => {
+    expect(accessExpiresAt({ expires_in: 86399 }, now)).toBe(now + 86_399_000);
+    expect(accessExpiresAt({}, now)).toBeUndefined();
+    expect(accessExpiresAt({ expires_in: 0 }, now)).toBeUndefined();
+  });
+
+  test("a row refreshes when it can and its token is expiring or of unknown age", () => {
+    const fresh = { refresh_token_enc: "r", access_expires_at: now + 60 * 60 * 1000 };
+    const expiring = { refresh_token_enc: "r", access_expires_at: now + REFRESH_MARGIN_MS - 1 };
+    const expired = { refresh_token_enc: "r", access_expires_at: now - 1 };
+    const unknownAge = { refresh_token_enc: "r" };
+    expect(needsRefresh(fresh, now)).toBe(false);
+    expect(needsRefresh(expiring, now)).toBe(true);
+    expect(needsRefresh(expired, now)).toBe(true);
+    // The rows connected before expiry was recorded: refresh once, then it is known.
+    expect(needsRefresh(unknownAge, now)).toBe(true);
+  });
+
+  test("a row without a refresh token never refreshes (Notion: the access token is all there is)", () => {
+    expect(needsRefresh({ access_expires_at: now - 1 }, now)).toBe(false);
+    expect(needsRefresh({}, now)).toBe(false);
+  });
+
+  test("storeConnection persists the expiry on insert and on re-store", async () => {
+    const t = { users: [{ _id: OWNER }], teams: [{ _id: TEAM }], app_installations: [] as any[] };
+    const c = ctx(t);
+    const base = {
+      provider: "linear", user_id: OWNER, team_id: TEAM, access_token_enc: "a1", refresh_token_enc: "r1",
+      granted_scopes: ["read"], pending_confirm_hash: "h", access_expires_at: now + 1000,
+    };
+    await (storeConnection as any)._handler(c, base);
+    expect(t.app_installations[0].access_expires_at).toBe(now + 1000);
+    t.app_installations[0].last_error = "stale";
+    await (storeConnection as any)._handler(c, { ...base, access_token_enc: "a2", access_expires_at: now + 2000 });
+    expect(t.app_installations.length).toBe(1);
+    expect(t.app_installations[0].access_expires_at).toBe(now + 2000);
+    expect(t.app_installations[0].last_error).toBeUndefined();
+  });
+});
+
+/* ------------------------------------------------------------------------
+ * The refresh action, over the real handlers and a provider we control.
+ * The provider answers only when the test says so, which is how two
+ * refreshes, a reconnect, or a disconnect are made to overlap the await.
+ * ---------------------------------------------------------------------- */
+describe("getFreshAccessTokenForTeam (Linear)", () => {
+  const CLIENT_ID = "lin-client";
+  const SECRET = "lin-secret-for-tests";
+  const realFetch = globalThis.fetch;
+  const savedEnv = { id: process.env.LINEAR_OAUTH_CLIENT_ID, secret: process.env.LINEAR_OAUTH_CLIENT_SECRET };
+  beforeEach(() => {
+    process.env.LINEAR_OAUTH_CLIENT_ID = CLIENT_ID;
+    process.env.LINEAR_OAUTH_CLIENT_SECRET = SECRET;
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    process.env.LINEAR_OAUTH_CLIENT_ID = savedEnv.id;
+    process.env.LINEAR_OAUTH_CLIENT_SECRET = savedEnv.secret;
+  });
+
+  const registry: Record<string, any> = {
+    "oauthConnectors:getConnectionForTeam": getConnectionForTeam,
+    "oauthConnectors:updateStoredTokens": updateStoredTokens,
+    "oauthConnectors:storeConnection": storeConnection,
+    "oauthConnectors:claimRefresh": claimRefresh,
+  };
+  /** A gate a test can hold shut: the caller stalls at that mutation until
+   *  `open()` — how "provider answered, DB write not yet issued" is staged. */
+  function gate() {
+    let open!: () => void;
+    const held = new Promise<void>((r) => { open = r; });
+    let arrived!: () => void;
+    const reached = new Promise<void>((r) => { arrived = r; });
+    return { held, open, reached, arrived };
+  }
+  function actionCtx(t: Record<string, any[]>, gates: Record<string, ReturnType<typeof gate>> = {}) {
+    const inner = ctx(t);
+    const dispatch = async (ref: any, args: any) => {
+      const name = getFunctionName(ref);
+      const fn = registry[name];
+      if (!fn) throw new Error(`no test handler for ${name}`);
+      const g = gates[name];
+      if (g) { g.arrived(); await g.held; }
+      return (fn as any)._handler(inner, args);
+    };
+    return { runQuery: dispatch, runMutation: dispatch, _inner: inner } as any;
+  }
+
+  /** Linear's token endpoint, answering one call at a time on command. */
+  function stubLinear() {
+    const pending: Array<{ body: string; resolve: (r: Response) => void }> = [];
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const u = typeof input === "string" ? input : input.url;
+      if (u !== PROVIDERS.linear.tokenUrl) throw new Error(`unexpected fetch ${u}`);
+      return new Promise<Response>((resolve) => pending.push({ body: String(init?.body ?? ""), resolve }));
+    }) as any;
+    const answer = (i: number, body: any, status = 200) =>
+      pending[i].resolve(new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } }));
+    const untilCalls = async (n: number) => {
+      for (let i = 0; i < 200 && pending.length < n; i++) await new Promise((r) => setTimeout(r, 0));
+      if (pending.length < n) throw new Error(`provider saw ${pending.length} calls, wanted ${n}`);
+    };
+    return { pending, answer, untilCalls };
+  }
+
+  const pair = (n: number | string) => ({ access_token: `access-${n}`, refresh_token: `refresh-${n}`, expires_in: 86399, token_type: "Bearer" });
+  const NO_CONNECTION = { ok: false, error: "no_connection: Linear is not connected for this team" };
+
+  async function tables(opts: { expiresAt?: number } = {}) {
+    return {
+      users: [{ _id: OWNER }],
+      teams: [{ _id: TEAM }],
+      app_installations: [{
+        _id: "inst_1", provider: "linear", team_id: TEAM, connected_by: OWNER, granted_scopes: ["read"],
+        access_token_enc: await encryptRefreshToken("access-0", SECRET),
+        refresh_token_enc: await encryptRefreshToken("refresh-0", SECRET),
+        access_expires_at: opts.expiresAt, created_at: 1, updated_at: 1,
+      }] as any[],
+    };
+  }
+  const run = (t: any, gates?: Record<string, ReturnType<typeof gate>>) =>
+    (getFreshAccessTokenForTeam as any)._handler(actionCtx(t, gates), { provider: "linear", team_id: TEAM });
+  const stored = async (t: any) => ({
+    access: await decryptRefreshToken(t.app_installations[0].access_token_enc, SECRET),
+    refresh: await decryptRefreshToken(t.app_installations[0].refresh_token_enc, SECRET),
+    row: t.app_installations[0],
+  });
+  /** A reconnect landing while a refresh is in flight. */
+  const reconnect = (t: any) => (async () => (storeConnection as any)._handler(ctx(t), {
+    provider: "linear", user_id: OWNER, team_id: TEAM, granted_scopes: ["read"], pending_confirm_hash: "h",
+    access_token_enc: await encryptRefreshToken("access-re", SECRET),
+    refresh_token_enc: await encryptRefreshToken("refresh-re", SECRET),
+    access_expires_at: Date.now() + 86_399_000,
+  }))();
+  const expireLease = (t: any) => { t.app_installations[0].refresh_lease_until = Date.now() - 1; };
+
+  test("an unknown-age token refreshes once; the rotated pair and expiry land together, and a fresh row skips the provider", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const p = run(t);
+    await linear.untilCalls(1);
+    expect(linear.pending[0].body).toContain("grant_type=refresh_token");
+    expect(linear.pending[0].body).toContain("refresh_token=refresh-0");
+    linear.answer(0, pair(1));
+    expect(await p).toEqual({ ok: true, token: "access-1" });
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-1", "refresh-1"]);
+    expect(s.row.access_expires_at).toBeGreaterThan(Date.now() + 86_000_000);
+    expect(s.row.last_error).toBeUndefined();
+    expect(s.row.refresh_lease_id).toBeUndefined();
+    expect(await run(t)).toEqual({ ok: true, token: "access-1" });   // fresh: no provider call
+    expect(linear.pending).toHaveLength(1);
+  });
+
+  test("two overlapping refreshes make ONE provider call; the waiter returns the claimant's pair", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const a = run(t);
+    await linear.untilCalls(1);
+    expect(typeof t.app_installations[0].refresh_lease_id).toBe("string");
+    const b = run(t);
+    await new Promise((r) => setTimeout(r, 400));
+    expect(linear.pending).toHaveLength(1);
+    linear.answer(0, pair(1));
+    expect(await a).toEqual({ ok: true, token: "access-1" });
+    expect(await b).toEqual({ ok: true, token: "access-1" });
+    expect(linear.pending).toHaveLength(1);
+    expect((await stored(t)).row.refresh_lease_id).toBeUndefined();
+  });
+
+  test("a reconnect during the await wins: the fetched pair is dropped and the caller gets the reconnect's token", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const a = run(t);
+    await linear.untilCalls(1);
+    await reconnect(t);
+    linear.answer(0, pair(1));
+    expect(await a).toEqual({ ok: true, token: "access-re" });
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-re", "refresh-re"]);
+    expect(t.app_installations).toHaveLength(1);
+  });
+
+  test("a disconnect during the await yields no credentials and resurrects nothing", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const a = run(t);
+    await linear.untilCalls(1);
+    t.app_installations.length = 0;
+    linear.answer(0, pair(1));
+    expect(await a).toEqual(NO_CONNECTION);
+    expect(t.app_installations).toHaveLength(0);
+  });
+
+  test("a late refusal after a reconnect stamps nothing and returns the reconnect's token", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const a = run(t);
+    await linear.untilCalls(1);
+    await reconnect(t);
+    linear.answer(0, { error: "invalid_grant" }, 400);
+    expect(await a).toEqual({ ok: true, token: "access-re" });
+    expect(t.app_installations[0].last_error).toBeUndefined();
+    expect(t.app_installations[0].refresh_lease_id).toBeUndefined();
+  });
+
+  test("a refusal with nobody else involved parks the connection with a reconnect message and loses nothing", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const a = run(t);
+    await linear.untilCalls(1);
+    linear.answer(0, { error: "invalid_grant" }, 400);
+    const res = await a;
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("reconnect Linear");
+    expect(t.app_installations[0].last_error).toContain("invalid_grant");
+    expect(t.app_installations[0].refresh_lease_id).toBeUndefined();
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-0", "refresh-0"]);
+  });
+
+  test("A succeeds and stalls before its write; lease expires; B claims and succeeds; A writes first: A is refused, B's pair lands, both return B's pair", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const gateA = gate();
+    const gateB = gate();
+    const a = run(t, { "oauthConnectors:updateStoredTokens": gateA });
+    await linear.untilCalls(1);
+    linear.answer(0, pair("a"));             // A's provider grant succeeds ...
+    await gateA.reached;                     // ... and A stalls before the DB write
+    expireLease(t);                          // A's lease lapses
+    const b = run(t, { "oauthConnectors:updateStoredTokens": gateB });
+    await linear.untilCalls(2);              // B claimed a new lease and asked the provider
+    const leaseB = t.app_installations[0].refresh_lease_id;
+    linear.answer(1, pair("b"));             // B's grant succeeds too, its write delayed
+    await gateB.reached;
+    gateA.open();                            // A writes first
+    await new Promise((r) => setTimeout(r, 300));
+    const mid = await stored(t);
+    expect([mid.access, mid.refresh]).toEqual(["access-0", "refresh-0"]);   // A wrote nothing
+    expect(mid.row.refresh_lease_id).toBe(leaseB);                          // and cleared no lease
+    gateB.open();                            // then B writes
+    expect(await b).toEqual({ ok: true, token: "access-b" });
+    expect(await a).toEqual({ ok: true, token: "access-b" });                 // A deferred to the owner
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-b", "refresh-b"]);
+    expect(s.row.last_error).toBeUndefined();
+    expect(s.row.refresh_lease_id).toBeUndefined();
+  });
+
+  test("expiry, replacement, then the OLD claimant fails late: it cannot clear the new lease or park the row, and waits for the new claimant", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const a = run(t);
+    await linear.untilCalls(1);
+    expireLease(t);
+    const b = run(t);
+    await linear.untilCalls(2);
+    const leaseB = t.app_installations[0].refresh_lease_id;
+    linear.answer(0, { error: "invalid_grant" }, 400);   // A's late failure
+    await new Promise((r) => setTimeout(r, 300));
+    expect(t.app_installations[0].refresh_lease_id).toBe(leaseB);   // B's lease intact
+    expect(t.app_installations[0].last_error).toBeUndefined();
+    linear.answer(1, pair("b"));
+    expect(await b).toEqual({ ok: true, token: "access-b" });
+    expect(await a).toEqual({ ok: true, token: "access-b" });
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-b", "refresh-b"]);
+    expect(s.row.refresh_lease_id).toBeUndefined();
+  });
+
+  test("no usable refresh token, reconnect lands while the release is staged: the captured token is not returned, the reconnect's is; no provider call", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    t.app_installations[0].refresh_token_enc = "v1.not.ciphertext";   // undecryptable
+    const g = gate();
+    const a = run(t, { "oauthConnectors:updateStoredTokens": g });
+    await g.reached;                          // claimed, decrypt failed, about to release
+    await reconnect(t);
+    g.open();
+    expect(await a).toEqual({ ok: true, token: "access-re" });
+    expect(linear.pending).toHaveLength(0);
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-re", "refresh-re"]);
+  });
+
+  test("no usable refresh token, disconnect lands while the release is staged: no credentials, nothing resurrected, no provider call", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    t.app_installations[0].refresh_token_enc = "v1.not.ciphertext";
+    const g = gate();
+    const a = run(t, { "oauthConnectors:updateStoredTokens": g });
+    await g.reached;
+    t.app_installations.length = 0;
+    g.open();
+    expect(await a).toEqual(NO_CONNECTION);
+    expect(t.app_installations).toHaveLength(0);
+    expect(linear.pending).toHaveLength(0);
+  });
+
+  test("no usable refresh token and nobody else involved: the access token is returned and the lease released; no provider call", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    t.app_installations[0].refresh_token_enc = "v1.not.ciphertext";
+    expect(await run(t)).toEqual({ ok: true, token: "access-0" });
+    expect(t.app_installations[0].refresh_lease_id).toBeUndefined();
+    expect(linear.pending).toHaveLength(0);
+  });
+
+  test("a lease left by a dead claimant expires and the next caller refreshes", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    t.app_installations[0].refresh_lease_id = "dead";
+    expireLease(t);
+    const a = run(t);
+    await linear.untilCalls(1);
+    linear.answer(0, pair(1));
+    expect(await a).toEqual({ ok: true, token: "access-1" });
+  });
+
+  test("claimRefresh: a stale read cannot claim, a second claim is held, each claim has its own id", async () => {
+    const t = await tables();
+    const enc = t.app_installations[0].access_token_enc;
+    expect(await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: "not-the-row's", now: Date.now() })).toEqual({ ok: false, reason: "superseded" });
+    const first = await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, now: Date.now() });
+    expect(first.ok).toBe(true);
+    expect(typeof first.lease).toBe("string");
+    expect(await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, now: Date.now() })).toEqual({ ok: false, reason: "held" });
+    expireLease(t);
+    const second = await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, now: Date.now() });
+    expect(second.ok).toBe(true);
+    expect(second.lease).not.toBe(first.lease);
+    expect(t.app_installations[0].refresh_lease_until).toBeLessThanOrEqual(Date.now() + REFRESH_LEASE_MS);
+  });
+
+  test("updateStoredTokens: both outcomes need the exact lease AND the read ciphertext; the passing write releases the lease", async () => {
+    const t = await tables();
+    const enc = t.app_installations[0].access_token_enc;
+    t.app_installations[0].refresh_lease_id = "current";
+    const staleFail = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, lease: "old", last_error: "late" });
+    expect(staleFail).toEqual({ ok: false, reason: "superseded" });
+    const staleSuccess = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, lease: "old", access_token_enc: "late-enc", access_expires_at: 5 });
+    expect(staleSuccess).toEqual({ ok: false, reason: "superseded" });
+    const movedOn = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: "other-enc", lease: "current", access_token_enc: "x", access_expires_at: 5 });
+    expect(movedOn).toEqual({ ok: false, reason: "superseded" });
+    expect(t.app_installations[0].last_error).toBeUndefined();
+    expect(t.app_installations[0].access_token_enc).toBe(enc);
+    expect(t.app_installations[0].refresh_lease_id).toBe("current");
+    const ok = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, lease: "current", access_token_enc: "new-enc", access_expires_at: 5 });
+    expect(ok).toEqual({ ok: true });
+    expect(t.app_installations[0].access_token_enc).toBe("new-enc");
+    expect(t.app_installations[0].refresh_lease_id).toBeUndefined();
+    expect(await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "nope", expected_enc: enc, lease: "x", last_error: "e" })).toEqual({ ok: false, reason: "gone" });
   });
 });

--- a/packages/convex/convex/oauthConnectors.ts
+++ b/packages/convex/convex/oauthConnectors.ts
@@ -13,7 +13,7 @@
 // providers (mail) stay on their own path.
 
 import { v } from "convex/values";
-import { action, internalMutation, internalQuery, query } from "./_generated/server";
+import { action, internalAction, internalMutation, internalQuery, query } from "./_generated/server";
 import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { getAuthUserId } from "@convex-dev/auth/server";
@@ -179,6 +179,67 @@ export const resolveTeam = internalQuery({
 });
 
 /* ==========================================================================
+ * Token endpoint + refresh
+ * ========================================================================== */
+
+/** One POST to the provider's token endpoint, in the shape it wants: Notion
+ *  takes JSON with HTTP basic auth, Linear takes a form with the client pair
+ *  in the body. Shared by the code exchange and the refresh. */
+async function tokenRequest(
+  p: ProviderConfig,
+  env: { clientId: string; clientSecret: string },
+  params: Record<string, string>,
+): Promise<{ ok: boolean; status: number; tok: any }> {
+  const signal = AbortSignal.timeout(15_000);
+  const resp =
+    p.tokenAuth === "basic"
+      ? await fetch(p.tokenUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            Authorization: `Basic ${btoa(`${env.clientId}:${env.clientSecret}`)}`,
+          },
+          body: JSON.stringify(params),
+          signal,
+        })
+      : await fetch(p.tokenUrl, {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ ...params, client_id: env.clientId, client_secret: env.clientSecret }).toString(),
+          signal,
+        });
+  let tok: any = null;
+  try {
+    tok = await resp.json();
+  } catch {
+    tok = null;
+  }
+  return { ok: resp.ok, status: resp.status, tok };
+}
+
+/** Absolute expiry from a token response, or undefined when the provider
+ *  gave no expires_in (Notion: tokens do not expire). */
+export function accessExpiresAt(tok: any, now: number): number | undefined {
+  return typeof tok?.expires_in === "number" && tok.expires_in > 0 ? now + tok.expires_in * 1000 : undefined;
+}
+
+/** Refresh this far ahead of expiry so an in-flight sync never straddles it. */
+export const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+/** A row refreshes when it CAN (has a refresh token) and its access token is
+ *  expiring, expired, or of unknown age. Rows without a refresh token never
+ *  refresh: their access token is the only credential there is. */
+export function needsRefresh(
+  row: { refresh_token_enc?: string; access_expires_at?: number },
+  now: number,
+): boolean {
+  if (!row.refresh_token_enc) return false;
+  if (row.access_expires_at === undefined) return true;
+  return row.access_expires_at - now < REFRESH_MARGIN_MS;
+}
+
+/* ==========================================================================
  * Callback — code exchange, encrypted store, PENDING until confirmed
  * ========================================================================== */
 
@@ -217,26 +278,9 @@ export const callbackHandler = async (ctx: any, request: Request): Promise<Respo
   // Exchange the code.
   let tok: any;
   try {
-    const headers: Record<string, string> = { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" };
-    const body = new URLSearchParams({ code, redirect_uri: redirectUri(), grant_type: "authorization_code" });
-    if (p.tokenAuth === "basic") {
-      headers.Authorization = `Basic ${btoa(`${env.clientId}:${env.clientSecret}`)}`;
-      // Notion wants JSON, not form-encoded.
-      const resp = await fetch(p.tokenUrl, {
-        method: "POST",
-        headers: { ...headers, "Content-Type": "application/json" },
-        body: JSON.stringify({ code, redirect_uri: redirectUri(), grant_type: "authorization_code" }),
-        signal: AbortSignal.timeout(15_000),
-      });
-      tok = await resp.json();
-      if (!resp.ok) return errorRedirect(p.id, tok?.error ?? `token_${resp.status}`);
-    } else {
-      body.set("client_id", env.clientId);
-      body.set("client_secret", env.clientSecret);
-      const resp = await fetch(p.tokenUrl, { method: "POST", headers, body, signal: AbortSignal.timeout(15_000) });
-      tok = await resp.json();
-      if (!resp.ok) return errorRedirect(p.id, tok?.error ?? `token_${resp.status}`);
-    }
+    const res = await tokenRequest(p, env, { code, redirect_uri: redirectUri(), grant_type: "authorization_code" });
+    tok = res.tok;
+    if (!res.ok) return errorRedirect(p.id, tok?.error ?? `token_${res.status}`);
   } catch (err) {
     return errorRedirect(p.id, "token_exchange_failed");
   }
@@ -258,6 +302,7 @@ export const callbackHandler = async (ctx: any, request: Request): Promise<Respo
     account_id: accountId,
     access_token_enc: await encryptRefreshToken(tok.access_token, env.clientSecret),
     refresh_token_enc: typeof tok.refresh_token === "string" ? await encryptRefreshToken(tok.refresh_token, env.clientSecret) : undefined,
+    access_expires_at: accessExpiresAt(tok, Date.now()),
     granted_scopes: scopes,
     pending_confirm_hash: confirmHash,
   });
@@ -288,6 +333,7 @@ export const storeConnection = internalMutation({
     account_id: v.optional(v.string()),
     access_token_enc: v.string(),
     refresh_token_enc: v.optional(v.string()),
+    access_expires_at: v.optional(v.number()),
     granted_scopes: v.array(v.string()),
     pending_confirm_hash: v.string(),
   },
@@ -305,6 +351,10 @@ export const storeConnection = internalMutation({
       await (ctx.db as any).patch(existing._id, {
         access_token_enc: args.access_token_enc,
         refresh_token_enc: args.refresh_token_enc ?? existing.refresh_token_enc,
+        access_expires_at: args.access_expires_at,
+        last_error: undefined,
+        refresh_lease_id: undefined,
+        refresh_lease_until: undefined,
         granted_scopes: args.granted_scopes,
         account_label: args.account_label ?? existing.account_label,
         account_id: args.account_id ?? existing.account_id,
@@ -323,6 +373,7 @@ export const storeConnection = internalMutation({
       account_id: args.account_id,
       access_token_enc: args.access_token_enc,
       refresh_token_enc: args.refresh_token_enc,
+      access_expires_at: args.access_expires_at,
       granted_scopes: args.granted_scopes,
       pending_confirm_hash: args.pending_confirm_hash,
       pending_expires_at: now + CONFIRM_TTL_MS,
@@ -441,21 +492,226 @@ export const deleteConnection = internalMutation({
   },
 });
 
-/** For a future agent verb: the decrypted access token, owner-checked. Not a
- *  public function — nothing hands a token to a client. */
-export const getAccessTokenForTeam = internalQuery({
+/** The connection row's credential fields, for the refresh action only.
+ *  Nothing hands a token to a client. */
+export const getConnectionForTeam = internalQuery({
   args: { provider: v.string(), team_id: v.id("teams") },
-  handler: async (ctx, args): Promise<{ token: string } | null> => {
+  handler: async (ctx, args) => {
     if (!isConnectorId(args.provider)) return null;
-    const p = PROVIDERS[args.provider];
-    const env = providerEnv(p);
-    if (!env) return null;
     const row = await (ctx.db as any)
       .query("app_installations")
-      .withIndex("by_provider_team", (q: any) => q.eq("provider", p.id).eq("team_id", args.team_id))
+      .withIndex("by_provider_team", (q: any) => q.eq("provider", args.provider).eq("team_id", args.team_id))
       .first();
     if (!row || row.pending_confirm_hash) return null;
-    const token = await decryptRefreshToken(row.access_token_enc, env.clientSecret);
-    return token ? { token } : null;
+    return {
+      _id: row._id,
+      access_token_enc: row.access_token_enc as string,
+      refresh_token_enc: row.refresh_token_enc as string | undefined,
+      access_expires_at: row.access_expires_at as number | undefined,
+      refresh_lease_until: row.refresh_lease_until as number | undefined,
+      refresh_lease_id: row.refresh_lease_id as string | undefined,
+    };
+  },
+});
+
+/** How long one caller may hold the refresh; long enough for a slow token
+ *  endpoint, short enough that a crashed claimant does not block a team. */
+export const REFRESH_LEASE_MS = 30 * 1000;
+/** How long a waiter watches for the claimant's write before trying itself. */
+const REFRESH_WAIT_MS = 15 * 1000;
+const REFRESH_POLL_MS = 250;
+
+/**
+ * Claim the refresh for one row. Every concurrent caller that finds the
+ * token expiring lands here; exactly one gets `ok`, the rest are told the
+ * refresh is `held` and wait for the credentials to change. The claim is
+ * also a compare and swap on the ciphertext, so a caller holding a stale
+ * read cannot claim over credentials that already moved on.
+ */
+export const claimRefresh = internalMutation({
+  args: { installation_id: v.id("app_installations"), expected_enc: v.string(), now: v.number() },
+  handler: async (ctx, args): Promise<{ ok: boolean; lease?: string; reason?: "gone" | "superseded" | "held" }> => {
+    const row = await (ctx.db as any).get(args.installation_id);
+    if (!row) return { ok: false, reason: "gone" };
+    if (row.access_token_enc !== args.expected_enc) return { ok: false, reason: "superseded" };
+    if (typeof row.refresh_lease_until === "number" && row.refresh_lease_until > args.now) return { ok: false, reason: "held" };
+    const lease = crypto.randomUUID();
+    await (ctx.db as any).patch(args.installation_id, { refresh_lease_id: lease, refresh_lease_until: args.now + REFRESH_LEASE_MS });
+    return { ok: true, lease };
+  },
+});
+
+/**
+ * Persist the outcome of one refresh. Both outcomes are fenced the same way:
+ * the writer must still own the lease it claimed AND the credentials must be
+ * the ones it read. Nothing about the order in which provider responses
+ * arrive says whose pair is newer, so an expired claimant's late success is
+ * refused like its late failure would be; the caller then defers to the
+ * current owner's write (see getFreshAccessTokenForTeam). A reconnect
+ * clears the lease and rewrites the ciphertext, so anything in flight
+ * before it is refused on both counts. A deleted row is reported, never
+ * recreated. The one write that passes releases the lease.
+ */
+export const updateStoredTokens = internalMutation({
+  args: {
+    installation_id: v.id("app_installations"),
+    expected_enc: v.string(),
+    lease: v.string(),
+    access_token_enc: v.optional(v.string()),
+    refresh_token_enc: v.optional(v.string()),
+    access_expires_at: v.optional(v.number()),
+    last_error: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ ok: boolean; reason?: "gone" | "superseded" }> => {
+    const row = await (ctx.db as any).get(args.installation_id);
+    if (!row) return { ok: false, reason: "gone" };
+    const release = { refresh_lease_id: undefined, refresh_lease_until: undefined, updated_at: Date.now() };
+    if (row.refresh_lease_id !== args.lease || row.access_token_enc !== args.expected_enc) return { ok: false, reason: "superseded" };
+    if (args.access_token_enc) {
+      await (ctx.db as any).patch(args.installation_id, {
+        ...release,
+        access_token_enc: args.access_token_enc,
+        access_expires_at: args.access_expires_at,
+        last_error: undefined,
+        ...(args.refresh_token_enc ? { refresh_token_enc: args.refresh_token_enc } : {}),
+      });
+      return { ok: true };
+    }
+    await (ctx.db as any).patch(args.installation_id, { ...release, last_error: args.last_error });
+    return { ok: true };
+  },
+});
+
+/**
+ * The access token for a team's connection, refreshed when it is expiring
+ * or of unknown age (see needsRefresh). Same shape as googleOAuth's
+ * getFreshAccessToken: a refusal is returned, not thrown, so callers can
+ * say "reconnect Linear" instead of "401". `force` refreshes regardless of
+ * the recorded expiry, for a caller that just got a 401 on a token this
+ * function considered fresh.
+ *
+ * Single flight: the provider rotates the refresh token on the first grant,
+ * so a second concurrent grant with the same token is refused. One caller
+ * claims the lease and talks to the provider; the others wait for the row
+ * to change and return the pair that landed. Every outcome write is a
+ * fenced by lease ownership and credential compare and swap
+ * (updateStoredTokens); when a write is refused the caller waits for the
+ * current owner's write and returns what the row holds then, never the pair
+ * it fetched: a disconnected connection yields no credentials, a superseded
+ * refresh yields the owner's.
+ */
+export const getFreshAccessTokenForTeam = internalAction({
+  args: { provider: v.string(), team_id: v.id("teams"), force: v.optional(v.boolean()) },
+  handler: async (ctx, args): Promise<{ ok: boolean; token?: string; error?: string }> => {
+    if (!isConnectorId(args.provider)) return { ok: false, error: "unknown provider" };
+    const p = PROVIDERS[args.provider];
+    const env = providerEnv(p);
+    if (!env) return { ok: false, error: notConfigured(p) };
+    type Row = { _id: any; access_token_enc: string; refresh_token_enc?: string; access_expires_at?: number; refresh_lease_until?: number; refresh_lease_id?: string };
+    const noConnection = { ok: false, error: `no_connection: ${p.name} is not connected for this team` };
+    const read = (): Promise<Row | null> =>
+      ctx.runQuery(internal.oauthConnectors.getConnectionForTeam, { provider: p.id, team_id: args.team_id });
+    const tokenOf = async (row: Row) => {
+      const token = await decryptRefreshToken(row.access_token_enc, env.clientSecret);
+      return token ? { ok: true, token } : { ok: false, error: `${p.name} token undecryptable (${p.env.clientSecret} rotated?): reconnect ${p.name}` };
+    };
+    /** Current credentials, as the row holds them now. */
+    const current = async () => {
+      const row = await read();
+      return row ? await tokenOf(row) : noConnection;
+    };
+    /** Wait for another claimant's write. Resolves with the new credentials,
+     *  or null once the lease lapsed with nothing written. */
+    const waitForOther = async (seenEnc: string) => {
+      const deadline = Date.now() + REFRESH_WAIT_MS;
+      while (Date.now() < deadline) {
+        const row = await read();
+        if (!row) return noConnection;
+        if (row.access_token_enc !== seenEnc) return await tokenOf(row);
+        if (typeof row.refresh_lease_until !== "number" || row.refresh_lease_until <= Date.now()) return null;
+        await new Promise((r) => setTimeout(r, REFRESH_POLL_MS));
+      }
+      return null;
+    };
+
+    let row = await read();
+    if (!row) return noConnection;
+    const now = Date.now();
+    if (!args.force && !needsRefresh(row, now)) return await tokenOf(row);
+
+    // Claim, or wait for whoever holds the claim.
+    let lease: string | undefined;
+    for (let attempt = 0; attempt < 3 && !lease; attempt++) {
+      const claim = await ctx.runMutation(internal.oauthConnectors.claimRefresh, {
+        installation_id: row._id,
+        expected_enc: row.access_token_enc,
+        now: Date.now(),
+      });
+      if (claim.ok) { lease = claim.lease; break; }
+      if (claim.reason === "gone") return noConnection;
+      const landed = await waitForOther(row.access_token_enc);
+      if (landed) return landed;
+      const again = await read();
+      if (!again) return noConnection;
+      row = again;
+      if (!needsRefresh(row, Date.now())) return await tokenOf(row);
+    }
+    if (!lease) return { ok: false, error: `${p.name} refresh is held by another caller; retry` };
+
+    const refreshToken = row.refresh_token_enc ? await decryptRefreshToken(row.refresh_token_enc, env.clientSecret) : null;
+    /** A refused write means the row is no longer ours: a reconnect landed
+     *  or a newer claimant holds the lease. Their write is the answer, so
+     *  wait for it; the pair we fetched is never handed out. */
+    const deferToOwner = async (reason: "gone" | "superseded" | undefined) => {
+      if (reason === "gone") return noConnection;
+      const landed = await waitForOther(row!.access_token_enc);
+      return landed ?? await current();
+    };
+    if (!refreshToken) {
+      // No refresh token (or undecryptable): the access token is all we
+      // have. Releasing the lease is an outcome write like any other, so a
+      // reconnect or disconnect that landed meanwhile refuses it, and the
+      // captured row's token is then not the answer.
+      const released = await ctx.runMutation(internal.oauthConnectors.updateStoredTokens, {
+        installation_id: row._id,
+        expected_enc: row.access_token_enc,
+        lease,
+      });
+      return released.ok ? await tokenOf(row) : await deferToOwner(released.reason);
+    }
+    const fail = async (error: string) => {
+      const stamped = await ctx.runMutation(internal.oauthConnectors.updateStoredTokens, {
+        installation_id: row!._id,
+        expected_enc: row!.access_token_enc,
+        lease: lease!,
+        last_error: error,
+      });
+      return stamped.ok ? { ok: false, error } : await deferToOwner(stamped.reason);
+    };
+    let res: { ok: boolean; status: number; tok: any };
+    try {
+      res = await tokenRequest(p, env, { grant_type: "refresh_token", refresh_token: refreshToken });
+    } catch {
+      return await fail(`${p.name} token endpoint unreachable; the next sync retries`);
+    }
+    const tok = res.tok;
+    if (!res.ok || typeof tok?.access_token !== "string") {
+      const code = tok?.error ?? `token_${res.status}`;
+      const revoked = code === "invalid_grant" || res.status === 400 || res.status === 401;
+      return await fail(
+        revoked
+          ? `${p.name} refresh refused (${code}): access was revoked or the refresh token expired; reconnect ${p.name} from Settings > Integrations`
+          : `${p.name} refresh failed (${code}); the next sync retries`,
+      );
+    }
+    const written = await ctx.runMutation(internal.oauthConnectors.updateStoredTokens, {
+      installation_id: row._id,
+      expected_enc: row.access_token_enc,
+      lease,
+      access_token_enc: await encryptRefreshToken(tok.access_token, env.clientSecret),
+      refresh_token_enc: typeof tok.refresh_token === "string" ? await encryptRefreshToken(tok.refresh_token, env.clientSecret) : undefined,
+      access_expires_at: accessExpiresAt(tok, now),
+    });
+    return written.ok ? { ok: true, token: tok.access_token } : await deferToOwner(written.reason);
   },
 });

--- a/packages/convex/convex/oauthConnectorsSchema.ts
+++ b/packages/convex/convex/oauthConnectorsSchema.ts
@@ -26,6 +26,18 @@ export const oauthConnectorTables = {
      *  So access_token_enc is always present and refresh_token_enc is optional. */
     access_token_enc: v.string(),
     refresh_token_enc: v.optional(v.string()),
+    /** When the access token stops working, from the provider's expires_in.
+     *  Linear rotates 24h tokens (since 2026-04-01); getFreshAccessTokenForTeam
+     *  refreshes ahead of this. Absent with a refresh token present means
+     *  "unknown", which refreshes on first use. */
+    access_expires_at: v.optional(v.number()),
+    /** Single flight for the refresh: the caller that claimed it talks to the
+     *  provider, the rest wait for the row to change. Same lease shape as
+     *  agent task claims; a dead claimant's lease expires in seconds. */
+    refresh_lease_until: v.optional(v.number()),
+    /** The claimant's ticket: outcome writes that carry another id are late
+     *  finishes of an expired claim and are refused. */
+    refresh_lease_id: v.optional(v.string()),
     granted_scopes: v.array(v.string()),
     /** Same two-phase confirm as Google: the row is PENDING until the
      *  authenticated browser session confirms it owns the redirect. */

--- a/packages/web/components/integrations/IssueSyncSources.tsx
+++ b/packages/web/components/integrations/IssueSyncSources.tsx
@@ -156,7 +156,7 @@ function SourceRow({ source }: { source: any }) {
             parts={[
               source.project_id ? (
                 <Link to={`/projects/${source.project_id}`} className="hover:text-sol-cyan hover:underline">
-                  {source.project_name ?? "project"}
+                  {source.project_title ?? source.project_name ?? "project"}
                 </Link>
               ) : (
                 "project pending"


### PR DESCRIPTION
Linear issue sync stopped when its daily access token expired. Refresh now renews the encrypted token pair before expiry and permits only the current lease owner, with unchanged credentials, to store an outcome. Late responses cannot overwrite a reconnect or restore a disconnected account. A source paused during sync stays paused when that sync finishes.

The integrations source link also uses the project title returned by the backend.

Validation: 85 focused handler/integration tests, all three package typechecks, and root lint pass (157 existing warnings). Controls cover overlapping refreshes, expired claimants, reconnect/disconnect during provider and storage waits, and paused-source outcomes. Full CI and production verification follow before release.
