### PR TITLE
test(cli): make clock and lock fixtures deterministic

### DIFF
--- a/packages/cli/src/browser/instance.test.ts
+++ b/packages/cli/src/browser/instance.test.ts
@@ -181,19 +181,32 @@ describe("acquireStartLock", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    // Wait until it actually holds the lock before signalling.
-    const lockFile = path.join(browserHome(), "start.lock");
-    for (let i = 0; i < 100 && !fs.existsSync(lockFile); i++) {
-      await new Promise((r) => setTimeout(r, 50));
-    }
-    expect(fs.existsSync(lockFile)).toBe(true);
+    const deadline = setTimeout(() => proc.kill("SIGKILL"), 4000);
+    try {
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let output = "";
+      while (!output.includes("\n")) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        output += decoder.decode(value, { stream: true });
+      }
+      reader.releaseLock();
+      expect(output).toBe("acquired\n");
+      const lockFile = path.join(browserHome(), "start.lock");
+      expect(fs.existsSync(lockFile)).toBe(true);
 
-    proc.kill("SIGTERM");
-    await proc.exited;
-    expect(fs.existsSync(lockFile)).toBe(false);
-    // Re-raised rather than swallowed: the process must still die by the
-    // signal (128 + 15), so callers and shells see what they expect.
-    expect(proc.exitCode === 143 || proc.signalCode === "SIGTERM").toBe(true);
+      proc.kill("SIGTERM");
+      await proc.exited;
+      expect(fs.existsSync(lockFile)).toBe(false);
+      // Re-raised rather than swallowed: the process must still die by the
+      // signal (128 + 15), so callers and shells see what they expect.
+      expect(proc.exitCode === 143 || proc.signalCode === "SIGTERM").toBe(true);
+    } finally {
+      clearTimeout(deadline);
+      if (proc.exitCode === null) proc.kill("SIGKILL");
+      await proc.exited;
+    }
   });
 
   test("reports who it is waiting for instead of blocking silently", async () => {

--- a/packages/cli/src/daemon.registry-dispatch.test.ts
+++ b/packages/cli/src/daemon.registry-dispatch.test.ts
@@ -3,7 +3,7 @@
 // per-client value the old inline branch produced. These are pure assertions
 // against the shared registry plus the small daemon-exported dispatch helpers, so
 // they pin the byte-identical mandate without needing a live daemon.
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, spyOn } from "bun:test";
 import { AGENT_CLIENTS, type AgentClientId } from "@codecast/shared/contracts";
 import {
   parseTranscriptFor,
@@ -175,7 +175,12 @@ describe("parseTranscriptFor dispatches to the per-client parser", () => {
     expect(parseTranscriptFor("gemini", geminiJson)).toEqual(parseGeminiSessionFile(geminiJson));
   });
   test("cursor -> parseCursorTranscriptFile", () => {
-    expect(parseTranscriptFor("cursor", cursorTranscript)).toEqual(parseCursorTranscriptFile(cursorTranscript));
+    const clock = spyOn(Date, "now").mockReturnValue(1767225600000);
+    try {
+      expect(parseTranscriptFor("cursor", cursorTranscript)).toEqual(parseCursorTranscriptFile(cursorTranscript));
+    } finally {
+      clock.mockRestore();
+    }
   });
   const opencodeSnapshot = JSON.stringify({
     info: { id: "ses_x" },


### PR DESCRIPTION
Two CLI tests depended on timing outside the behavior they test. The Cursor comparison now uses one fixed synchronous clock and restores it in `finally`, so full object equality no longer depends on two calls landing in the same millisecond.

The browser shutdown fixture now waits for the child to finish lock acquisition before sending SIGTERM. File creation precedes handler registration, so polling file existence could kill the child too early. The test retains immediate lock removal and signal exit assertions, with bounded cleanup of its disposable child.

Both changes are test-only. Full CI is required before merge; the earlier failed runs remain recorded.
