### PR TITLE
fix(integrations): serialize Google token refreshes

### DIFF
--- a/docs/architecture/issue-sync.md
+++ b/docs/architecture/issue-sync.md
@@ -182,9 +182,15 @@ Tokens: Linear via `oauthConnectors.getFreshAccessTokenForTeam`, which
 refreshes the 24 hour access token ahead of `access_expires_at` and stores
 the rotated refresh token in the same write; a refused refresh lands on the
 connection's `last_error` and parks the source with a "reconnect" message.
+The protocol lives in `convex/lib/tokenRefresh.ts` and serves every
+connector that stores a refresh token (Linear and Notion through
+`oauthConnectors`, Gmail through `googleOAuth`, which caches the access
+token with its expiry for the same reason).
 The refresh is single flight: a caller claims a lease (`refresh_lease_id`
 plus `refresh_lease_until`, the agent task lease shape; the claim itself is
-a compare and swap on the access ciphertext) before talking to the provider,
+a compare and swap on the credential identity, both ciphertexts, so a
+reconnect that only replaced the refresh grant refuses a stale claim before
+any provider request) before talking to the provider,
 and concurrent callers wait for the row to change instead of spending the
 same refresh token twice. Every outcome write, success or failure, is
 fenced by exact lease ownership and by the credentials the writer read, and

--- a/packages/convex/convex/_generated/api.d.ts
+++ b/packages/convex/convex/_generated/api.d.ts
@@ -117,6 +117,7 @@ import type * as lib_liveSessions from "../lib/liveSessions.js";
 import type * as lib_openTasksValidator from "../lib/openTasksValidator.js";
 import type * as lib_repoSearch from "../lib/repoSearch.js";
 import type * as lib_sanitize from "../lib/sanitize.js";
+import type * as lib_tokenRefresh from "../lib/tokenRefresh.js";
 import type * as lib_userSend from "../lib/userSend.js";
 import type * as lib_viewWriters from "../lib/viewWriters.js";
 import type * as linearApi from "../linearApi.js";
@@ -314,6 +315,7 @@ declare const fullApi: ApiFromModules<{
   "lib/openTasksValidator": typeof lib_openTasksValidator;
   "lib/repoSearch": typeof lib_repoSearch;
   "lib/sanitize": typeof lib_sanitize;
+  "lib/tokenRefresh": typeof lib_tokenRefresh;
   "lib/userSend": typeof lib_userSend;
   "lib/viewWriters": typeof lib_viewWriters;
   linearApi: typeof linearApi;

--- a/packages/convex/convex/appConnections.ts
+++ b/packages/convex/convex/appConnections.ts
@@ -111,6 +111,7 @@ export const listConnections = query({
             by_me: true,
             at: install.created_at,
             detail: install.email ?? undefined,
+            health: healthOf(install),
             disconnect_id: String(install._id),
           });
         }

--- a/packages/convex/convex/googleOAuth.test.ts
+++ b/packages/convex/convex/googleOAuth.test.ts
@@ -47,7 +47,8 @@ import {
   resolveConnectUser,
   signStateWith,
   storeConnection,
-  updateStoredRefreshToken,
+  claimRefresh,
+  writeRefreshOutcome,
 } from "./googleOAuth";
 
 const CLIENT_ID = "test-client.apps.googleusercontent.com";
@@ -75,17 +76,29 @@ const registry: Record<string, any> = {
   "googleOAuth:getOwnedConnection": getOwnedConnection,
   "googleOAuth:finishConfirm": finishConfirm,
   "googleOAuth:deleteConnection": deleteConnection,
-  "googleOAuth:updateStoredRefreshToken": updateStoredRefreshToken,
+  "googleOAuth:claimRefresh": claimRefresh,
+  "googleOAuth:writeRefreshOutcome": writeRefreshOutcome,
 };
 
 // Action/httpAction ctx: no db — run* dispatches to the real registered
 // handlers over the fake db, like production's runQuery/runMutation would.
