### PR TITLE
fix(cli): recover sync after idle without restart loops

### DIFF
--- a/packages/cli/src/daemon.bootOrder.guard.test.ts
+++ b/packages/cli/src/daemon.bootOrder.guard.test.ts
@@ -28,7 +28,7 @@ const mainAt = src.indexOf(MAIN);
 const SEQUENCE: Array<{ anchor: string; why: string }> = [
   { anchor: 'logLifecycle("daemon_start"', why: "boot starts here" },
   { anchor: "hookServer = startHookServer(", why: "the loopback server listens" },
-  { anchor: "await checkForForcedUpdate(", why: "the first network call" },
+  { anchor: "void checkForForcedUpdate(", why: "the update check runs in the background" },
   { anchor: "readAvailableSkills()", why: "the boot skills sweep" },
   { anchor: "setHookStatusSink(", why: "the hook status handler registers" },
 ];
@@ -52,5 +52,13 @@ describe("daemon boot order", () => {
     const slice = sliceBetween(src, 'logLifecycle("daemon_start"', "hookServer = startHookServer(", mainAt);
     const lines = codeLines(slice.text).length;
     expect(lines, `${lines} code lines run before the loopback server listens`).toBeLessThan(80);
+  });
+
+  test("updates and skill discovery cannot hold sync startup behind an unresolved promise", () => {
+    const main = src.slice(mainAt);
+    expect(main).not.toContain("await checkForForcedUpdate(");
+    const skills = sliceBetween(main, "const syncStartupSkills = async () => {", "const retryQueue = new RetryQueue(");
+    expect(skills.text).toContain("setImmediate(() => {");
+    expect(skills.text).toContain("void syncStartupSkills().catch(");
   });
 });

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -83,7 +83,9 @@ import { OpencodeServer } from "./opencodeServer.js";
 import {
   buildDaemonLauncherScript,
   buildDaemonPlistXml,
+  buildWatchdogShellScript,
   daemonPlistNeedsUpgrade,
+  daemonLauncherMatchesCommand,
   daemonTickStale,
   DAEMON_HEARTBEAT_STALE_MS,
   DAEMON_LAUNCHER_FILENAME,
@@ -20336,10 +20338,10 @@ function migrateDaemonPlistToStableLauncher(): void {
 
 /** What the supervision tick should do, from what it observed. Pure so the
  *  branches are testable without launchd. */
-export function watchdogSupervisionAction(input: { loaded: boolean; plistExists: boolean; heartbeat: string | null; now: number }): "bootstrap" | "plist_missing" | "kickstart" | "none" {
+export function watchdogSupervisionAction(input: { loaded: boolean; plistExists: boolean; heartbeat: string | null; now: number; scriptChanged?: boolean }): "bootstrap" | "plist_missing" | "kickstart" | "none" {
   if (!input.loaded) return input.plistExists ? "bootstrap" : "plist_missing";
   // Loaded. A stale heartbeat means the loop is wedged or dead.
-  return watchdogHeartbeatStale(input.heartbeat, input.now) ? "kickstart" : "none";
+  return input.scriptChanged || watchdogHeartbeatStale(input.heartbeat, input.now) ? "kickstart" : "none";
 }
 
 let lastWatchdogEnsureAt = 0;
@@ -20347,7 +20349,7 @@ let watchdogEnsureInFlight = false;
 // Async: three launchctl calls on the health tick held the loop for their
 // whole round trip. The throttle stamp is taken before the first await, and
 // the in flight flag keeps the boot call and the tick from overlapping.
-async function ensureWatchdogSupervised(force = false): Promise<void> {
+export async function ensureWatchdogSupervised(force = false): Promise<void> {
   if (platform !== "darwin" || !process.getuid) return;
   const now = Date.now();
   if (!force && now - lastWatchdogEnsureAt < 4 * 60 * 1000) return;
@@ -20364,10 +20366,23 @@ async function ensureWatchdogSupervised(force = false): Promise<void> {
       _execFileAsync("launchctl", args, { timeout: 10_000 }).then(() => true, () => false);
     const plistPath = `${process.env.HOME}/Library/LaunchAgents/${label}.plist`;
     const loaded = await launchctl(["print", `${domain}/${label}`]);
+    const scriptPath = path.join(CONFIG_DIR, "watchdog.sh");
+    const launcher = await fs.promises.readFile(path.join(CONFIG_DIR, DAEMON_LAUNCHER_FILENAME), "utf-8").catch(() => "");
+    const { executablePath, args } = getDaemonExecInfo();
+    const previousScript = await fs.promises.readFile(scriptPath, "utf-8").catch(() => null);
+    const script = buildWatchdogShellScript({
+      isBinary: args[0] === "--",
+      watchdogCommand: [executablePath, "--", "_watchdog"].map(shellEscapeForSh).join(" "),
+    });
+    const scriptChanged = daemonLauncherMatchesCommand(launcher, executablePath, args) && previousScript !== script;
+    if (scriptChanged) {
+      await fs.promises.writeFile(`${scriptPath}.${process.pid}.tmp`, script, { mode: 0o755 });
+      await fs.promises.rename(`${scriptPath}.${process.pid}.tmp`, scriptPath);
+    }
     const heartbeat = loaded
       ? await fs.promises.readFile(path.join(CONFIG_DIR, WATCHDOG_HEARTBEAT_FILENAME), "utf-8").catch(() => null)
       : null;
-    const action = watchdogSupervisionAction({ loaded, plistExists: fs.existsSync(plistPath), heartbeat, now });
+    const action = watchdogSupervisionAction({ loaded, plistExists: fs.existsSync(plistPath), heartbeat, now, scriptChanged });
     switch (action) {
       case "plist_missing":
         log(`Watchdog plist missing (${plistPath}): run 'cast setup' to restore supervision`);
@@ -20378,8 +20393,11 @@ async function ensureWatchdogSupervised(force = false): Promise<void> {
         await launchctl(["kickstart", `${domain}/${label}`]);
         return;
       case "kickstart":
-        log("Watchdog loaded but heartbeat stale: kickstarting the wedged loop");
-        await launchctl(["kickstart", "-k", `${domain}/${label}`]);
+        log(scriptChanged ? "Watchdog script updated: reloading resident loop" : "Watchdog loaded but heartbeat stale: kickstarting the wedged loop");
+        if (!(await launchctl(["kickstart", "-k", `${domain}/${label}`])) && scriptChanged) {
+          if (previousScript === null) await fs.promises.unlink(scriptPath);
+          else await fs.promises.writeFile(scriptPath, previousScript, { mode: 0o755 });
+        }
         return;
       case "none":
         return;
@@ -22208,14 +22226,7 @@ async function main(): Promise<void> {
   // and the boot sweep only covers generations orphaned before we started.
   setInterval(() => { void sweepStaleTmuxServers(); }, 3_600_000);
 
-  // Check for forced updates immediately on startup before anything else
-  // This allows recovery from broken versions by downloading a fix early
-  try {
-    const didUpdate = await checkForForcedUpdate(syncService);
-    if (didUpdate) return; // process.exit already called inside
-  } catch (err) {
-    log(`Startup update check failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
+  void checkForForcedUpdate(syncService);
 
   // Repair any project paths that were stored incorrectly (one-time on startup)
   repairProjectPaths(syncService).catch(err => {
@@ -22446,7 +22457,7 @@ async function main(): Promise<void> {
   // read here is async: the sweep stats a path per segment of every project
   // dir name, which is thousands of stats on a machine with hundreds of
   // projects, and it runs on the same loop the hook server answers from.
-  {
+  const syncStartupSkills = async () => {
     const globalSkills = await readAvailableSkills();
     if (globalSkills.length > 0) {
       const skillsJson = JSON.stringify(globalSkills);
@@ -22491,7 +22502,10 @@ async function main(): Promise<void> {
         }
       }
     } catch {}
-  }
+  };
+  setImmediate(() => {
+    void syncStartupSkills().catch((err) => logError("Startup skills scan failed", err instanceof Error ? err : new Error(String(err))));
+  });
 
   const retryQueue = new RetryQueue({
     initialDelayMs: 3000,
@@ -24877,6 +24891,13 @@ export async function runWatchdog(): Promise<void> {
   const logLine = (msg: string) => {
     try { fs.appendFileSync(LOG_FILE, `[${new Date().toISOString()}] [watchdog] ${msg}\n`); } catch {}
   };
+  const daemonPlist = path.join(process.env.HOME || "", "Library", "LaunchAgents", `${DAEMON_LAUNCHD_LABEL}.plist`);
+  const supervised = platform === "darwin" && fs.existsSync(daemonPlist);
+  const { executablePath, args } = getDaemonExecInfo();
+  const launcher = supervised
+    ? await fs.promises.readFile(path.join(CONFIG_DIR, DAEMON_LAUNCHER_FILENAME), "utf-8").catch(() => "")
+    : "";
+  const mayUpgradeDaemon = !supervised || daemonLauncherMatchesCommand(launcher, executablePath, args);
 
   // 1. Report crash loop info if crash file exists
   if (fs.existsSync(CRASH_FILE)) {
@@ -24885,6 +24906,7 @@ export async function runWatchdog(): Promise<void> {
       if (crashes.count > 3) {
         await fetch(`${siteUrl}/cli/log`, {
           method: "POST",
+          signal: AbortSignal.timeout(10_000),
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             api_token: config.auth_token,
@@ -24932,8 +24954,6 @@ export async function runWatchdog(): Promise<void> {
       const lastTick = state.lastHeartbeatTick || state.lastWatchdogCheck || 0;
       const staleness = passNow - lastTick;
       if (lastTick > 0 && staleness > DAEMON_HEARTBEAT_STALE_MS) {
-        // A busy boot starves the tick stamper but keeps writing daemon.log; a
-        // truly wedged loop runs no JS and cannot log (see daemonTickStale).
         let logAgeMs: number | null = null;
         try { logAgeMs = passNow - fs.statSync(path.join(CONFIG_DIR, "daemon.log")).mtimeMs; } catch {}
         if (daemonTickStale(staleness, passGap, logAgeMs)) {
@@ -24956,6 +24976,7 @@ export async function runWatchdog(): Promise<void> {
   try {
     const response = await fetch(`${siteUrl}/cli/heartbeat`, {
       method: "POST",
+      signal: AbortSignal.timeout(10_000),
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         api_token: config.auth_token,
@@ -24977,6 +24998,7 @@ export async function runWatchdog(): Promise<void> {
   const sendWatchdogLog = async (level: string, message: string) => {
     await fetch(`${siteUrl}/cli/log`, {
       method: "POST",
+      signal: AbortSignal.timeout(10_000),
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         api_token: config.auth_token,
@@ -24988,7 +25010,7 @@ export async function runWatchdog(): Promise<void> {
     }).catch(() => {});
   };
 
-  if (minCliVersion && compareVersions(version, minCliVersion) < 0) {
+  if (mayUpgradeDaemon && minCliVersion && compareVersions(version, minCliVersion) < 0) {
     logLine(`Binary outdated: current=${version} min=${minCliVersion}, updating...`);
     await sendWatchdogLog("info", `[LIFECYCLE] watchdog_update_start: current=${version} min=${minCliVersion}`);
     const result = await performUpdate();
@@ -25010,7 +25032,7 @@ export async function runWatchdog(): Promise<void> {
   }
 
   // 3c. If daemon is alive but running an older version than the binary, kill it
-  if (daemonAlive && daemonPid > 0) {
+  if (mayUpgradeDaemon && daemonAlive && daemonPid > 0) {
     try {
       const state = readDaemonState();
       const daemonVersion = state.runtimeVersion;
@@ -25032,6 +25054,16 @@ export async function runWatchdog(): Promise<void> {
   if (!daemonAlive) {
     logLine("Daemon not running, restarting...");
 
+    if (supervised) {
+      const domain = `gui/${process.getuid!()}`;
+      const job = await readLaunchdDaemonJobAsync();
+      if (!job.loaded) {
+        await _execFileAsync("launchctl", ["bootstrap", domain, daemonPlist], { timeout: 5000 });
+      }
+      await _execFileAsync("launchctl", ["kickstart", `${domain}/${DAEMON_LAUNCHD_LABEL}`], { timeout: 5000 });
+      return;
+    }
+
     // Handle force_update before restart so daemon starts with new binary
     const updateCmd = commands.find(c => c.command === "force_update");
     if (updateCmd) {
@@ -25040,6 +25072,7 @@ export async function runWatchdog(): Promise<void> {
       // Report result
       await fetch(`${siteUrl}/cli/command-result`, {
         method: "POST",
+        signal: AbortSignal.timeout(10_000),
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           api_token: config.auth_token,
@@ -25059,6 +25092,7 @@ export async function runWatchdog(): Promise<void> {
     for (const cmd of commands) {
       await fetch(`${siteUrl}/cli/command-result`, {
         method: "POST",
+        signal: AbortSignal.timeout(10_000),
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           api_token: config.auth_token,
@@ -25070,7 +25104,6 @@ export async function runWatchdog(): Promise<void> {
 
     // Spawn daemon
     clearCrashCount();
-    const { executablePath, args } = getDaemonExecInfo();
     try {
       const child = spawn(executablePath, args, {
         detached: true,
@@ -25095,7 +25128,8 @@ function getDaemonExecInfo(): { executablePath: string; args: string[] } {
   if (isBinary) {
     return { executablePath: execPath, args: ["--", "_daemon"] };
   }
-  return { executablePath: execPath, args: [path.resolve(__dirname, "daemon.js")] };
+  const source = path.resolve(__dirname, "daemon.ts");
+  return { executablePath: execPath, args: [fs.existsSync(source) ? source : path.resolve(__dirname, "daemon.js"), "_daemon"] };
 }
 
 // Only run directly if executed as the main module (not when imported)

--- a/packages/cli/src/daemonBuildId.ts
+++ b/packages/cli/src/daemonBuildId.ts
@@ -10,4 +10,4 @@
 //
 // This file is excluded from its own hash, and it imports nothing on purpose:
 // the CLI fast path reads it, so it must never pull in a module graph.
-export const DAEMON_BUILD_ID = "3aa2fcd54b47";
+export const DAEMON_BUILD_ID = "c720e84dbcd1";

--- a/packages/cli/src/daemonRestartGating.test.ts
+++ b/packages/cli/src/daemonRestartGating.test.ts
@@ -68,6 +68,13 @@ describe("daemon restart gating", () => {
     expect(body).toContain("startDaemon();");
   });
 
+  test("ordinary CLI use and automatic updates both respect the configured installation", () => {
+    expect(functionBody(index, "ensureDaemonRunning")).toContain("ownsDaemonInstallation()");
+    expect(functionBody(index, "bounceDaemonIfBuildChanged")).toContain("ownsDaemonInstallation()");
+    expect(functionBody(index, "bounceDaemonIfBuildChanged")).toContain("if (!ownsInstallation) return false;");
+    expect(functionBody(index, "ownsDaemonInstallation")).toContain("daemonLauncherMatchesCommand(");
+  });
+
   test("the update paths no longer stop the daemon before performUpdate", () => {
     // performUpdate renames the executable and the running daemon holds the old
     // inode. The stop that used to run before the update bought nothing and

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -116,6 +116,7 @@ import {
   buildWatchdogPlistXml,
   buildWatchdogShellScript,
   daemonPlistNeedsUpgrade,
+  daemonLauncherMatchesCommand,
   DAEMON_LAUNCHER_FILENAME,
   shellEscapeForSh,
   watchdogPlistNeedsUpgrade,
@@ -1122,6 +1123,12 @@ function ensureDaemonRunning(): void {
           // that could START a restart would let a worktree bounce the main
           // daemon into its own tree on every edit.
           if (daemonBuildUnchanged(readRunningBuildId(), DAEMON_BUILD_ID)) return;
+          const supervised = getMacLaunchdDaemonStatus();
+          if (supervised?.configured) {
+            const { executablePath, args } = getExecutableInfo();
+            const launcher = fs.readFileSync(DAEMON_LAUNCHER_SCRIPT_PATH, "utf-8");
+            if (!daemonLauncherMatchesCommand(launcher, executablePath, args)) return;
+          }
           const pid = getDaemonPid();
           if (pid) {
             try { process.kill(pid, "SIGTERM"); } catch { return; }
@@ -1278,6 +1285,7 @@ function getStuckSyncs(): StuckSync[] {
     // already skips them; without the same skip here they always read as stuck
     // (file grows past lastSyncedPosition) even though every message is synced.
     if (filePath.includes("/.codex/sessions/") && isAppServerManagedRollout(filePath)) continue;
+    if (filePath.includes("/.codex/sessions/") && stats.size <= getPosition(filePath)) continue;
     const unsynced = stats.size - record.lastSyncedPosition;
     if (unsynced < STUCK_SYNC_MIN_BYTES) continue;
     if (stats.mtimeMs <= record.lastSyncedAt) continue;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1102,6 +1102,12 @@ function kickstartManagedDaemon(): boolean {
   return result.status === 0;
 }
 
+function ownsDaemonInstallation(): boolean {
+  if (!getMacLaunchdDaemonStatus()?.configured) return true;
+  const { executablePath, args } = getExecutableInfo();
+  return daemonLauncherMatchesCommand(fs.readFileSync(DAEMON_LAUNCHER_SCRIPT_PATH, "utf-8"), executablePath, args);
+}
+
 function ensureDaemonRunning(): void {
   const config = readConfig();
   if (!config?.auth_token) return;
@@ -1123,12 +1129,7 @@ function ensureDaemonRunning(): void {
           // that could START a restart would let a worktree bounce the main
           // daemon into its own tree on every edit.
           if (daemonBuildUnchanged(readRunningBuildId(), DAEMON_BUILD_ID)) return;
-          const supervised = getMacLaunchdDaemonStatus();
-          if (supervised?.configured) {
-            const { executablePath, args } = getExecutableInfo();
-            const launcher = fs.readFileSync(DAEMON_LAUNCHER_SCRIPT_PATH, "utf-8");
-            if (!daemonLauncherMatchesCommand(launcher, executablePath, args)) return;
-          }
+          if (!ownsDaemonInstallation()) return;
           const pid = getDaemonPid();
           if (pid) {
             try { process.kill(pid, "SIGTERM"); } catch { return; }
@@ -1638,7 +1639,10 @@ function bounceDaemonIfBuildChanged(daemonWasRunning: boolean): boolean {
   const runningBuild = readRunningBuildId();
 
   let installedBuild: string | null = null;
+  let ownsInstallation = false;
   try {
+    ownsInstallation = ownsDaemonInstallation();
+    if (!ownsInstallation) return false;
     const { executablePath, args } = getExecutableInfo("_build-id");
     const r = spawnSync(executablePath, args, {
       encoding: "utf-8",
@@ -1649,6 +1653,7 @@ function bounceDaemonIfBuildChanged(daemonWasRunning: boolean): boolean {
     if (BUILD_ID_VALUE_RE.test(out)) installedBuild = out;
   } catch {}
 
+  if (!ownsInstallation) return false;
   if (daemonBuildUnchanged(runningBuild, installedBuild)) return false;
 
   stopDaemon();

--- a/packages/cli/src/supervision.recovery.e2e.test.ts
+++ b/packages/cli/src/supervision.recovery.e2e.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import {
+  buildDaemonLauncherScript,
+  buildDaemonPlistXml,
+  buildWatchdogPlistXml,
+  buildWatchdogShellScript,
+  daemonLauncherMatchesCommand,
+  daemonTickStale,
+  DAEMON_HEARTBEAT_BUSY_GRACE_MS,
+  shellEscapeForSh,
+} from "./supervision.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "cast-supervision-recovery-"));
+  roots.push(home);
+  fs.mkdirSync(path.join(home, ".codecast"));
+  fs.mkdirSync(path.join(home, "bin"));
+  fs.writeFileSync(path.join(home, "bin", "launchctl"), `#!/bin/sh
+printf '%s\\n' "$*" >> "$HOME/calls"
+if [ "$1" = print ]; then
+  fixture_pid=$(cat "$HOME/fixture-pid" 2>/dev/null || echo 123)
+  printf 'state = running\\npid = %s\\n' "$fixture_pid"
+fi
+if [ "$1" = kickstart ] && [ -f "$HOME/fail-kickstart" ]; then
+  rm "$HOME/fail-kickstart"
+  exit 1
+fi
+`, { mode: 0o755 });
+  fs.writeFileSync(path.join(home, "bin", "date"), `#!/bin/sh
+if [ "$1" = +%s ]; then cat "$HOME/now"; else /bin/date "$@"; fi
+`, { mode: 0o755 });
+  return home;
+}
+
+function run(file: string, args: string[], home: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, args, {
+      env: { ...process.env, HOME: home, PATH: `${home}/bin:${process.env.PATH}` },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 25_000,
+    });
+    let stderr = "";
+    let stdout = "";
+    child.stdout.on("data", (data) => { stdout += data; });
+    child.stderr.on("data", (data) => { stderr += data; });
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function watchdogPass(home: string, now: number, tickAge: number, gap: number) {
+  const dir = path.join(home, ".codecast");
+  fs.writeFileSync(path.join(home, "now"), String(Math.floor(now / 1000)));
+  fs.writeFileSync(path.join(dir, "daemon.state"), JSON.stringify({ lastHeartbeatTick: now - tickAge }));
+  fs.writeFileSync(path.join(dir, "watchdog.heartbeat"), String(now - gap));
+  fs.appendFileSync(path.join(dir, "daemon.log"), "still receiving filesystem events\n");
+  fs.utimesSync(path.join(dir, "daemon.log"), now / 1000, now / 1000);
+  const script = buildWatchdogShellScript({ isBinary: false, watchdogCommand: "" });
+  const loop = script.lastIndexOf("\nwhile :; do");
+  expect(loop).toBeGreaterThan(0);
+  const scriptPath = path.join(home, "watchdog-pass.sh");
+  fs.writeFileSync(scriptPath, `${script.slice(0, loop)}\ncheck_once\n`);
+  expect(await run("/bin/sh", [scriptPath], home)).toMatchObject({ code: 0 });
+  return fs.readFileSync(path.join(home, "calls"), "utf-8").split("\n").filter((line) => line.startsWith("kickstart"));
+}
+
+describe("watchdog recovery with continuing log activity", () => {
+  test("fresh log writes cannot excuse a dead heartbeat forever", () => {
+    expect(daemonTickStale(DAEMON_HEARTBEAT_BUSY_GRACE_MS, 60_000, 0)).toBe(false);
+    expect(daemonTickStale(DAEMON_HEARTBEAT_BUSY_GRACE_MS + 1, 60_000, 0)).toBe(true);
+    expect(daemonTickStale(DAEMON_HEARTBEAT_BUSY_GRACE_MS + 1, 8 * 3_600_000, 0)).toBe(false);
+  });
+
+  test.skipIf(process.platform !== "darwin")("resident shell recovers once, then leaves a restored heartbeat alone", async () => {
+    const home = fixture();
+    const now = Math.floor(Date.now() / 1000) * 1000;
+    expect(await watchdogPass(home, now, 240_000, 60_000)).toHaveLength(0);
+    expect(await watchdogPass(home, now + 420_000, 660_000, 60_000)).toHaveLength(1);
+    expect(await watchdogPass(home, now + 480_000, 30_000, 60_000)).toHaveLength(1);
+  });
+
+  test.skipIf(process.platform !== "darwin")("sleep gets a grace pass; a dead timer still recovers after wake", async () => {
+    const home = fixture();
+    const now = Math.floor(Date.now() / 1000) * 1000;
+    const sleep = 8 * 3_600_000;
+    expect(await watchdogPass(home, now, sleep, sleep)).toHaveLength(0);
+    expect(await watchdogPass(home, now + 60_000, sleep + 60_000, 60_000)).toHaveLength(1);
+  });
+
+  test.skipIf(process.platform !== "darwin")("healthy wake and ordinary idle never restart", async () => {
+    const home = fixture();
+    const now = Math.floor(Date.now() / 1000) * 1000;
+    expect(await watchdogPass(home, now, 8 * 3_600_000, 8 * 3_600_000)).toHaveLength(0);
+    expect(await watchdogPass(home, now + 60_000, 0, 60_000)).toHaveLength(0);
+    expect(await watchdogPass(home, now + 120_000, 30_000, 60_000)).toHaveLength(0);
+  });
+});
+
+test("status distinguishes consumed Codex metadata from unread transcript bytes", async () => {
+  const home = fixture();
+  const dir = path.join(home, ".codex", "sessions", "2026", "09", "04");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "rollout-01a06e11-085e-7883-a28f-b6127cf23ffe.jsonl");
+  const timestamp = new Date(Date.now() - 3_600_000).toISOString();
+  const data = JSON.stringify({ type: "session_meta", timestamp, payload: { source: "cli", originator: "codex_cli_rs" } }) + "\n"
+    + JSON.stringify({ type: "compacted", timestamp, payload: { summary: "history ".repeat(500) } }) + "\n";
+  fs.writeFileSync(file, data);
+  fs.writeFileSync(path.join(home, ".codecast", "sync-ledger.json"), JSON.stringify({
+    [file]: { lastSyncedAt: Date.now() - 7_200_000, lastSyncedPosition: 0, messageCount: 1 },
+  }));
+  const positions = path.join(home, ".codecast", "positions.json");
+  fs.writeFileSync(positions, JSON.stringify({ [file]: Buffer.byteLength(data) }));
+  const args = [path.join(import.meta.dir, "main.ts"), "status"];
+  const consumed = await run(process.execPath, args, home);
+  expect(consumed, consumed.stderr).toMatchObject({ code: 0 });
+  expect(consumed.stdout).not.toContain("Stuck syncs");
+  fs.writeFileSync(positions, JSON.stringify({ [file]: 0 }));
+  const unread = await run(process.execPath, args, home);
+  expect(unread, unread.stderr).toMatchObject({ code: 0 });
+  expect(unread.stdout).toContain("Stuck syncs");
+}, 60_000);
+
+describe("automatic upgrade installation ownership", () => {
+  const sourceArgs = ["/src/codecast/packages/cli/src/daemon.ts", "_daemon"];
+  const launcher = buildDaemonLauncherScript({ daemonCommand: "'/opt/bun' '/src/codecast/packages/cli/src/daemon.ts' '_daemon'" });
+
+  test("the same installation may upgrade its daemon", () => {
+    expect(daemonLauncherMatchesCommand(launcher, "/opt/bun", sourceArgs)).toBe(true);
+  });
+
+  test("a newer installed binary or worktree cannot bounce the source daemon", () => {
+    expect(daemonLauncherMatchesCommand(launcher, "/bin/codecast", ["--", "_daemon"])).toBe(false);
+    expect(daemonLauncherMatchesCommand(launcher, "/opt/bun", ["/src/codecast/.conductor/feature/packages/cli/src/daemon.ts", "_daemon"])).toBe(false);
+    expect(daemonLauncherMatchesCommand("", "/opt/bun", sourceArgs)).toBe(false);
+  });
+});
+
+describe.skipIf(process.platform !== "darwin")("production watchdog process", () => {
+  async function prepare(home: string, convexUrl: string) {
+    const dir = path.join(home, ".codecast");
+    fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify({ auth_token: "fixture-token", user_id: "fixture-user", convex_url: convexUrl }));
+    fs.writeFileSync(path.join(dir, "daemon-launcher.sh"), buildDaemonLauncherScript({ daemonCommand: "'/different/install/codecast' '--' '_daemon'" }));
+    const launchAgents = path.join(home, "Library", "LaunchAgents");
+    fs.mkdirSync(launchAgents, { recursive: true });
+    fs.writeFileSync(path.join(launchAgents, "sh.codecast.daemon.plist"), "fixture");
+  }
+
+  test.each([false, true])("the managed daemon refreshes an obsolete watchdog once (first reload fails: %s)", async (failFirst) => {
+    const home = fixture();
+    const dir = path.join(home, ".codecast");
+    const launchAgents = path.join(home, "Library", "LaunchAgents");
+    fs.mkdirSync(launchAgents, { recursive: true });
+    const launcher = path.join(dir, "daemon-launcher.sh");
+    const daemonCommand = [process.execPath, path.join(import.meta.dir, "daemon.ts"), "_daemon"].map(shellEscapeForSh).join(" ");
+    fs.writeFileSync(launcher, buildDaemonLauncherScript({ daemonCommand }));
+    fs.writeFileSync(path.join(launchAgents, "sh.codecast.daemon.plist"), buildDaemonPlistXml({ scriptPath: launcher, configDir: dir }));
+    const watchdog = path.join(dir, "watchdog.sh");
+    fs.writeFileSync(watchdog, "old resident loop");
+    fs.writeFileSync(path.join(dir, "watchdog.heartbeat"), String(Date.now()));
+    fs.writeFileSync(path.join(launchAgents, "sh.codecast.watchdog.plist"), buildWatchdogPlistXml({ scriptPath: watchdog, configDir: dir }));
+    if (failFirst) fs.writeFileSync(path.join(home, "fail-kickstart"), "1");
+    const result = await run(process.execPath, [path.join(import.meta.dir, "test-helpers/watchdogRecovery.ts"), "supervise"], home);
+    expect(result, result.stderr).toMatchObject({ code: 0 });
+    expect(fs.readFileSync(watchdog, "utf-8")).toBe(buildWatchdogShellScript({ isBinary: false, watchdogCommand: "" }));
+    const kickstarts = fs.readFileSync(path.join(home, "calls"), "utf-8").split("\n").filter((line) => line.startsWith("kickstart"));
+    expect(kickstarts).toEqual(Array(failFirst ? 2 : 1).fill(`kickstart -k gui/${process.getuid!()}/sh.codecast.watchdog`));
+  }, 30_000);
+
+  test("a foreign watchdog leaves a live older daemon running", async () => {
+    const home = fixture();
+    const server = Bun.serve({ port: 0, fetch: () => Response.json({ min_cli_version: "999.0.0" }) });
+    const incumbent = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    try {
+      await prepare(home, `http://127.0.0.1:${server.port}`);
+      fs.writeFileSync(path.join(home, ".codecast", "daemon.pid"), String(incumbent.pid));
+      fs.writeFileSync(path.join(home, ".codecast", "daemon.state"), JSON.stringify({ runtimeVersion: "0.0.1", lastHeartbeatTick: Date.now() }));
+      const result = await run(process.execPath, [path.join(import.meta.dir, "test-helpers/watchdogRecovery.ts")], home);
+      expect(result, result.stderr).toMatchObject({ code: 0 });
+      expect(incumbent.exitCode).toBeNull();
+      expect(incumbent.signalCode).toBeNull();
+      expect(fs.existsSync(path.join(home, "calls"))).toBe(false);
+    } finally {
+      incumbent.kill("SIGKILL");
+      server.stop(true);
+    }
+  }, 30_000);
+
+  test("ordinary CLI use from a foreign installation leaves the managed daemon running", async () => {
+    const home = fixture();
+    const server = Bun.serve({ port: 0, fetch: () => Response.json({}) });
+    const incumbent = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    try {
+      await prepare(home, `http://127.0.0.1:${server.port}`);
+      fs.writeFileSync(path.join(home, ".codecast", "daemon.pid"), String(incumbent.pid));
+      fs.writeFileSync(path.join(home, ".codecast", "daemon.version"), "0.0.1");
+      const result = await run(process.execPath, [path.join(import.meta.dir, "main.ts"), "config", "web_url"], home);
+      expect(result, result.stderr).toMatchObject({ code: 0 });
+      expect(incumbent.exitCode).toBeNull();
+      expect(incumbent.signalCode).toBeNull();
+      expect(fs.readFileSync(path.join(home, ".codecast", "daemon.pid"), "utf-8")).toBe(String(incumbent.pid));
+      expect(fs.readFileSync(path.join(home, "calls"), "utf-8")).not.toContain("kickstart");
+    } finally {
+      incumbent.kill("SIGKILL");
+      server.stop(true);
+    }
+  }, 30_000);
+
+  test("a dead managed daemon recovers through its supervisor without consuming pending commands", async () => {
+    const home = fixture();
+    const requests: string[] = [];
+    const server = Bun.serve({ port: 0, fetch: (request) => {
+      requests.push(new URL(request.url).pathname);
+      return Response.json({ min_cli_version: "999.0.0", commands: [{ id: "pending-send", command: "resume_session" }] });
+    } });
+    try {
+      await prepare(home, `http://127.0.0.1:${server.port}`);
+      const result = await run(process.execPath, [path.join(import.meta.dir, "test-helpers/watchdogRecovery.ts")], home);
+      expect(result, result.stderr).toMatchObject({ code: 0 });
+      const calls = fs.readFileSync(path.join(home, "calls"), "utf-8");
+      expect(calls).toContain(`kickstart gui/${process.getuid!()}/sh.codecast.daemon`);
+      expect(requests).toEqual(["/cli/heartbeat"]);
+      expect(fs.existsSync(path.join(home, ".codecast", "daemon.pid"))).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  }, 30_000);
+
+  test("a stalled heartbeat endpoint cannot block local recovery forever", async () => {
+    const home = fixture();
+    const server = Bun.serve({ port: 0, fetch: () => new Promise<Response>(() => {}) });
+    try {
+      await prepare(home, `http://127.0.0.1:${server.port}`);
+      const result = await run(process.execPath, [path.join(import.meta.dir, "test-helpers/watchdogRecovery.ts")], home);
+      expect(result, result.stderr).toMatchObject({ code: 0 });
+      expect(fs.readFileSync(path.join(home, "calls"), "utf-8")).toContain(`kickstart gui/${process.getuid!()}/sh.codecast.daemon`);
+    } finally {
+      server.stop(true);
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/supervision.ts
+++ b/packages/cli/src/supervision.ts
@@ -37,6 +37,11 @@ export function shellEscapeForSh(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+export function daemonLauncherMatchesCommand(launcher: string, executable: string, args: string[]): boolean {
+  const command = [executable, ...args].map(shellEscapeForSh).join(" ");
+  return launcher.split("\n").some((line) => line.trim() === `exec ${command}`);
+}
+
 // exec (not plain invocation) so the daemon replaces the shell and launchd tracks
 // the daemon's pid as the job instance — kickstart, KeepAlive, and the mutual
 // supervision pid checks all depend on that.
@@ -61,6 +66,7 @@ export const WATCHDOG_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
 // kept here so the shell script and any future native watchdog agree on one number.
 const WATCHDOG_INTERVAL_SECONDS = 60;
 export const DAEMON_HEARTBEAT_STALE_MS = 180000; // 3 min = 6 missed 30s daemon heartbeats
+export const DAEMON_HEARTBEAT_BUSY_GRACE_MS = 10 * 60 * 1000;
 
 // The daemon's heartbeat tick freezes during system sleep exactly like it does
 // when the event loop is wedged — and the watchdog resumes its loop within
@@ -78,10 +84,6 @@ export const WATCHDOG_AWAKE_GAP_MS = WATCHDOG_INTERVAL_SECONDS * 1000 + 30_000;
 // Pure verdict shared by both watchdog forms (dev shell inline check, compiled
 // `_watchdog` pass). gapMs is the watchdog's time since its own previous pass;
 // null (first pass, missing stamp) defers — a fresh watchdog has no baseline.
-// logAgeMs is the time since the daemon last wrote daemon.log (null = unknown):
-// a wedged event loop runs no JS and cannot log, while a busy-but-alive boot
-// (transcript sweeps, git subprocesses) starves the tick stamper yet keeps
-// logging — killing it just restarts the same slow boot and loops the outage.
 export function daemonTickStale(
   tickAgeMs: number,
   gapMs: number | null,
@@ -92,7 +94,7 @@ export function daemonTickStale(
   if (tickAgeMs <= thresholdMs) return false;
   if (gapMs === null || gapMs < 0) return false;
   if (gapMs >= awakeGapMs) return false;
-  if (logAgeMs !== null && logAgeMs >= 0 && logAgeMs <= thresholdMs) return false;
+  if (tickAgeMs <= Math.max(thresholdMs, DAEMON_HEARTBEAT_BUSY_GRACE_MS) && logAgeMs !== null && logAgeMs >= 0 && logAgeMs <= thresholdMs) return false;
   return true;
 }
 
@@ -278,12 +280,9 @@ check_once() {
         # wedged event loop. A large gap in our OWN loop = the machine slept and
         # the daemon may simply not have re-stamped yet — give it one cycle.
         if [ "\$LOOP_GAP" -ge 0 ] && [ "\$LOOP_GAP" -lt ${WATCHDOG_AWAKE_GAP_MS} ]; then
-          # A wedged event loop runs no JS and cannot write daemon.log. A busy
-          # boot starves the tick stamper but keeps logging — killing it only
-          # restarts the same slow boot. Kill when the log is ALSO silent.
           LOG_MTIME=\$(stat -f %m "\${HOME}/.codecast/daemon.log" 2>/dev/null || echo 0)
           LOG_AGE=\$(( NOW_MS - LOG_MTIME * 1000 ))
-          if [ "\$LOG_MTIME" -gt 0 ] && [ "\$LOG_AGE" -le ${DAEMON_HEARTBEAT_STALE_MS} ]; then
+          if [ "\$AGE" -le ${DAEMON_HEARTBEAT_BUSY_GRACE_MS} ] && [ "\$LOG_MTIME" -gt 0 ] && [ "\$LOG_AGE" -le ${DAEMON_HEARTBEAT_STALE_MS} ]; then
             log "Daemon tick stale (\${AGE}ms) but daemon.log written \${LOG_AGE}ms ago - busy, not wedged"
           else
             STALE=1
@@ -342,7 +341,7 @@ run_check() {
   ${watchdogCommand} 2>>"\$LOGFILE" && return 0
   log "Watchdog failed (exit \$?), checking for update"
 
-  LATEST="\$(curl -fsSL "\$DL_HOST/latest.json" 2>/dev/null)" || { log "Failed to fetch latest.json"; return 1; }
+  LATEST="\$(curl -fsSL --connect-timeout 10 --max-time 30 "\$DL_HOST/latest.json" 2>/dev/null)" || { log "Failed to fetch latest.json"; return 1; }
   VERSION="\$(printf '%s' "\$LATEST" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p')"
   [ -z "\$VERSION" ] && { log "Could not parse version"; return 1; }
 
@@ -360,7 +359,7 @@ run_check() {
   DIR="\${HOME}/.local/bin"; mkdir -p "\$DIR"
   TMP="\$(mktemp)"
   log "Downloading codecast v\$VERSION (\$P-\$A)"
-  curl -fsSL "\$DL_HOST/codecast-\$P-\$A" -o "\$TMP" 2>>"\$LOGFILE" || { rm -f "\$TMP"; log "Download failed"; return 1; }
+  curl -fsSL --connect-timeout 10 --max-time 180 "\$DL_HOST/codecast-\$P-\$A" -o "\$TMP" 2>>"\$LOGFILE" || { rm -f "\$TMP"; log "Download failed"; return 1; }
   mv "\$TMP" "\$DIR/codecast" && chmod +x "\$DIR/codecast"
   printf '%s' "\$VERSION" > "\$LAST_DL_FILE"
   log "Installed v\$VERSION, retrying watchdog"

--- a/packages/cli/src/test-helpers/watchdogRecovery.ts
+++ b/packages/cli/src/test-helpers/watchdogRecovery.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureWatchdogSupervised, runWatchdog } from "../daemon.js";
+
+if (process.argv[2] === "supervise") {
+  fs.writeFileSync(path.join(process.env.HOME!, "fixture-pid"), String(process.pid));
+  await ensureWatchdogSupervised(true);
+  await ensureWatchdogSupervised(true);
+} else {
+  await runWatchdog();
+}
+process.exit(0);


### PR DESCRIPTION
Sync could remain disconnected after wake or restart because startup waited for update checks and skill discovery. The watchdog could also excuse a dead heartbeat indefinitely while logs kept moving, and a newer CLI from another installation could repeatedly replace the daemon configured in launchd.

Run ancillary startup work in the background, bound watchdog network waits and heartbeat grace, and recover managed daemons through their configured supervisor while preserving pending commands. Ordinary CLI calls and post-update restarts both respect installation ownership. Refresh the resident watchdog when its script changes. Use the accepted Codex file position when reporting stuck syncs so consumed metadata does not appear as an upload backlog.

Validation: CI run 34144777482 is green on 81e5d09: build, lint, typecheck, CLI tests, Convex tests, and web tests. Local recovery tests exercise the production CLI and watchdog in child processes with isolated home directories, including sleep/wake, stalled HTTP, competing installations, and script reload failures. The live doctor completed the transcript → server → daemon → agent → server round trip. A later full macOS CLI run stalled inside the OS rename syscall and was stopped; the clean CI suite passed.