-function actionCtx(userId: string | null, t: Record<string, any[]>) {
+/** A gate a test can hold shut: the caller stalls at that function until
+ *  `open()` — how "provider answered, DB write not yet issued" is staged. */
+function gate() {
+  let open!: () => void;
+  const held = new Promise<void>((r) => { open = r; });
+  let arrived!: () => void;
+  const reached = new Promise<void>((r) => { arrived = r; });
+  return { held, open, reached, arrived };
+}
+function actionCtx(userId: string | null, t: Record<string, any[]>, gates: Record<string, ReturnType<typeof gate>> = {}) {
   const inner = dbCtx(userId, t);
   const dispatch = async (ref: any, args: any) => {
     const name = getFunctionName(ref);
     const fn = registry[name];
     if (!fn) throw new Error(`no test handler registered for "${name}" — typo'd function path?`);
+    const g = gates[name];
+    if (g) { g.arrived(); await g.held; }
     return (fn as any)._handler(inner, args);
   };
   return { runQuery: dispatch, runMutation: dispatch, _inner: inner } as any;
@@ -567,5 +580,182 @@ describe("listConnections", () => {
     // Another user sees nothing; an unauthenticated caller sees nothing.
     expect(await (listConnections as any)._handler(dbCtx("u_other", t), {})).toHaveLength(0);
     expect(await (listConnections as any)._handler(dbCtx(null, t), {})).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------------
+ * Single flight refresh (lib/tokenRefresh) on the Gmail connection: the
+ * provider answers only when the test says so, which is how two refreshes,
+ * a reconnect, or a disconnect are made to overlap the await.
+ * ---------------------------------------------------------------------- */
+describe("getFreshAccessToken: cache, single flight and fenced writes", () => {
+  function stubGoogleDeferred() {
+    const pending: Array<{ body: string; resolve: (r: Response) => void }> = [];
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const u = typeof input === "string" ? input : input.url;
+      if (u !== GOOGLE_TOKEN_URL) throw new Error(`unexpected fetch: ${u}`);
+      return new Promise<Response>((resolve) => pending.push({ body: String(init?.body ?? ""), resolve }));
+    }) as any;
+    const answer = (i: number, body: any, status = 200) =>
+      pending[i].resolve(new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } }));
+    const untilCalls = async (n: number) => {
+      for (let i = 0; i < 200 && pending.length < n; i++) await new Promise((r) => setTimeout(r, 0));
+      if (pending.length < n) throw new Error(`Google saw ${pending.length} calls, wanted ${n}`);
+    };
+    return { pending, answer, untilCalls };
+  }
+  const grant = (n: string, rotate = false) => ({ access_token: `ya29.${n}`, expires_in: 3599, ...(rotate ? { refresh_token: `1//${n}` } : {}) });
+  const run = (t: any, gates?: Record<string, ReturnType<typeof gate>>) =>
+    (getFreshAccessToken as any)._handler(actionCtx(OWNER, t, gates), { installation_id: "gi_1" });
+  const seeded = async () => tables({ google_installations: [confirmedRow(await encryptRefreshToken(PLAINTEXT_RT, CLIENT_SECRET))] });
+  const cached = async (t: any) => (t.google_installations[0]?.access_token_enc ? decryptRefreshToken(t.google_installations[0].access_token_enc, CLIENT_SECRET) : null);
+  const reconnect = (t: any) => (async () => (storeConnection as any)._handler(dbCtx(OWNER, t), {
+    user_id: OWNER, email: "person@gmail.com", granted_scopes: [GMAIL_READONLY_SCOPE], pending_confirm_hash: "h",
+    refresh_token_enc: await encryptRefreshToken("1//reconnected", CLIENT_SECRET),
+  }))();
+
+  test("a row from before caching refreshes once, caches the token with its expiry, and the next call skips Google", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const a = run(t);
+    await google.untilCalls(1);
+    google.answer(0, grant("one"));
+    const res = await a;
+    expect(res.ok).toBe(true);
+    expect(res.access_token).toBe("ya29.one");
+    expect(res.expires_in).toBeGreaterThan(3500);
+    expect(await cached(t)).toBe("ya29.one");
+    expect(t.google_installations[0].access_expires_at).toBeGreaterThan(Date.now() + 3_500_000);
+    expect(t.google_installations[0].refresh_lease_id).toBeUndefined();
+    const again = await run(t);
+    expect(again.access_token).toBe("ya29.one");
+    expect(google.pending).toHaveLength(1);   // served from the cache
+  });
+
+  test("two overlapping refreshes make ONE Google call; the waiter returns the claimant's token", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const a = run(t);
+    await google.untilCalls(1);
+    const b = run(t);
+    await new Promise((r) => setTimeout(r, 400));
+    expect(google.pending).toHaveLength(1);
+    google.answer(0, grant("one", true));
+    expect((await a).access_token).toBe("ya29.one");
+    expect((await b).access_token).toBe("ya29.one");
+    expect(google.pending).toHaveLength(1);
+    expect(await decryptRefreshToken(t.google_installations[0].refresh_token_enc, CLIENT_SECRET)).toBe("1//one");
+  });
+
+  test("a reconnect during the await wins: the fetched pair is dropped and the caller refreshes once more on the new grant", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const a = run(t);
+    await google.untilCalls(1);
+    await reconnect(t);
+    google.answer(0, grant("stale", true));   // refused: the row moved on
+    await google.untilCalls(2);               // second grant, with the reconnected refresh token
+    expect(new URLSearchParams(google.pending[1].body).get("refresh_token")).toBe("1//reconnected");
+    google.answer(1, grant("fresh"));
+    const res = await a;
+    expect(res.access_token).toBe("ya29.fresh");
+    expect(await cached(t)).toBe("ya29.fresh");
+    expect(await decryptRefreshToken(t.google_installations[0].refresh_token_enc, CLIENT_SECRET)).toBe("1//reconnected");
+    expect(t.google_installations).toHaveLength(1);
+  });
+
+  test("PRE-CLAIM reconnect: A reads the old grant, the reconnect lands before A claims; A's stale claim is refused and the only Google call carries the reconnected grant", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const g = gate();
+    const a = run(t, { "googleOAuth:claimRefresh": g });
+    await g.reached;                                       // read done, claim not yet issued
+    await reconnect(t);                                    // new refresh grant, still no access ciphertext
+    g.open();
+    await google.untilCalls(1);
+    expect(new URLSearchParams(google.pending[0].body).get("refresh_token")).toBe("1//reconnected");
+    google.answer(0, grant("fresh", true));
+    const res = await a;
+    expect(res.access_token).toBe("ya29.fresh");
+    expect(google.pending).toHaveLength(1);                // the old grant was never sent
+    expect(await decryptRefreshToken(t.google_installations[0].refresh_token_enc, CLIENT_SECRET)).toBe("1//fresh");
+    expect(await cached(t)).toBe("ya29.fresh");
+  });
+
+  test("a disconnect during the await yields no credentials and resurrects nothing", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const a = run(t);
+    await google.untilCalls(1);
+    t.google_installations.length = 0;
+    google.answer(0, grant("one"));
+    const res = await a;
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("No such Gmail connection");
+    expect(t.google_installations).toHaveLength(0);
+  });
+
+  test("A succeeds and stalls before its write; lease expires; B claims and succeeds; A writes first: A is refused, B's pair lands, both return B's token", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const gateA = gate();
+    const gateB = gate();
+    const a = run(t, { "googleOAuth:writeRefreshOutcome": gateA });
+    await google.untilCalls(1);
+    google.answer(0, grant("a", true));
+    await gateA.reached;
+    t.google_installations[0].refresh_lease_until = Date.now() - 1;   // A looks dead
+    const b = run(t, { "googleOAuth:writeRefreshOutcome": gateB });
+    await google.untilCalls(2);
+    const leaseB = t.google_installations[0].refresh_lease_id;
+    google.answer(1, grant("b", true));
+    await gateB.reached;
+    gateA.open();
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await cached(t)).toBeNull();                                  // A wrote nothing
+    expect(t.google_installations[0].refresh_lease_id).toBe(leaseB);    // and cleared no lease
+    gateB.open();
+    expect((await b).access_token).toBe("ya29.b");
+    expect((await a).access_token).toBe("ya29.b");
+    expect(await cached(t)).toBe("ya29.b");
+    expect(await decryptRefreshToken(t.google_installations[0].refresh_token_enc, CLIENT_SECRET)).toBe("1//b");
+    expect(t.google_installations[0].refresh_lease_id).toBeUndefined();
+  });
+
+  test("a late invalid_grant after a reconnect stamps nothing on the reconnected row", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const a = run(t);
+    await google.untilCalls(1);
+    await reconnect(t);
+    google.answer(0, { error: "invalid_grant" }, 400);   // refused: not ours to park
+    await google.untilCalls(2);                            // refreshes again on the new grant
+    google.answer(1, grant("fresh"));
+    expect((await a).access_token).toBe("ya29.fresh");
+    expect(t.google_installations[0].last_error).toBeUndefined();
+    expect(t.google_installations[0].refresh_lease_id).toBeUndefined();
+  });
+
+  test("the generic path refuses the released Linear action's access-only stamp: Gmail never accepts a legacy form", async () => {
+    const t = await seeded();
+    t.google_installations[0].access_token_enc = "cached-enc";
+    const claim = await (claimRefresh as any)._handler(dbCtx(OWNER, t), { installation_id: "gi_1", expected_enc: "cached-enc", now: Date.now() });
+    expect(claim).toEqual({ ok: false, reason: "superseded" });
+    const write = await (writeRefreshOutcome as any)._handler(dbCtx(OWNER, t), { installation_id: "gi_1", expected_enc: "cached-enc", lease: "any", refresh_token_enc: "late" });
+    expect(write).toEqual({ ok: false, reason: "superseded" });
+    expect(t.google_installations[0].refresh_token_enc).not.toBe("late");
+  });
+
+  test("invalid_grant alone parks the row with the reconnect hint and releases the lease", async () => {
+    const google = stubGoogleDeferred();
+    const t = await seeded();
+    const a = run(t);
+    await google.untilCalls(1);
+    google.answer(0, { error: "invalid_grant" }, 400);
+    const res = await a;
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("reconnect Gmail");
+    expect(t.google_installations[0].last_error).toContain("invalid_grant");
+    expect(t.google_installations[0].refresh_lease_id).toBeUndefined();
   });
 });

--- a/packages/convex/convex/googleOAuth.ts
+++ b/packages/convex/convex/googleOAuth.ts
@@ -42,6 +42,7 @@
 import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import { claimRefreshOn, writeRefreshOutcomeOn, singleFlightRefresh, type RefreshRow } from "./lib/tokenRefresh";
 import { query, action, internalAction, internalMutation, internalQuery } from "./functions";
 import { getAuthenticatedUserId } from "./pendingMessages";
 import { convexSiteUrl, webBaseUrl } from "./slack";
@@ -412,6 +413,13 @@ export const storeConnection = internalMutation({
       const stillPending = !!existing.pending_confirm_hash;
       await (ctx.db as any).patch(existing._id, {
         refresh_token_enc: args.refresh_token_enc ?? existing.refresh_token_enc,
+        // A reconnect is a fresh grant: drop the cached access token and any
+        // refresh in flight, whose outcome write is then refused.
+        access_token_enc: undefined,
+        access_expires_at: undefined,
+        refresh_lease_id: undefined,
+        refresh_lease_until: undefined,
+        last_error: undefined,
         granted_scopes: args.granted_scopes,
         updated_at: now,
         // A still-pending row gets THIS callback's confirm token (the older
@@ -552,14 +560,21 @@ export const getOwnedConnection = internalQuery({
     installation_id: v.string(),
     include_pending: v.optional(v.boolean()),
   },
-  handler: async (ctx, args): Promise<{ _id: string; refresh_token_enc: string } | null> => {
+  handler: async (ctx, args): Promise<(RefreshRow & { _id: string }) | null> => {
     const userId = await getAuthenticatedUserId(ctx, args.api_token);
     if (!userId) return null;
     const rowId = (ctx.db as any).normalizeId("google_installations", args.installation_id);
-    const row = rowId ? await ctx.db.get(rowId) : null;
-    if (!row || (row as any).scope_user_id.toString() !== userId.toString()) return null;
-    if ((row as any).pending_confirm_hash && !args.include_pending) return null;
-    return { _id: rowId.toString(), refresh_token_enc: (row as any).refresh_token_enc };
+    const row: any = rowId ? await ctx.db.get(rowId) : null;
+    if (!row || row.scope_user_id.toString() !== userId.toString()) return null;
+    if (row.pending_confirm_hash && !args.include_pending) return null;
+    return {
+      _id: rowId.toString(),
+      refresh_token_enc: row.refresh_token_enc,
+      access_token_enc: row.access_token_enc,
+      access_expires_at: row.access_expires_at,
+      refresh_lease_id: row.refresh_lease_id,
+      refresh_lease_until: row.refresh_lease_until,
+    };
   },
 });
 
@@ -572,17 +587,42 @@ export const deleteConnection = internalMutation({
   },
 });
 
-// updateStoredRefreshToken — Google MAY rotate the refresh token in a refresh
-// response; ignoring the new one leaves a permanently stale ciphertext and a
-// forced reconnect later. Internal: only getFreshAccessToken calls it, with a
-// ciphertext it just produced.
-export const updateStoredRefreshToken = internalMutation({
-  args: { installation_id: v.string(), refresh_token_enc: v.string() },
+// The previous getFreshAccessToken stored a rotated refresh token through an
+// unfenced updateStoredRefreshToken. It is gone, not bridged: a legacy call
+// carries no credential or lease identity, so no write it asks for can be
+// proven safe. The drain is structural and checked at cut time: nothing in
+// the codebase invokes googleOAuth.getFreshAccessToken yet (the Gmail agent
+// verbs are still to come) and google_installations holds no rows, so no
+// pre-deploy action can be in flight when this ships.
+
+/** Claim the refresh for one connection (lib/tokenRefresh.claimRefreshOn). */
+export const claimRefresh = internalMutation({
+  args: { installation_id: v.string(), expected_enc: v.string(), now: v.number() },
   handler: async (ctx, args) => {
     const rowId = (ctx.db as any).normalizeId("google_installations", args.installation_id);
-    if (!rowId) return { ok: false };
-    await (ctx.db as any).patch(rowId, { refresh_token_enc: args.refresh_token_enc, updated_at: Date.now() });
-    return { ok: true };
+    if (!rowId) return { ok: false, reason: "gone" as const };
+    return await claimRefreshOn(ctx.db, rowId, args.expected_enc, args.now);
+  },
+});
+
+/** Persist one refresh outcome, fenced (lib/tokenRefresh.writeRefreshOutcomeOn).
+ *  Google MAY rotate the refresh token in a refresh response; ignoring the new
+ *  one leaves a permanently stale ciphertext, so the pair lands in one write. */
+export const writeRefreshOutcome = internalMutation({
+  args: {
+    installation_id: v.string(),
+    expected_enc: v.string(),
+    lease: v.string(),
+    access_token_enc: v.optional(v.string()),
+    refresh_token_enc: v.optional(v.string()),
+    access_expires_at: v.optional(v.number()),
+    last_error: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { installation_id, ...outcome } = args;
+    const rowId = (ctx.db as any).normalizeId("google_installations", installation_id);
+    if (!rowId) return { ok: false, reason: "gone" as const };
+    return await writeRefreshOutcomeOn(ctx.db, rowId, outcome);
   },
 });
 
@@ -611,60 +651,55 @@ export const disconnect = action({
 
 // getFreshAccessToken — the refresh half. Internal only: access tokens flow to
 // the audited credential path (the coming agent verbs), never to clients.
+// The access token is cached with its expiry and refreshed single flight
+// (lib/tokenRefresh), so a Gmail call no longer pays a token round trip and
+// two concurrent callers cannot both spend a rotating refresh token.
 // invalid_grant means the user revoked us (or the secret rotated) — reported,
 // not thrown, so callers can surface "reconnect Gmail".
 export const getFreshAccessToken = internalAction({
-  args: { api_token: v.optional(v.string()), installation_id: v.string() },
+  args: { api_token: v.optional(v.string()), installation_id: v.string(), force: v.optional(v.boolean()) },
   handler: async (
     ctx,
     args,
   ): Promise<{ ok: boolean; access_token?: string; expires_in?: number; error?: string }> => {
     const env = googleEnv();
     if (!env) return { ok: false, error: NOT_CONFIGURED };
-    const conn = await ctx.runQuery(internalApi.googleOAuth.getOwnedConnection, {
-      api_token: args.api_token,
-      installation_id: args.installation_id,
+    const res = await singleFlightRefresh({
+      provider: "Google",
+      read: () => ctx.runQuery(internalApi.googleOAuth.getOwnedConnection, { api_token: args.api_token, installation_id: args.installation_id }),
+      claim: (installation_id, expected_enc, now) =>
+        ctx.runMutation(internalApi.googleOAuth.claimRefresh, { installation_id, expected_enc, now }),
+      write: (installation_id, outcome) =>
+        ctx.runMutation(internalApi.googleOAuth.writeRefreshOutcome, { installation_id, ...outcome }),
+      decrypt: (enc) => decryptRefreshToken(enc, env.clientSecret),
+      encrypt: (plain) => encryptRefreshToken(plain, env.clientSecret),
+      request: async (refreshToken) => {
+        const resp = await fetch(GOOGLE_TOKEN_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            refresh_token: refreshToken,
+            client_id: env.clientId,
+            client_secret: env.clientSecret,
+            grant_type: "refresh_token",
+          }).toString(),
+        });
+        let tok: any = null;
+        try { tok = await resp.json(); } catch { tok = null; }
+        return { ok: resp.ok, status: resp.status, tok };
+      },
+      force: args.force,
+      errors: {
+        noConnection: "No such Gmail connection for this account (or it is unconfirmed) — reconnect from the Apps tab",
+        undecryptable: "Stored token undecryptable (GOOGLE_OAUTH_CLIENT_SECRET rotated?) — disconnect and reconnect Gmail from the Apps tab",
+        reconnect: "reconnect Gmail from the Apps tab",
+      },
     });
-    if (!conn) {
-      return { ok: false, error: "No such Gmail connection for this account (or it is unconfirmed) — reconnect from the Apps tab" };
-    }
-    const refreshToken = await decryptRefreshToken(conn.refresh_token_enc, env.clientSecret);
-    if (!refreshToken) {
-      return {
-        ok: false,
-        error: "Stored token undecryptable (GOOGLE_OAUTH_CLIENT_SECRET rotated?) — disconnect and reconnect Gmail from the Apps tab",
-      };
-    }
-    let tok: any;
-    try {
-      const resp = await fetch(GOOGLE_TOKEN_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({
-          refresh_token: refreshToken,
-          client_id: env.clientId,
-          client_secret: env.clientSecret,
-          grant_type: "refresh_token",
-        }).toString(),
-      });
-      tok = await resp.json();
-    } catch {
-      return { ok: false, error: "Google token endpoint unreachable — retry; if it persists, reconnect Gmail from the Apps tab" };
-    }
-    if (!tok?.access_token) {
-      if (tok?.error === "invalid_grant") {
-        return { ok: false, error: "invalid_grant — access was revoked at Google; reconnect Gmail from the Apps tab" };
-      }
-      return { ok: false, error: tok?.error || "refresh_failed" };
-    }
-    // Google rotated the refresh token: persist the new one or the stored
-    // ciphertext goes permanently stale after Google retires the old.
-    if (tok.refresh_token) {
-      await ctx.runMutation(internalApi.googleOAuth.updateStoredRefreshToken, {
-        installation_id: conn._id,
-        refresh_token_enc: await encryptRefreshToken(String(tok.refresh_token), env.clientSecret),
-      });
-    }
-    return { ok: true, access_token: tok.access_token, expires_in: tok.expires_in };
+    if (!res.ok) return { ok: false, error: res.error };
+    return {
+      ok: true,
+      access_token: res.token,
+      expires_in: res.expires_at ? Math.max(0, Math.floor((res.expires_at - Date.now()) / 1000)) : undefined,
+    };
   },
 });

--- a/packages/convex/convex/googleOAuthSchema.ts
+++ b/packages/convex/convex/googleOAuthSchema.ts
@@ -19,6 +19,14 @@ export const googleOAuthTables = {
     // AES-256-GCM under a key HKDF-derived from GOOGLE_OAUTH_CLIENT_SECRET
     // (googleOAuth.ts encryptRefreshToken). Plaintext never touches the db.
     refresh_token_enc: v.string(),
+    /** Cached access token and its expiry (lib/tokenRefresh): a Gmail call
+     *  no longer pays a token round trip, and concurrent refreshes no longer
+     *  race the rotation. Absent on rows from before caching: unknown age. */
+    access_token_enc: v.optional(v.string()),
+    access_expires_at: v.optional(v.number()),
+    refresh_lease_id: v.optional(v.string()),
+    refresh_lease_until: v.optional(v.number()),
+    last_error: v.optional(v.string()),
     // Every scope Google reports as granted for this token (the token response's
     // `scope` field — with include_granted_scopes it is the FULL accumulated
     // set, so incremental grants replace rather than append here).

--- a/packages/convex/convex/lib/tokenRefresh.ts
+++ b/packages/convex/convex/lib/tokenRefresh.ts
@@ -1,0 +1,275 @@
+// Single flight OAuth token refresh, shared by every connector that stores a
+// refresh token (oauthConnectors.ts for Linear and Notion, googleOAuth.ts for
+// Gmail). docs/architecture/issue-sync.md S5 describes the protocol; this
+// module is the protocol, the connectors supply the table and the provider.
+//
+// Why one module: a provider rotates the refresh token on the first grant
+// and refuses the second, so two concurrent refreshes with the same token
+// are a lost token, not a harmless duplicate. The lease makes the grant
+// single flight; the fenced outcome write makes a late finish harmless.
+
+/** Refresh this far ahead of expiry so an in-flight call never straddles it. */
+export const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+/** How long one caller may hold the refresh; long enough for a slow token
+ *  endpoint, short enough that a crashed claimant does not block a team. */
+export const REFRESH_LEASE_MS = 30 * 1000;
+/** How long a waiter watches for the claimant's write before trying itself. */
+export const REFRESH_WAIT_MS = 15 * 1000;
+export const REFRESH_POLL_MS = 250;
+
+/** Absolute expiry from a token response, or undefined when the provider
+ *  gave no expires_in (Notion: tokens do not expire). */
+export function accessExpiresAt(tok: any, now: number): number | undefined {
+  return typeof tok?.expires_in === "number" && tok.expires_in > 0 ? now + tok.expires_in * 1000 : undefined;
+}
+
+/** The credential fields every connector row carries for this protocol. */
+export type RefreshRow = {
+  _id: any;
+  access_token_enc?: string;
+  refresh_token_enc?: string;
+  access_expires_at?: number;
+  refresh_lease_id?: string;
+  refresh_lease_until?: number;
+};
+
+/** A row refreshes when it CAN (has a refresh token) and its access token is
+ *  expiring, expired, or of unknown age. Rows without a refresh token never
+ *  refresh: their access token is the only credential there is. */
+export function needsRefresh(row: { refresh_token_enc?: string; access_expires_at?: number }, now: number): boolean {
+  if (!row.refresh_token_enc) return false;
+  if (row.access_expires_at === undefined) return true;
+  return row.access_expires_at - now < REFRESH_MARGIN_MS;
+}
+
+/** The credential identity a claimant or writer proves it read: BOTH
+ *  ciphertexts. Every refresh rewrites the access one and every reconnect
+ *  rewrites the refresh one (random IV even for the same plaintext), so any
+ *  change to either credential changes the stamp. The access ciphertext
+ *  alone was not enough: a legacy or just-reconnected row has none, and a
+ *  reconnect that only replaced the refresh grant was invisible to a stale
+ *  claim, which then refreshed the OLD grant over the new connection. */
+export const stampOf = (row: { access_token_enc?: string; refresh_token_enc?: string }) =>
+  `${row.access_token_enc ?? ""}|${row.refresh_token_enc ?? ""}`;
+
+/** Per table options for the mutation bodies. */
+export type StampOptions = {
+  /**
+   * Transition compatibility for ONE table, remove in the release after this
+   * one ships: an action that started under the previous protocol (the
+   * released Linear action in flight at the moment of deploy) carries the
+   * access ciphertext alone. Only the Linear wrapper turns this on, because
+   * only there is a non-empty access ciphertext unique per refresh and per
+   * reconnect (Linear reconnects always cache one), so the legacy form still
+   * proves the credentials read are the credentials held. The empty legacy
+   * stamp (a row without cache, the pre-claim hole) never matches. The
+   * generic path, and Gmail, accept the two-ciphertext form only.
+   */
+  acceptLegacyAccessStamp?: boolean;
+};
+
+/** Does the stamp a caller read still describe this row? */
+export function stampMatches(
+  row: { access_token_enc?: string; refresh_token_enc?: string },
+  expected: string,
+  opts: StampOptions = {},
+): boolean {
+  if (expected === stampOf(row)) return true;
+  if (!opts.acceptLegacyAccessStamp) return false;
+  const legacyAccessOnly = expected !== "" && !expected.includes("|");
+  return legacyAccessOnly && expected === (row.access_token_enc ?? "");
+}
+
+export type ClaimResult = { ok: boolean; lease?: string; reason?: "gone" | "superseded" | "held" };
+export type OutcomeArgs = {
+  /** stampOf(row) as the writer read it. */
+  expected_enc: string;
+  lease: string;
+  access_token_enc?: string;
+  refresh_token_enc?: string;
+  access_expires_at?: number;
+  last_error?: string;
+};
+export type WriteResult = { ok: boolean; reason?: "gone" | "superseded" };
+
+/**
+ * Mutation body: claim the refresh for one row. Every concurrent caller that
+ * finds the token expiring lands here; exactly one gets `ok` and a lease id,
+ * the rest are told the refresh is `held` and wait for the credentials to
+ * change. The claim is also a compare and swap on the stamp, so a caller
+ * holding a stale read cannot claim over credentials that already moved on.
+ */
+export async function claimRefreshOn(db: any, id: any, expectedEnc: string, now: number, opts: StampOptions = {}): Promise<ClaimResult> {
+  const row = await db.get(id);
+  if (!row) return { ok: false, reason: "gone" };
+  if (!stampMatches(row, expectedEnc, opts)) return { ok: false, reason: "superseded" };
+  if (typeof row.refresh_lease_until === "number" && row.refresh_lease_until > now) return { ok: false, reason: "held" };
+  const lease = crypto.randomUUID();
+  await db.patch(id, { refresh_lease_id: lease, refresh_lease_until: now + REFRESH_LEASE_MS });
+  return { ok: true, lease };
+}
+
+/**
+ * Mutation body: persist the outcome of one refresh. Both outcomes are
+ * fenced the same way: the writer must still own the lease it claimed AND
+ * the credentials must be the ones it read. Nothing about the order in
+ * which provider responses arrive says whose pair is newer, so an expired
+ * claimant's late success is refused like its late failure would be. A
+ * reconnect clears the lease and rewrites the stamp, so anything in flight
+ * before it is refused on both counts. A deleted row is reported, never
+ * recreated. The one write that passes releases the lease.
+ */
+export async function writeRefreshOutcomeOn(db: any, id: any, args: OutcomeArgs, opts: StampOptions = {}): Promise<WriteResult> {
+  const row = await db.get(id);
+  if (!row) return { ok: false, reason: "gone" };
+  if (row.refresh_lease_id !== args.lease || !stampMatches(row, args.expected_enc, opts)) return { ok: false, reason: "superseded" };
+  const release = { refresh_lease_id: undefined, refresh_lease_until: undefined, updated_at: Date.now() };
+  if (args.access_token_enc) {
+    await db.patch(id, {
+      ...release,
+      access_token_enc: args.access_token_enc,
+      access_expires_at: args.access_expires_at,
+      last_error: undefined,
+      ...(args.refresh_token_enc ? { refresh_token_enc: args.refresh_token_enc } : {}),
+    });
+    return { ok: true };
+  }
+  await db.patch(id, { ...release, last_error: args.last_error });
+  return { ok: true };
+}
+
+export type RefreshResult = { ok: boolean; token?: string; expires_at?: number; error?: string };
+
+export type RefreshDeps = {
+  /** Provider name for messages ("Linear", "Gmail"). */
+  provider: string;
+  /** The row as it is now; null when disconnected or still pending. */
+  read: () => Promise<RefreshRow | null>;
+  claim: (id: any, expectedEnc: string, now: number) => Promise<ClaimResult>;
+  write: (id: any, args: OutcomeArgs) => Promise<WriteResult>;
+  decrypt: (enc: string) => Promise<string | null>;
+  encrypt: (plain: string) => Promise<string>;
+  /** One refresh grant at the provider's token endpoint. */
+  request: (refreshToken: string) => Promise<{ ok: boolean; status: number; tok: any }>;
+  /** Refresh even if the recorded expiry says the token is fresh. */
+  force?: boolean;
+  errors: { noConnection: string; undecryptable: string; reconnect: string };
+  /** Internal: one retry after deferring to an owner that left no cached token. */
+  _retried?: boolean;
+};
+
+/**
+ * The access token for one connection, refreshed when it is expiring or of
+ * unknown age. A refusal is returned, not thrown, so callers can say
+ * "reconnect" instead of "401".
+ *
+ * One caller claims the lease and talks to the provider; the others wait
+ * for the row to change and return the pair that landed. Every outcome
+ * write is fenced by lease ownership and credential compare and swap; when
+ * a write is refused the caller waits for the current owner's write and
+ * returns what the row holds then, never the pair it fetched: a
+ * disconnected connection yields no credentials, a superseded refresh
+ * yields the owner's.
+ */
+export async function singleFlightRefresh(deps: RefreshDeps): Promise<RefreshResult> {
+  const noConnection: RefreshResult = { ok: false, error: deps.errors.noConnection };
+  const tokenOf = async (row: RefreshRow): Promise<RefreshResult> => {
+    const token = row.access_token_enc ? await deps.decrypt(row.access_token_enc) : null;
+    return token ? { ok: true, token, expires_at: row.access_expires_at } : { ok: false, error: deps.errors.undecryptable };
+  };
+  /** Wait for another claimant's write. Resolves with the new credentials,
+   *  or null once the lease lapsed with nothing written. */
+  const waitForOther = async (seenEnc: string): Promise<RefreshResult | null> => {
+    const deadline = Date.now() + REFRESH_WAIT_MS;
+    while (Date.now() < deadline) {
+      const row = await deps.read();
+      if (!row) return noConnection;
+      // The credentials changed: a claimant wrote a pair (use it), or a
+      // reconnect replaced the grant without caching a token yet (nothing
+      // landed to use; the caller refreshes on the new grant).
+      if (stampOf(row) !== seenEnc) return row.access_token_enc ? await tokenOf(row) : null;
+      if (typeof row.refresh_lease_until !== "number" || row.refresh_lease_until <= Date.now()) return null;
+      await new Promise((r) => setTimeout(r, REFRESH_POLL_MS));
+    }
+    return null;
+  };
+
+  let row = await deps.read();
+  if (!row) return noConnection;
+  const now = Date.now();
+  if (!deps.force && !needsRefresh(row, now)) return await tokenOf(row);
+
+  // Claim, or wait for whoever holds the claim.
+  let lease: string | undefined;
+  for (let attempt = 0; attempt < 3 && !lease; attempt++) {
+    const claim = await deps.claim(row._id, stampOf(row), Date.now());
+    if (claim.ok) { lease = claim.lease; break; }
+    if (claim.reason === "gone") return noConnection;
+    const landed = await waitForOther(stampOf(row));
+    if (landed) return landed;
+    const again = await deps.read();
+    if (!again) return noConnection;
+    row = again;
+    if (!needsRefresh(row, Date.now())) return await tokenOf(row);
+  }
+  if (!lease) return { ok: false, error: `${deps.provider} refresh is held by another caller; retry` };
+  const mine = row;
+  const stamp = stampOf(mine);
+
+  /** A refused write means the row is no longer ours: a reconnect landed or
+   *  a newer claimant holds the lease. Their write is the answer, so wait
+   *  for it; the pair we fetched is never handed out. */
+  const deferToOwner = async (reason: WriteResult["reason"]): Promise<RefreshResult> => {
+    if (reason === "gone") return noConnection;
+    const landed = await waitForOther(stamp);
+    if (landed) return landed;
+    // Nobody is refreshing and the row holds a refresh token but no cached
+    // access token (a reconnect just replaced the grant): refresh once more
+    // on the new grant instead of reporting the old one as undecryptable.
+    const latest = await deps.read();
+    if (!latest) return noConnection;
+    if (!latest.access_token_enc && latest.refresh_token_enc && !deps._retried) {
+      return await singleFlightRefresh({ ...deps, force: false, _retried: true });
+    }
+    return await tokenOf(latest);
+  };
+
+  const refreshToken = mine.refresh_token_enc ? await deps.decrypt(mine.refresh_token_enc) : null;
+  if (!refreshToken) {
+    // No refresh token (or undecryptable): the access token is all we have.
+    // Releasing the lease is an outcome write like any other, so a reconnect
+    // or disconnect that landed meanwhile refuses it.
+    const released = await deps.write(mine._id, { expected_enc: stamp, lease });
+    if (!released.ok) return await deferToOwner(released.reason);
+    return mine.access_token_enc ? await tokenOf(mine) : { ok: false, error: deps.errors.undecryptable };
+  }
+  const fail = async (error: string) => {
+    const stamped = await deps.write(mine._id, { expected_enc: stamp, lease: lease!, last_error: error });
+    return stamped.ok ? { ok: false, error } : await deferToOwner(stamped.reason);
+  };
+  let res: { ok: boolean; status: number; tok: any };
+  try {
+    res = await deps.request(refreshToken);
+  } catch {
+    return await fail(`${deps.provider} token endpoint unreachable; the next call retries`);
+  }
+  const tok = res.tok;
+  if (!res.ok || typeof tok?.access_token !== "string") {
+    const code = tok?.error ?? `token_${res.status}`;
+    const revoked = code === "invalid_grant" || res.status === 400 || res.status === 401;
+    return await fail(
+      revoked
+        ? `${deps.provider} refresh refused (${code}): access was revoked or the refresh token expired; ${deps.errors.reconnect}`
+        : `${deps.provider} refresh failed (${code}); the next call retries`,
+    );
+  }
+  const expiresAt = accessExpiresAt(tok, now);
+  const written = await deps.write(mine._id, {
+    expected_enc: stamp,
+    lease,
+    access_token_enc: await deps.encrypt(tok.access_token),
+    refresh_token_enc: typeof tok.refresh_token === "string" ? await deps.encrypt(tok.refresh_token) : undefined,
+    access_expires_at: expiresAt,
+  });
+  return written.ok ? { ok: true, token: tok.access_token, expires_at: expiresAt } : await deferToOwner(written.reason);
+}

--- a/packages/convex/convex/oauthConnectors.test.ts
+++ b/packages/convex/convex/oauthConnectors.test.ts
@@ -5,6 +5,7 @@ import {
   PROVIDERS, storeConnection, finishConfirm, deleteConnection, getConnectUrl, accessExpiresAt, needsRefresh, REFRESH_MARGIN_MS,
   getConnectionForTeam, updateStoredTokens, getFreshAccessTokenForTeam, claimRefresh, REFRESH_LEASE_MS,
 } from "./oauthConnectors";
+import { stampOf, stampMatches } from "./lib/tokenRefresh";
 import { signStateWith, verifyStateWith, encryptRefreshToken, decryptRefreshToken } from "./googleOAuth";
 
 // The generic connector shares Google's security design; these tests pin the
@@ -463,6 +464,51 @@ describe("getFreshAccessTokenForTeam (Linear)", () => {
     expect(linear.pending).toHaveLength(0);
   });
 
+  test("a reconnect that lands between the read and the claim: the stale claim is refused and the reconnect's token is returned with no provider call", async () => {
+    const linear = stubLinear();
+    const t = await tables();
+    const g = gate();
+    const a = run(t, { "oauthConnectors:claimRefresh": g });
+    await g.reached;                          // A has read the old row, not yet claimed
+    await reconnect(t);
+    g.open();
+    expect(await a).toEqual({ ok: true, token: "access-re" });
+    expect(linear.pending).toHaveLength(0);   // the old grant was never sent
+    const s = await stored(t);
+    expect([s.access, s.refresh]).toEqual(["access-re", "refresh-re"]);
+  });
+
+  test("transition: an action started under the access-only stamp (Linear v5 in flight) still claims and lands; the empty legacy stamp never matches", async () => {
+    const t = await tables();
+    const row = t.app_installations[0];
+    const legacy = row.access_token_enc;                       // what the v5 action sends
+    const claim = await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: legacy, now: Date.now() });
+    expect(claim.ok).toBe(true);
+    const ok = await (updateStoredTokens as any)._handler(ctx(t), {
+      installation_id: "inst_1", expected_enc: legacy, lease: claim.lease,
+      access_token_enc: "v5-access-enc", refresh_token_enc: "v5-refresh-enc", access_expires_at: Date.now() + 1000,
+    });
+    expect(ok).toEqual({ ok: true });                          // the rotated pair is not discarded
+    expect(t.app_installations[0].refresh_token_enc).toBe("v5-refresh-enc");
+    // A reconnect that only changed the refresh ciphertext is visible to the new form...
+    expect(stampMatches({ access_token_enc: "a", refresh_token_enc: "r2" }, stampOf({ access_token_enc: "a", refresh_token_enc: "r1" }))).toBe(false);
+    // ...the legacy form is refused when empty (row without cache) or wrong, and
+    // accepted only where a table opts in.
+    const optIn = { acceptLegacyAccessStamp: true };
+    expect(stampMatches({ refresh_token_enc: "r2" }, "", optIn)).toBe(false);
+    expect(stampMatches({ access_token_enc: "a", refresh_token_enc: "r" }, "b", optIn)).toBe(false);
+    expect(stampMatches({ access_token_enc: "a", refresh_token_enc: "r" }, "a", optIn)).toBe(true);
+    expect(stampMatches({ access_token_enc: "a", refresh_token_enc: "r" }, "a")).toBe(false);   // generic path
+  });
+
+  test("invariant the legacy discrimination rests on: a ciphertext never contains the stamp separator", async () => {
+    for (const plain of ["a", "refresh-0", "x".repeat(300), "|pipe|inside|"]) {
+      const enc = await encryptRefreshToken(plain, SECRET);
+      expect(enc).toMatch(/^v1\.[A-Za-z0-9+/=]+\.[A-Za-z0-9+/=]+$/);
+      expect(enc.includes("|")).toBe(false);
+    }
+  });
+
   test("a lease left by a dead claimant expires and the next caller refreshes", async () => {
     const linear = stubLinear();
     const t = await tables();
@@ -476,7 +522,7 @@ describe("getFreshAccessTokenForTeam (Linear)", () => {
 
   test("claimRefresh: a stale read cannot claim, a second claim is held, each claim has its own id", async () => {
     const t = await tables();
-    const enc = t.app_installations[0].access_token_enc;
+    const enc = stampOf(t.app_installations[0]);
     expect(await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: "not-the-row's", now: Date.now() })).toEqual({ ok: false, reason: "superseded" });
     const first = await (claimRefresh as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, now: Date.now() });
     expect(first.ok).toBe(true);
@@ -489,9 +535,10 @@ describe("getFreshAccessTokenForTeam (Linear)", () => {
     expect(t.app_installations[0].refresh_lease_until).toBeLessThanOrEqual(Date.now() + REFRESH_LEASE_MS);
   });
 
-  test("updateStoredTokens: both outcomes need the exact lease AND the read ciphertext; the passing write releases the lease", async () => {
+  test("updateStoredTokens: both outcomes need the exact lease AND the read credentials; the passing write releases the lease", async () => {
     const t = await tables();
-    const enc = t.app_installations[0].access_token_enc;
+    const accessEnc = t.app_installations[0].access_token_enc;
+    const enc = stampOf(t.app_installations[0]);
     t.app_installations[0].refresh_lease_id = "current";
     const staleFail = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, lease: "old", last_error: "late" });
     expect(staleFail).toEqual({ ok: false, reason: "superseded" });
@@ -500,7 +547,7 @@ describe("getFreshAccessTokenForTeam (Linear)", () => {
     const movedOn = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: "other-enc", lease: "current", access_token_enc: "x", access_expires_at: 5 });
     expect(movedOn).toEqual({ ok: false, reason: "superseded" });
     expect(t.app_installations[0].last_error).toBeUndefined();
-    expect(t.app_installations[0].access_token_enc).toBe(enc);
+    expect(t.app_installations[0].access_token_enc).toBe(accessEnc);
     expect(t.app_installations[0].refresh_lease_id).toBe("current");
     const ok = await (updateStoredTokens as any)._handler(ctx(t), { installation_id: "inst_1", expected_enc: enc, lease: "current", access_token_enc: "new-enc", access_expires_at: 5 });
     expect(ok).toEqual({ ok: true });

--- a/packages/convex/convex/oauthConnectors.ts
+++ b/packages/convex/convex/oauthConnectors.ts
@@ -25,6 +25,7 @@ import {
   signStateWith,
   verifyStateWith,
 } from "./googleOAuth";
+import { claimRefreshOn, writeRefreshOutcomeOn, singleFlightRefresh } from "./lib/tokenRefresh";
 
 /* ==========================================================================
  * The provider table
@@ -218,26 +219,8 @@ async function tokenRequest(
   return { ok: resp.ok, status: resp.status, tok };
 }
 
-/** Absolute expiry from a token response, or undefined when the provider
- *  gave no expires_in (Notion: tokens do not expire). */
-export function accessExpiresAt(tok: any, now: number): number | undefined {
-  return typeof tok?.expires_in === "number" && tok.expires_in > 0 ? now + tok.expires_in * 1000 : undefined;
-}
-
-/** Refresh this far ahead of expiry so an in-flight sync never straddles it. */
-export const REFRESH_MARGIN_MS = 5 * 60 * 1000;
-
-/** A row refreshes when it CAN (has a refresh token) and its access token is
- *  expiring, expired, or of unknown age. Rows without a refresh token never
- *  refresh: their access token is the only credential there is. */
-export function needsRefresh(
-  row: { refresh_token_enc?: string; access_expires_at?: number },
-  now: number,
-): boolean {
-  if (!row.refresh_token_enc) return false;
-  if (row.access_expires_at === undefined) return true;
-  return row.access_expires_at - now < REFRESH_MARGIN_MS;
-}
+import { accessExpiresAt, needsRefresh, REFRESH_MARGIN_MS, REFRESH_LEASE_MS } from "./lib/tokenRefresh";
+export { accessExpiresAt, needsRefresh, REFRESH_MARGIN_MS, REFRESH_LEASE_MS };
 
 /* ==========================================================================
  * Callback — code exchange, encrypted store, PENDING until confirmed
@@ -514,44 +497,19 @@ export const getConnectionForTeam = internalQuery({
   },
 });
 
-/** How long one caller may hold the refresh; long enough for a slow token
- *  endpoint, short enough that a crashed claimant does not block a team. */
-export const REFRESH_LEASE_MS = 30 * 1000;
-/** How long a waiter watches for the claimant's write before trying itself. */
-const REFRESH_WAIT_MS = 15 * 1000;
-const REFRESH_POLL_MS = 250;
+/** Transition: accept the released action's access-only stamp on this table
+ *  only; remove in the release after the two-ciphertext stamp ships. */
+const LEGACY_STAMP = { acceptLegacyAccessStamp: true } as const;
 
-/**
- * Claim the refresh for one row. Every concurrent caller that finds the
- * token expiring lands here; exactly one gets `ok`, the rest are told the
- * refresh is `held` and wait for the credentials to change. The claim is
- * also a compare and swap on the ciphertext, so a caller holding a stale
- * read cannot claim over credentials that already moved on.
- */
+/** Claim the refresh for one row (lib/tokenRefresh.claimRefreshOn). */
 export const claimRefresh = internalMutation({
   args: { installation_id: v.id("app_installations"), expected_enc: v.string(), now: v.number() },
-  handler: async (ctx, args): Promise<{ ok: boolean; lease?: string; reason?: "gone" | "superseded" | "held" }> => {
-    const row = await (ctx.db as any).get(args.installation_id);
-    if (!row) return { ok: false, reason: "gone" };
-    if (row.access_token_enc !== args.expected_enc) return { ok: false, reason: "superseded" };
-    if (typeof row.refresh_lease_until === "number" && row.refresh_lease_until > args.now) return { ok: false, reason: "held" };
-    const lease = crypto.randomUUID();
-    await (ctx.db as any).patch(args.installation_id, { refresh_lease_id: lease, refresh_lease_until: args.now + REFRESH_LEASE_MS });
-    return { ok: true, lease };
-  },
+  // Linear rows always cache an access ciphertext, so the released action's
+  // access-only stamp is still a proof here (lib/tokenRefresh.StampOptions).
+  handler: async (ctx, args) => await claimRefreshOn(ctx.db, args.installation_id, args.expected_enc, args.now, LEGACY_STAMP),
 });
 
-/**
- * Persist the outcome of one refresh. Both outcomes are fenced the same way:
- * the writer must still own the lease it claimed AND the credentials must be
- * the ones it read. Nothing about the order in which provider responses
- * arrive says whose pair is newer, so an expired claimant's late success is
- * refused like its late failure would be; the caller then defers to the
- * current owner's write (see getFreshAccessTokenForTeam). A reconnect
- * clears the lease and rewrites the ciphertext, so anything in flight
- * before it is refused on both counts. A deleted row is reported, never
- * recreated. The one write that passes releases the lease.
- */
+/** Persist one refresh outcome, fenced (lib/tokenRefresh.writeRefreshOutcomeOn). */
 export const updateStoredTokens = internalMutation({
   args: {
     installation_id: v.id("app_installations"),
@@ -562,43 +520,17 @@ export const updateStoredTokens = internalMutation({
     access_expires_at: v.optional(v.number()),
     last_error: v.optional(v.string()),
   },
-  handler: async (ctx, args): Promise<{ ok: boolean; reason?: "gone" | "superseded" }> => {
-    const row = await (ctx.db as any).get(args.installation_id);
-    if (!row) return { ok: false, reason: "gone" };
-    const release = { refresh_lease_id: undefined, refresh_lease_until: undefined, updated_at: Date.now() };
-    if (row.refresh_lease_id !== args.lease || row.access_token_enc !== args.expected_enc) return { ok: false, reason: "superseded" };
-    if (args.access_token_enc) {
-      await (ctx.db as any).patch(args.installation_id, {
-        ...release,
-        access_token_enc: args.access_token_enc,
-        access_expires_at: args.access_expires_at,
-        last_error: undefined,
-        ...(args.refresh_token_enc ? { refresh_token_enc: args.refresh_token_enc } : {}),
-      });
-      return { ok: true };
-    }
-    await (ctx.db as any).patch(args.installation_id, { ...release, last_error: args.last_error });
-    return { ok: true };
+  handler: async (ctx, args) => {
+    const { installation_id, ...outcome } = args;
+    return await writeRefreshOutcomeOn(ctx.db, installation_id, outcome, LEGACY_STAMP);
   },
 });
 
 /**
- * The access token for a team's connection, refreshed when it is expiring
- * or of unknown age (see needsRefresh). Same shape as googleOAuth's
- * getFreshAccessToken: a refusal is returned, not thrown, so callers can
- * say "reconnect Linear" instead of "401". `force` refreshes regardless of
- * the recorded expiry, for a caller that just got a 401 on a token this
- * function considered fresh.
- *
- * Single flight: the provider rotates the refresh token on the first grant,
- * so a second concurrent grant with the same token is refused. One caller
- * claims the lease and talks to the provider; the others wait for the row
- * to change and return the pair that landed. Every outcome write is a
- * fenced by lease ownership and credential compare and swap
- * (updateStoredTokens); when a write is refused the caller waits for the
- * current owner's write and returns what the row holds then, never the pair
- * it fetched: a disconnected connection yields no credentials, a superseded
- * refresh yields the owner's.
+ * The access token for a team's connection, refreshed single flight when it
+ * is expiring or of unknown age (lib/tokenRefresh.singleFlightRefresh).
+ * `force` refreshes regardless of the recorded expiry, for a caller that
+ * just got a 401 on a token this function considered fresh.
  */
 export const getFreshAccessTokenForTeam = internalAction({
   args: { provider: v.string(), team_id: v.id("teams"), force: v.optional(v.boolean()) },
@@ -607,111 +539,23 @@ export const getFreshAccessTokenForTeam = internalAction({
     const p = PROVIDERS[args.provider];
     const env = providerEnv(p);
     if (!env) return { ok: false, error: notConfigured(p) };
-    type Row = { _id: any; access_token_enc: string; refresh_token_enc?: string; access_expires_at?: number; refresh_lease_until?: number; refresh_lease_id?: string };
-    const noConnection = { ok: false, error: `no_connection: ${p.name} is not connected for this team` };
-    const read = (): Promise<Row | null> =>
-      ctx.runQuery(internal.oauthConnectors.getConnectionForTeam, { provider: p.id, team_id: args.team_id });
-    const tokenOf = async (row: Row) => {
-      const token = await decryptRefreshToken(row.access_token_enc, env.clientSecret);
-      return token ? { ok: true, token } : { ok: false, error: `${p.name} token undecryptable (${p.env.clientSecret} rotated?): reconnect ${p.name}` };
-    };
-    /** Current credentials, as the row holds them now. */
-    const current = async () => {
-      const row = await read();
-      return row ? await tokenOf(row) : noConnection;
-    };
-    /** Wait for another claimant's write. Resolves with the new credentials,
-     *  or null once the lease lapsed with nothing written. */
-    const waitForOther = async (seenEnc: string) => {
-      const deadline = Date.now() + REFRESH_WAIT_MS;
-      while (Date.now() < deadline) {
-        const row = await read();
-        if (!row) return noConnection;
-        if (row.access_token_enc !== seenEnc) return await tokenOf(row);
-        if (typeof row.refresh_lease_until !== "number" || row.refresh_lease_until <= Date.now()) return null;
-        await new Promise((r) => setTimeout(r, REFRESH_POLL_MS));
-      }
-      return null;
-    };
-
-    let row = await read();
-    if (!row) return noConnection;
-    const now = Date.now();
-    if (!args.force && !needsRefresh(row, now)) return await tokenOf(row);
-
-    // Claim, or wait for whoever holds the claim.
-    let lease: string | undefined;
-    for (let attempt = 0; attempt < 3 && !lease; attempt++) {
-      const claim = await ctx.runMutation(internal.oauthConnectors.claimRefresh, {
-        installation_id: row._id,
-        expected_enc: row.access_token_enc,
-        now: Date.now(),
-      });
-      if (claim.ok) { lease = claim.lease; break; }
-      if (claim.reason === "gone") return noConnection;
-      const landed = await waitForOther(row.access_token_enc);
-      if (landed) return landed;
-      const again = await read();
-      if (!again) return noConnection;
-      row = again;
-      if (!needsRefresh(row, Date.now())) return await tokenOf(row);
-    }
-    if (!lease) return { ok: false, error: `${p.name} refresh is held by another caller; retry` };
-
-    const refreshToken = row.refresh_token_enc ? await decryptRefreshToken(row.refresh_token_enc, env.clientSecret) : null;
-    /** A refused write means the row is no longer ours: a reconnect landed
-     *  or a newer claimant holds the lease. Their write is the answer, so
-     *  wait for it; the pair we fetched is never handed out. */
-    const deferToOwner = async (reason: "gone" | "superseded" | undefined) => {
-      if (reason === "gone") return noConnection;
-      const landed = await waitForOther(row!.access_token_enc);
-      return landed ?? await current();
-    };
-    if (!refreshToken) {
-      // No refresh token (or undecryptable): the access token is all we
-      // have. Releasing the lease is an outcome write like any other, so a
-      // reconnect or disconnect that landed meanwhile refuses it, and the
-      // captured row's token is then not the answer.
-      const released = await ctx.runMutation(internal.oauthConnectors.updateStoredTokens, {
-        installation_id: row._id,
-        expected_enc: row.access_token_enc,
-        lease,
-      });
-      return released.ok ? await tokenOf(row) : await deferToOwner(released.reason);
-    }
-    const fail = async (error: string) => {
-      const stamped = await ctx.runMutation(internal.oauthConnectors.updateStoredTokens, {
-        installation_id: row!._id,
-        expected_enc: row!.access_token_enc,
-        lease: lease!,
-        last_error: error,
-      });
-      return stamped.ok ? { ok: false, error } : await deferToOwner(stamped.reason);
-    };
-    let res: { ok: boolean; status: number; tok: any };
-    try {
-      res = await tokenRequest(p, env, { grant_type: "refresh_token", refresh_token: refreshToken });
-    } catch {
-      return await fail(`${p.name} token endpoint unreachable; the next sync retries`);
-    }
-    const tok = res.tok;
-    if (!res.ok || typeof tok?.access_token !== "string") {
-      const code = tok?.error ?? `token_${res.status}`;
-      const revoked = code === "invalid_grant" || res.status === 400 || res.status === 401;
-      return await fail(
-        revoked
-          ? `${p.name} refresh refused (${code}): access was revoked or the refresh token expired; reconnect ${p.name} from Settings > Integrations`
-          : `${p.name} refresh failed (${code}); the next sync retries`,
-      );
-    }
-    const written = await ctx.runMutation(internal.oauthConnectors.updateStoredTokens, {
-      installation_id: row._id,
-      expected_enc: row.access_token_enc,
-      lease,
-      access_token_enc: await encryptRefreshToken(tok.access_token, env.clientSecret),
-      refresh_token_enc: typeof tok.refresh_token === "string" ? await encryptRefreshToken(tok.refresh_token, env.clientSecret) : undefined,
-      access_expires_at: accessExpiresAt(tok, now),
+    const res = await singleFlightRefresh({
+      provider: p.name,
+      read: () => ctx.runQuery(internal.oauthConnectors.getConnectionForTeam, { provider: p.id, team_id: args.team_id }),
+      claim: (installation_id, expected_enc, now) =>
+        ctx.runMutation(internal.oauthConnectors.claimRefresh, { installation_id, expected_enc, now }),
+      write: (installation_id, outcome) =>
+        ctx.runMutation(internal.oauthConnectors.updateStoredTokens, { installation_id, ...outcome }),
+      decrypt: (enc) => decryptRefreshToken(enc, env.clientSecret),
+      encrypt: (plain) => encryptRefreshToken(plain, env.clientSecret),
+      request: (refreshToken) => tokenRequest(p, env, { grant_type: "refresh_token", refresh_token: refreshToken }),
+      force: args.force,
+      errors: {
+        noConnection: `no_connection: ${p.name} is not connected for this team`,
+        undecryptable: `${p.name} token undecryptable (${p.env.clientSecret} rotated?): reconnect ${p.name}`,
+        reconnect: `reconnect ${p.name} from Settings > Integrations`,
+      },
     });
-    return written.ok ? { ok: true, token: tok.access_token } : await deferToOwner(written.reason);
+    return res.ok ? { ok: true, token: res.token } : { ok: false, error: res.error };
   },
 });


### PR DESCRIPTION
Gmail refreshed on every credential request, allowing overlapping refreshes or a reconnect to lose a rotated grant. Share the existing refresh lease protocol with Linear, cache Google access tokens until near expiry, and fence claims and outcomes against both encrypted credentials.

Keep access-only stamp compatibility in the Linear table wrappers so older in-flight Linear actions can save their rotations. Google uses the strict protocol. Removing its old writer is gated on this installation having no Google rows, no application or scheduler callers, and no manual Google connector invocation during deployment; recheck the empty table immediately before the cut.

Validation: staged refresh, reconnect, disconnect and lease interleavings; actual released Linear action against the new writer; root typecheck/lint; full CI before publication. Google has no connected production account, so no live Google grant is claimed. No Linear compatibility removal in this cut.
